### PR TITLE
Add open page & copy code button to MSA login dialog

### DIFF
--- a/launcher/ui/dialogs/MSALoginDialog.ui
+++ b/launcher/ui/dialogs/MSALoginDialog.ui
@@ -49,14 +49,25 @@ aaaaa</string>
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="actionButton">
+       <property name="text">
+        <string>Open page and copy code</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Closes #55

![Screenshot of dialog](https://scrumplex.rocks/img/1642618298.png)

The button does miraculous things:
1. It opens the URL in the default browser handled by the system
2. It copies the code into the user's clipboard

This works on Wayland on Linux. It probably works on every other platform as well.