### PR TITLE
stop cmake from blocking builds on wsl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,6 @@ if(IS_IN_SOURCE_BUILD)
     message(FATAL_ERROR "You are building the Launcher in-source. Please separate the build tree from the source tree.")
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if(CMAKE_HOST_SYSTEM_VERSION MATCHES ".*[Mm]icrosoft.*" OR
-        CMAKE_HOST_SYSTEM_VERSION MATCHES ".*WSL.*"
-    )
-        message(FATAL_ERROR "Building the Launcher is not supported in Linux-on-Windows distributions.")
-    endif()
-endif()
-
 
 ##################################### Set CMake options #####################################
 set(CMAKE_AUTOMOC ON)

--- a/libraries/katabasis/CMakeLists.txt
+++ b/libraries/katabasis/CMakeLists.txt
@@ -5,14 +5,6 @@ if(IS_IN_SOURCE_BUILD)
     message(FATAL_ERROR "You are building Katabasis in-source. Please separate the build tree from the source tree.")
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if(CMAKE_HOST_SYSTEM_VERSION MATCHES ".*[Mm]icrosoft.*" OR
-        CMAKE_HOST_SYSTEM_VERSION MATCHES ".*WSL.*"
-    )
-        message(FATAL_ERROR "Building Katabasis is not supported in Linux-on-Windows distributions. Use a real Linux machine, not a fraudulent one.")
-    endif()
-endif()
-
 project(Katabasis)
 enable_testing()
 


### PR DESCRIPTION
In the `CMakeLists.txt` file for the main project - as well as the one for `katabasis` - builds on WSL instances are blocked by an `if` statement, even though this project builds perfectly fine without them. I see no reason as to why compilation should be completely blocked on WSL when there are no errors.

This just seems like a personal belief from the upstream developers about people being on "fraudulent" machines instead a "real Linux machine" - with no reasoning for it being blocked besides this.