### PR TITLE
Fix program executable name for shell script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 
 ####################################### Program Info #######################################
 
-set(Launcher_APP_BINARY_NAME "PolyMC" CACHE STRING "Name of the Launcher binary")
+set(Launcher_APP_BINARY_NAME "polymc" CACHE STRING "Name of the Launcher binary")
 add_subdirectory(program_info)
 
 ####################################### Install layout #######################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 
 ####################################### Program Info #######################################
 
-set(Launcher_APP_BINARY_NAME "polymc" CACHE STRING "Name of the Launcher binary")
+set(Launcher_APP_BINARY_NAME "PolyMC" CACHE STRING "Name of the Launcher binary")
 add_subdirectory(program_info)
 
 ####################################### Install layout #######################################

--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -14,7 +14,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 
-LAUNCHER_NAME=@Launcher_Name@
+LAUNCHER_NAME=@Launcher_APP_BINARY_NAME@
 LAUNCHER_DIR="$(dirname "$(readlink -f "$0")")"
 echo "Launcher Dir: ${LAUNCHER_DIR}"
 


### PR DESCRIPTION
The generated shell script used to launch PolyMC had an incorrect program executable name specified of `PolyMC`. The executable generated was called `polymc`, hence, the shell script would fail to open the program.

This changes the `CMakeLists.txt` file to change the output executable name to `PolyMC`.

Example of the behaviour with the incorrect name:
![image](https://user-images.githubusercontent.com/26304783/149600195-5f65bc5a-9e05-415c-8949-06d0484d808d.png)
