### PR TITLE
add rpm build script and spec file

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -45,6 +45,18 @@ cd packages/debian
 
 If everything works correctly, the .deb will be next to the build script, in `PolyMC/packages/debian`
 
+### Building a .rpm
+
+You don't need to install the build dependencies, as the script will use `dnf` to install them for you.
+
+```
+git clone https://github.com/PolyMC/PolyMC.git
+cd packages/rpm
+./makerpm.sh
+```
+
+If everything works correctly, the .rpm will be next to the build script, in `PolyMC/packages/rpm`
+
 ### Building from command line
 You need a source folder, a build folder and an install folder.
 

--- a/packages/rpm/makerpm.sh
+++ b/packages/rpm/makerpm.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+git submodule init
+git submodule update
+VERSION=$(git describe --tags | sed 's/-.*//')
+DIR=$(pwd)
+sed -i "s/Version:.*/Version: ${VERSION}/" polymc.spec
+sudo dnf builddep polymc.spec
+rpmbuild -ba polymc.spec

--- a/packages/rpm/polymc.spec
+++ b/packages/rpm/polymc.spec
@@ -1,0 +1,55 @@
+%global _origdir %(pwd)
+
+Name: polymc
+Version: 
+Release: 1%{?dist}
+Summary: A custom launcher for Minecraft
+License: GPLv3
+URL: https://polymc.org/
+
+BuildArch: x86_64
+BuildRequires:  java-devel
+BuildRequires:  pkgconfig(gl)
+BuildRequires:  pkgconfig(Qt5)
+BuildRequires:  pkgconfig(zlib)
+
+Requires: java-headless
+Requires: pkgconfig(gl)
+Requires: pkgconfig(Qt5)
+Requires: pkgconfig(zlib)
+
+%description
+A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once
+
+%prep
+mkdir -p %{_builddir}/%{name}
+cp -r %{_origdir}/../../* %{_builddir}/%{name}
+
+%build
+cd %{_builddir}/%{name}
+cmake \
+  -DLauncher_LAYOUT=lin-system \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLauncher_LIBRARY_DEST_DIR=%{_lib} \
+  .
+
+%cmake_build
+
+%install
+cd %{_builddir}/%{name}
+%cmake_install
+
+%files
+%{_bindir}/polymc
+%{_datadir}/applications/org.polymc.PolyMC.desktop
+%{_datadir}/metainfo/org.polymc.PolyMC.metainfo.xml
+%{_datadir}/polymc/jars/*
+%{_datadir}/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
+%{_libdir}/libLauncher_nbt++.so
+%{_libdir}/libLauncher_quazip.so
+%{_libdir}/libLauncher_rainbow.so
+%{_libdir}/libLauncher_iconfix.so
+
+%changelog
+* Fri Jan 7 2022 getchoo <getchoo at tuta dot io> - 1.0.4
+- Initial polymc spec


### PR DESCRIPTION
Resolves #5 by providing a build script similar to `makedeb.sh` that uses the current tag and HEAD to build a `.rpm` file.