### PR TITLE
Set PrefersNonDefaultGPU for hybrid devices

### DIFF
--- a/program_info/org.polymc.PolyMC.desktop.in
+++ b/program_info/org.polymc.PolyMC.desktop.in
@@ -7,5 +7,6 @@ Terminal=false
 Exec=@Launcher_APP_BINARY_NAME@
 StartupNotify=true
 Icon=org.polymc.PolyMC
+PrefersNonDefaultGPU=true
 Categories=Game;
 Keywords=game;minecraft;launcher;


### PR DESCRIPTION
With the Property 'PrefersNonDefaultGPU', you can signal to dekstop environments like GNOME that you want to run the application using the more powerful secondary graphics card, if such a card is available. Specification: https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html

With this change, you won't have to include a special prime-run script.