### PR TITLE
Readd original MultiMC/Launcher copyright

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -15,6 +15,20 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    
+# Launcher (https://github.com/MultiMC/Launcher)
+    Copyright 2012-2021 MultiMC Contributors
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
 # MinGW runtime (Windows)
 


### PR DESCRIPTION
The original MMC code remains Apache, we cannot re-license MMC/Launcher. (Not without direct and explicit consent from Peterix and any other MMC/Launcher developers.) 