### PR TITLE
Simplify the CMake build macro

### DIFF
--- a/packages/rpm/polymc.spec
+++ b/packages/rpm/polymc.spec
@@ -27,12 +27,7 @@ cp -r %{_origdir}/../../* %{_builddir}/%{name}
 
 %build
 cd %{_builddir}/%{name}
-cmake \
-  -DLauncher_LAYOUT=lin-system \
-  -DCMAKE_INSTALL_PREFIX=/usr \
-  -DLauncher_LIBRARY_DEST_DIR=%{_lib} \
-  .
-
+%cmake
 %cmake_build
 
 %install
@@ -51,5 +46,7 @@ cd %{_builddir}/%{name}
 %{_libdir}/libLauncher_iconfix.so
 
 %changelog
+* Mon Jan 10 2022 Cappy Ishihara - 1.0.4
+- Simplify the cmake macro
 * Fri Jan 7 2022 getchoo <getchoo at tuta dot io> - 1.0.4
 - Initial polymc spec

--- a/packages/rpm/polymc.spec
+++ b/packages/rpm/polymc.spec
@@ -27,7 +27,12 @@ cp -r %{_origdir}/../../* %{_builddir}/%{name}
 
 %build
 cd %{_builddir}/%{name}
-%cmake
+%cmake \
+  -DLauncher_LAYOUT=lin-system \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DLauncher_LIBRARY_DEST_DIR=%{_lib} \
+  .
+
 %cmake_build
 
 %install
@@ -47,6 +52,6 @@ cd %{_builddir}/%{name}
 
 %changelog
 * Mon Jan 10 2022 Cappy Ishihara - 1.0.4
-- Simplify the cmake macro
+- Made the cmake command a macro
 * Fri Jan 7 2022 getchoo <getchoo at tuta dot io> - 1.0.4
 - Initial polymc spec


### PR DESCRIPTION
Simplifies the CMake macro to actually comply with RPM guidelines (a simple %cmake instead of a long command that is not compatible with Fedora)