### PR TITLE
Nix: Package fixup

### DIFF
--- a/packages/nix/polymc/0001-pick-latest-java-first.patch
+++ b/packages/nix/polymc/0001-pick-latest-java-first.patch
@@ -1,0 +1,48 @@
+From 44e1b2a19a869b907b40e56c85c8a47aa6c22097 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mustafa=20=C3=87al=C4=B1=C5=9Fkan?= <musfay@protonmail.com>
+Date: Tue, 22 Jun 2021 21:50:11 +0300
+Subject: [PATCH] pick latest java first
+
+---
+ launcher/java/JavaInstallList.cpp | 4 ++--
+ launcher/java/JavaUtils.cpp       | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/launcher/java/JavaInstallList.cpp b/launcher/java/JavaInstallList.cpp
+index 0bded03c..40898e20 100644
+--- a/launcher/java/JavaInstallList.cpp
++++ b/launcher/java/JavaInstallList.cpp
+@@ -120,8 +120,8 @@ void JavaInstallList::updateListData(QList<BaseVersionPtr> versions)
+ 
+ bool sortJavas(BaseVersionPtr left, BaseVersionPtr right)
+ {
+-    auto rleft = std::dynamic_pointer_cast<JavaInstall>(left);
+-    auto rright = std::dynamic_pointer_cast<JavaInstall>(right);
++    auto rleft = std::dynamic_pointer_cast<JavaInstall>(right);
++    auto rright = std::dynamic_pointer_cast<JavaInstall>(left);
+     return (*rleft) > (*rright);
+ }
+ 
+diff --git a/launcher/java/JavaUtils.cpp b/launcher/java/JavaUtils.cpp
+index 5f004a10..6d633631 100644
+--- a/launcher/java/JavaUtils.cpp
++++ b/launcher/java/JavaUtils.cpp
+@@ -350,7 +350,6 @@ QList<QString> JavaUtils::FindJavaPaths()
+     qDebug() << "Linux Java detection incomplete - defaulting to \"java\"";
+ 
+     QList<QString> javas;
+-    javas.append(this->GetDefaultJava()->path);
+     auto scanJavaDir = [&](const QString & dirPath)
+     {
+         QDir dir(dirPath);
+@@ -379,6 +378,7 @@ QList<QString> JavaUtils::FindJavaPaths()
+     // general locations used by distro packaging
+     scanJavaDir("/usr/lib/jvm");
+     scanJavaDir("/usr/lib32/jvm");
++    javas.append(this->GetDefaultJava()->path);
+     // javas stored in MultiMC's folder
+     scanJavaDir("java");
+     return javas;
+-- 
+2.31.1
+

--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -13,6 +13,7 @@
 , libpulseaudio
 , qtbase
 , libGL
+, msaClientID ? ""
 
 # flake
 , self
@@ -46,6 +47,19 @@ mkDerivation rec {
   buildInputs = [ qtbase jdk8 zlib ];
 
   dontWrapQtApps = true;
+
+  patches = [ ./0001-pick-latest-java-first.patch ];
+
+  postPatch = ''
+    # hardcode jdk paths
+    substituteInPlace launcher/java/JavaUtils.cpp \
+      --replace 'scanJavaDir("/usr/lib/jvm")' 'javas.append("${jdk}/lib/openjdk/bin/java")' \
+      --replace 'scanJavaDir("/usr/lib32/jvm")' 'javas.append("${jdk8}/lib/openjdk/bin/java")'
+  '' + lib.optionalString (msaClientID != "") ''
+    # add client ID
+    substituteInPlace CMakeLists.txt \
+      --replace '17b47edd-c884-4997-926d-9e7f9a6b4647' '${msaClientID}'
+  '';
 
   postUnpack = ''
     # Copy submodules inputs


### PR DESCRIPTION
Package is missing a patch for finding Java versions on NixOS, this restores this and adds a way to override the msaClientID