### PR TITLE
Offline Mode Support

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -221,7 +221,11 @@ set(MINECRAFT_SOURCES
     minecraft/auth/flows/Mojang.h
     minecraft/auth/flows/MSA.cpp
     minecraft/auth/flows/MSA.h
+    minecraft/auth/flows/Offline.cpp
+    minecraft/auth/flows/Offline.h
 
+    minecraft/auth/steps/OfflineStep.cpp
+    minecraft/auth/steps/OfflineStep.h
     minecraft/auth/steps/EntitlementsStep.cpp
     minecraft/auth/steps/EntitlementsStep.h
     minecraft/auth/steps/GetSkinStep.cpp

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -769,6 +769,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/LoginDialog.h
     ui/dialogs/MSALoginDialog.cpp
     ui/dialogs/MSALoginDialog.h
+    ui/dialogs/OfflineLoginDialog.cpp
+    ui/dialogs/OfflineLoginDialog.h
     ui/dialogs/NewComponentDialog.cpp
     ui/dialogs/NewComponentDialog.h
     ui/dialogs/NewInstanceDialog.cpp
@@ -880,6 +882,7 @@ qt5_wrap_ui(LAUNCHER_UI
     ui/dialogs/ExportInstanceDialog.ui
     ui/dialogs/IconPickerDialog.ui
     ui/dialogs/MSALoginDialog.ui
+    ui/dialogs/OfflineLoginDialog.ui
     ui/dialogs/AboutDialog.ui
     ui/dialogs/LoginDialog.ui
     ui/dialogs/EditAccountDialog.ui

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -116,6 +116,12 @@ void LaunchController::login() {
         m_session->wants_online = m_online;
         m_accountToUse->fillSession(m_session);
 
+        // Launch immediately in true offline mode
+        if(m_accountToUse->isOffline()) {
+            launchInstance();
+            return;
+        }
+
         switch(m_accountToUse->accountState()) {
             case AccountState::Offline: {
                 m_session->wants_online = false;

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -314,6 +314,8 @@ bool AccountData::resumeStateFromV3(QJsonObject data) {
         type = AccountType::MSA;
     } else if (typeS == "Mojang") {
         type = AccountType::Mojang;
+    } else if (typeS == "Offline") {
+        type = AccountType::Offline;
     } else {
         qWarning() << "Failed to parse account data: type is not recognized.";
         return false;
@@ -363,6 +365,9 @@ QJsonObject AccountData::saveState() const {
         tokenToJSONV3(output, xboxApiToken, "xrp-main");
         tokenToJSONV3(output, mojangservicesToken, "xrp-mc");
     }
+    else if (type == AccountType::Offline) {
+        output["type"] = "Offline";
+    }
 
     tokenToJSONV3(output, yggdrasilToken, "ygg");
     profileToJSONV3(output, minecraftProfile, "profile");
@@ -371,7 +376,7 @@ QJsonObject AccountData::saveState() const {
 }
 
 QString AccountData::userName() const {
-    if(type != AccountType::Mojang) {
+    if(type == AccountType::MSA) {
         return QString();
     }
     return yggdrasilToken.extra["userName"].toString();
@@ -425,6 +430,9 @@ QString AccountData::profileName() const {
 QString AccountData::accountDisplayString() const {
     switch(type) {
         case AccountType::Mojang: {
+            return userName();
+        }
+        case AccountType::Offline: {
             return userName();
         }
         case AccountType::MSA: {

--- a/launcher/minecraft/auth/AccountData.h
+++ b/launcher/minecraft/auth/AccountData.h
@@ -38,7 +38,8 @@ struct MinecraftProfile {
 
 enum class AccountType {
     MSA,
-    Mojang
+    Mojang,
+    Offline
 };
 
 enum class AccountState {

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -302,7 +302,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
             }
 
             case MigrationColumn: {
-                if(account->isMSA()) {
+                if(account->isMSA() || account->isOffline()) {
                     return tr("N/A", "Can Migrate?");
                 }
                 if (account->canMigrate()) {

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -73,6 +73,8 @@ public: /* construction */
 
     static MinecraftAccountPtr createBlankMSA();
 
+    static MinecraftAccountPtr createOffline(const QString &username);
+
     static MinecraftAccountPtr loadFromJsonV2(const QJsonObject &json);
     static MinecraftAccountPtr loadFromJsonV3(const QJsonObject &json);
 
@@ -88,6 +90,8 @@ public: /* manipulation */
     shared_qobject_ptr<AccountTask> login(QString password);
 
     shared_qobject_ptr<AccountTask> loginMSA();
+
+    shared_qobject_ptr<AccountTask> loginOffline();
 
     shared_qobject_ptr<AccountTask> refresh();
 
@@ -128,6 +132,10 @@ public: /* queries */
         return data.type == AccountType::MSA;
     }
 
+    bool isOffline() const {
+        return data.type == AccountType::Offline;
+    }
+
     bool ownsMinecraft() const {
         return data.minecraftEntitlement.ownsMinecraft;
     }
@@ -147,6 +155,10 @@ public: /* queries */
             break;
             case AccountType::MSA: {
                 return "msa";
+            }
+            break;
+            case AccountType::Offline: {
+                return "offline";
             }
             break;
             default: {

--- a/launcher/minecraft/auth/flows/Offline.cpp
+++ b/launcher/minecraft/auth/flows/Offline.cpp
@@ -1,0 +1,17 @@
+#include "Offline.h"
+
+#include "minecraft/auth/steps/OfflineStep.h"
+
+OfflineRefresh::OfflineRefresh(
+    AccountData *data,
+    QObject *parent
+) : AuthFlow(data, parent) {
+    m_steps.append(new OfflineStep(m_data));
+}
+
+OfflineLogin::OfflineLogin(
+    AccountData *data,
+    QObject *parent
+) : AuthFlow(data, parent) {
+    m_steps.append(new OfflineStep(m_data));
+}

--- a/launcher/minecraft/auth/flows/Offline.h
+++ b/launcher/minecraft/auth/flows/Offline.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "AuthFlow.h"
+
+class OfflineRefresh : public AuthFlow
+{
+    Q_OBJECT
+public:
+    explicit OfflineRefresh(
+        AccountData *data,
+        QObject *parent = 0
+    );
+};
+
+class OfflineLogin : public AuthFlow
+{
+    Q_OBJECT
+public:
+    explicit OfflineLogin(
+        AccountData *data,
+        QObject *parent = 0
+    );
+};

--- a/launcher/minecraft/auth/steps/OfflineStep.cpp
+++ b/launcher/minecraft/auth/steps/OfflineStep.cpp
@@ -1,0 +1,18 @@
+#include "OfflineStep.h"
+
+#include "Application.h"
+
+OfflineStep::OfflineStep(AccountData* data) : AuthStep(data) {};
+OfflineStep::~OfflineStep() noexcept = default;
+
+QString OfflineStep::describe() {
+    return tr("Creating offline account.");
+}
+
+void OfflineStep::rehydrate() {
+    // NOOP
+}
+
+void OfflineStep::perform() {
+    emit finished(AccountTaskState::STATE_WORKING, tr("Created offline account."));
+}

--- a/launcher/minecraft/auth/steps/OfflineStep.cpp
+++ b/launcher/minecraft/auth/steps/OfflineStep.cpp
@@ -2,7 +2,7 @@
 
 #include "Application.h"
 
-OfflineStep::OfflineStep(AccountData* data) : AuthStep(data) {};
+OfflineStep::OfflineStep(AccountData* data) : AuthStep(data) {}
 OfflineStep::~OfflineStep() noexcept = default;
 
 QString OfflineStep::describe() {

--- a/launcher/minecraft/auth/steps/OfflineStep.h
+++ b/launcher/minecraft/auth/steps/OfflineStep.h
@@ -1,0 +1,20 @@
+
+#pragma once
+#include <QObject>
+
+#include "QObjectPtr.h"
+#include "minecraft/auth/AuthStep.h"
+
+#include <katabasis/DeviceFlow.h>
+
+class OfflineStep : public AuthStep {
+    Q_OBJECT
+public:
+    explicit OfflineStep(AccountData *data);
+    virtual ~OfflineStep() noexcept;
+
+    void perform() override;
+    void rehydrate() override;
+
+    QString describe() override;
+};

--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -42,8 +42,8 @@ void OfflineLoginDialog::accept()
     ui->progressBar->setVisible(true);
 
     // Setup the login task and start it
-    m_account = MinecraftAccount::createFromUsername(ui->userTextBox->text());
-    m_loginTask = m_account->login("TODO: create offline mode account flow");
+    m_account = MinecraftAccount::createOffline(ui->userTextBox->text());
+    m_loginTask = m_account->loginOffline();
     connect(m_loginTask.get(), &Task::failed, this, &OfflineLoginDialog::onTaskFailed);
     connect(m_loginTask.get(), &Task::succeeded, this, &OfflineLoginDialog::onTaskSucceeded);
     connect(m_loginTask.get(), &Task::status, this, &OfflineLoginDialog::onTaskStatus);

--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -1,0 +1,113 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OfflineLoginDialog.h"
+#include "ui_OfflineLoginDialog.h"
+
+#include "minecraft/auth/AccountTask.h"
+
+#include <QtWidgets/QPushButton>
+
+OfflineLoginDialog::OfflineLoginDialog(QWidget *parent) : QDialog(parent), ui(new Ui::OfflineLoginDialog)
+{
+    ui->setupUi(this);
+    ui->progressBar->setVisible(false);
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+OfflineLoginDialog::~OfflineLoginDialog()
+{
+    delete ui;
+}
+
+// Stage 1: User interaction
+void OfflineLoginDialog::accept()
+{
+    setUserInputsEnabled(false);
+    ui->progressBar->setVisible(true);
+
+    // Setup the login task and start it
+    m_account = MinecraftAccount::createFromUsername(ui->userTextBox->text());
+    m_loginTask = m_account->login("TODO: create offline mode account flow");
+    connect(m_loginTask.get(), &Task::failed, this, &OfflineLoginDialog::onTaskFailed);
+    connect(m_loginTask.get(), &Task::succeeded, this, &OfflineLoginDialog::onTaskSucceeded);
+    connect(m_loginTask.get(), &Task::status, this, &OfflineLoginDialog::onTaskStatus);
+    connect(m_loginTask.get(), &Task::progress, this, &OfflineLoginDialog::onTaskProgress);
+    m_loginTask->start();
+}
+
+void OfflineLoginDialog::setUserInputsEnabled(bool enable)
+{
+    ui->userTextBox->setEnabled(enable);
+    ui->buttonBox->setEnabled(enable);
+}
+
+// Enable the OK button only when the textbox contains something.
+void OfflineLoginDialog::on_userTextBox_textEdited(const QString &newText)
+{
+    ui->buttonBox->button(QDialogButtonBox::Ok)
+        ->setEnabled(!newText.isEmpty());
+}
+
+void OfflineLoginDialog::onTaskFailed(const QString &reason)
+{
+    // Set message
+    auto lines = reason.split('\n');
+    QString processed;
+    for(auto line: lines) {
+        if(line.size()) {
+            processed += "<font color='red'>" + line + "</font><br />";
+        }
+        else {
+            processed += "<br />";
+        }
+    }
+    ui->label->setText(processed);
+
+    // Re-enable user-interaction
+    setUserInputsEnabled(true);
+    ui->progressBar->setVisible(false);
+}
+
+void OfflineLoginDialog::onTaskSucceeded()
+{
+    QDialog::accept();
+}
+
+void OfflineLoginDialog::onTaskStatus(const QString &status)
+{
+    ui->label->setText(status);
+}
+
+void OfflineLoginDialog::onTaskProgress(qint64 current, qint64 total)
+{
+    ui->progressBar->setMaximum(total);
+    ui->progressBar->setValue(current);
+}
+
+// Public interface
+MinecraftAccountPtr OfflineLoginDialog::newAccount(QWidget *parent, QString msg)
+{
+    OfflineLoginDialog dlg(parent);
+    dlg.ui->label->setText(msg);
+    if (dlg.exec() == QDialog::Accepted)
+    {
+        return dlg.m_account;
+    }
+    return 0;
+}

--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -1,18 +1,3 @@
-/* Copyright 2013-2021 MultiMC Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #include "OfflineLoginDialog.h"
 #include "ui_OfflineLoginDialog.h"
 

--- a/launcher/ui/dialogs/OfflineLoginDialog.h
+++ b/launcher/ui/dialogs/OfflineLoginDialog.h
@@ -1,0 +1,58 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <QtWidgets/QDialog>
+#include <QtCore/QEventLoop>
+
+#include "minecraft/auth/MinecraftAccount.h"
+#include "tasks/Task.h"
+
+namespace Ui
+{
+class OfflineLoginDialog;
+}
+
+class OfflineLoginDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    ~OfflineLoginDialog();
+
+    static MinecraftAccountPtr newAccount(QWidget *parent, QString message);
+
+private:
+    explicit OfflineLoginDialog(QWidget *parent = 0);
+
+    void setUserInputsEnabled(bool enable);
+
+protected
+slots:
+    void accept();
+
+    void onTaskFailed(const QString &reason);
+    void onTaskSucceeded();
+    void onTaskStatus(const QString &status);
+    void onTaskProgress(qint64 current, qint64 total);
+
+    void on_userTextBox_textEdited(const QString &newText);
+
+private:
+    Ui::OfflineLoginDialog *ui;
+    MinecraftAccountPtr m_account;
+    Task::Ptr m_loginTask;
+};

--- a/launcher/ui/dialogs/OfflineLoginDialog.h
+++ b/launcher/ui/dialogs/OfflineLoginDialog.h
@@ -1,18 +1,3 @@
-/* Copyright 2013-2021 MultiMC Contributors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #pragma once
 
 #include <QtWidgets/QDialog>

--- a/launcher/ui/dialogs/OfflineLoginDialog.ui
+++ b/launcher/ui/dialogs/OfflineLoginDialog.ui
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OfflineLoginDialog</class>
+ <widget class="QDialog" name="OfflineLoginDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>150</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Add Account</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string notr="true">Message label placeholder.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="userTextBox">
+     <property name="placeholderText">
+      <string>Username</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>69</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/launcher/ui/dialogs/OfflineLoginDialog.ui
+++ b/launcher/ui/dialogs/OfflineLoginDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>150</height>
+    <width>500</width>
+    <height>250</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -158,7 +158,13 @@ void AccountListPage::on_actionAddOffline_triggered()
 {
     MinecraftAccountPtr account = OfflineLoginDialog::newAccount(
         this,
-        tr("Please enter your desired username to add your offline account.")
+        tr("Please enter your desired username to add your offline account. <br>"
+           "<br>"
+           "It is required by Mojang that you own Minecraft BEFORE you may use offline mode. <br>"
+           "The PolyMC organization denounces piracy and takes NO LIABILITY WHATSOEVER <br>"
+           "for any illegal activity that may occur in usage of the offline mode feature. <br></b>"
+           "<br>"
+           "By continuing you promise that you own a Minecraft account.")
     );
 
     if (account)

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -161,8 +161,8 @@ void AccountListPage::on_actionAddOffline_triggered()
         tr("Please enter your desired username to add your offline account. <br>"
            "<br>"
            "It is required by Mojang that you own Minecraft BEFORE you may use offline mode. <br>"
-           "The PolyMC organization denounces piracy and takes NO LIABILITY WHATSOEVER <br>"
-           "for any illegal activity that may occur in usage of the offline mode feature. <br></b>"
+           "The PolyMC developers denounce piracy and take NO LIABILITY WHATSOEVER for <br>"
+           "any illegal activity that may occur in usage of the offline mode feature. <br>"
            "<br>"
            "By continuing you promise that you own a Minecraft account.")
     );

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -24,6 +24,7 @@
 #include "net/NetJob.h"
 
 #include "ui/dialogs/ProgressDialog.h"
+#include "ui/dialogs/OfflineLoginDialog.h"
 #include "ui/dialogs/LoginDialog.h"
 #include "ui/dialogs/MSALoginDialog.h"
 #include "ui/dialogs/CustomMessageBox.h"
@@ -142,6 +143,22 @@ void AccountListPage::on_actionAddMicrosoft_triggered()
     MinecraftAccountPtr account = MSALoginDialog::newAccount(
         this,
         tr("Please enter your Mojang account email and password to add your account.")
+    );
+
+    if (account)
+    {
+        m_accounts->addAccount(account);
+        if (m_accounts->count() == 1) {
+            m_accounts->setDefaultAccount(account);
+        }
+    }
+}
+
+void AccountListPage::on_actionAddOffline_triggered()
+{
+    MinecraftAccountPtr account = OfflineLoginDialog::newAccount(
+        this,
+        tr("Please enter your desired username to add your offline account.")
     );
 
     if (account)

--- a/launcher/ui/pages/global/AccountListPage.h
+++ b/launcher/ui/pages/global/AccountListPage.h
@@ -62,6 +62,7 @@ public:
 public slots:
     void on_actionAddMojang_triggered();
     void on_actionAddMicrosoft_triggered();
+    void on_actionAddOffline_triggered();
     void on_actionRemove_triggered();
     void on_actionRefresh_triggered();
     void on_actionSetDefault_triggered();

--- a/launcher/ui/pages/global/AccountListPage.ui
+++ b/launcher/ui/pages/global/AccountListPage.ui
@@ -54,6 +54,7 @@
    </attribute>
    <addaction name="actionAddMicrosoft"/>
    <addaction name="actionAddMojang"/>
+   <addaction name="actionAddOffline"/>
    <addaction name="actionRefresh"/>
    <addaction name="actionRemove"/>
    <addaction name="actionSetDefault"/>
@@ -101,6 +102,11 @@
   <action name="actionAddMicrosoft">
    <property name="text">
     <string>Add Microsoft</string>
+   </property>
+  </action>
+  <action name="actionAddOffline">
+   <property name="text">
+    <string>Add Offline</string>
    </property>
   </action>
   <action name="actionRefresh">


### PR DESCRIPTION
This is only the UI part of https://github.com/PolyMC/PolyMC/issues/43, to demonstrate the desired UX. Players will be able to add offline mode accounts that can be selected with the account switcher the same way that online mode accounts can already be used.

The new `OfflineLoginDialog` is simply a slightly modified version of `LoginDialog` (basically just without the password field).

I don't know when or even if I can fully implement this. Please feel free to copy any of this as a basis for a PR with a working implementation.

Closes https://github.com/PolyMC/PolyMC/issues/43