### PR TITLE
nix: add support for non-flake builds and channels

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+(import packages/nix/flake-compat.nix).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -65,6 +81,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "libnbtplusplus": "libnbtplusplus",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,10 @@
 {
   description = "PolyMC flake";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.flake-compat = {
+    url = "github:edolstra/flake-compat";
+    flake = false;
+  };
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.libnbtplusplus = {
     url = "github:multimc/libnbtplusplus";

--- a/packages/nix/flake-compat.nix
+++ b/packages/nix/flake-compat.nix
@@ -1,0 +1,9 @@
+let
+  lock = builtins.fromJSON (builtins.readFile ../../flake.lock);
+  inherit (lock.nodes.flake-compat.locked) rev narHash;
+  flake-compat = fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${rev}.tar.gz";
+    sha256 = narHash;
+  };
+in
+import flake-compat { src = ../..; }


### PR DESCRIPTION
We use the well-established `flake-compat` to achieve a similar effect to #34. I think this is more maintainable because it outsources complexity to `flake-compat` and avoids adding more code paths here.