### PR TITLE
metainfo: add github action to automatically update metainfo with latest 

### DIFF
--- a/.github/workflows/metainfo.yml
+++ b/.github/workflows/metainfo.yml
@@ -29,6 +29,6 @@ jobs:
           git add program_info/org.polymc.PolyMC.metainfo.xml
           tag=$(git describe --tags $(git rev-list --tags --max-count=1))
           msg=$(git tag -l --format='%(contents)' $tag)
-          git commit -m "$msgs"
+          git commit -m "$msg"
           git tag -f $tag
           git push --force origin $tag

--- a/.github/workflows/metainfo.yml
+++ b/.github/workflows/metainfo.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           git clone https://github.com/dada513/tag-metainfo-xml metainfo-updater
           cd metainfo-updater
-        # checkout to good known commit
           git checkout ace02c74fe014def09250c161c87d82cecd95036
           go build
           ./tag-metainfo-xml PolyMC PolyMC ../program_info/org.polymc.PolyMC.metainfo.xml

--- a/.github/workflows/metainfo.yml
+++ b/.github/workflows/metainfo.yml
@@ -1,0 +1,34 @@
+name: Metainfo-updater
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  xml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Update metainfo with tag-metainfo-xml
+        run: |
+          git clone https://github.com/dada513/tag-metainfo-xml metainfo-updater
+          cd metainfo-updater
+        # checkout to good known commit
+          git checkout ace02c74fe014def09250c161c87d82cecd95036
+          go build
+          ./tag-metainfo-xml PolyMC PolyMC ../program_info/org.polymc.PolyMC.metainfo.xml
+      - name: update tag with metainfo changes
+        run: |
+          git config user.name github-actions
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add program_info/org.polymc.PolyMC.metainfo.xml
+          git commit -m "bot: update metainfo with latest tags"
+          tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+          git tag -f $tag
+          git push --force origin $tag

--- a/.github/workflows/metainfo.yml
+++ b/.github/workflows/metainfo.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           git clone https://github.com/dada513/tag-metainfo-xml metainfo-updater
           cd metainfo-updater
-          git checkout ace02c74fe014def09250c161c87d82cecd95036
+          git checkout 684da34f49fc3f119d15751049556b51612a24e7
           go build
           ./tag-metainfo-xml PolyMC PolyMC ../program_info/org.polymc.PolyMC.metainfo.xml
       - name: update tag with metainfo changes

--- a/.github/workflows/metainfo.yml
+++ b/.github/workflows/metainfo.yml
@@ -24,10 +24,11 @@ jobs:
           ./tag-metainfo-xml PolyMC PolyMC ../program_info/org.polymc.PolyMC.metainfo.xml
       - name: update tag with metainfo changes
         run: |
-          git config user.name github-actions
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name $GITHUB_ACTOR
+          git config user.email $GITHUB_ACTOR@users.noreply.github.com
           git add program_info/org.polymc.PolyMC.metainfo.xml
-          git commit -m "bot: update metainfo with latest tags"
           tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+          msg=$(git tag -l --format='%(contents)' $tag)
+          git commit -m "$msgs"
           git tag -f $tag
           git push --force origin $tag

--- a/program_info/org.polymc.PolyMC.metainfo.xml
+++ b/program_info/org.polymc.PolyMC.metainfo.xml
@@ -38,7 +38,7 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.0.2" date="2022-01-01" />
+    <release version="master" date="2022-01-01" />
   </releases>
   <content_rating type="oars-1.0">
     <content_attribute id="violence-cartoon">moderate</content_attribute>


### PR DESCRIPTION
The metainfo.xml file has a problematic releases field.
Every release, it would have to be updated to properly reflect the new release
This PR automates this. GithubActions will push an update whenever a new tag is created to that tag containing  the metainfo.xml with the proper tag fields (using github API to populate fields)

Tested on my repo, works fine