### PR TITLE
Migrate to upstream QuaZip 1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
     path = libraries/libnbtplusplus
     url = https://github.com/MultiMC/libnbtplusplus.git
     pushurl = git@github.com:MultiMC/libnbtplusplus.git
-[submodule "libraries/quazip"]
-    path = libraries/quazip
-    url = https://github.com/PolyMC/quazip.git
-    pushurl = git@github.com:PolyMC/quazip.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
     path = libraries/libnbtplusplus
     url = https://github.com/MultiMC/libnbtplusplus.git
     pushurl = git@github.com:MultiMC/libnbtplusplus.git
+
+[submodule "libraries/quazip"]
+	path = libraries/quazip
+	url = https://github.com/stachenov/quazip.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,6 @@ add_subdirectory(libraries/javacheck) # java compatibility checker
 add_subdirectory(libraries/xz-embedded) # xz compression
 if (NOT QuaZip-Qt${QT_VERSION_MAJOR}_FOUND)
     set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
-    add_compile_definitions(QUAZIP_USE_SUBMODULE)
     MESSAGE(STATUS "Adding QuaZip submodule, with QT_VERSION_MAJOR ${QUAZIP_QT_MAJOR_VERSION}")
     add_subdirectory(libraries/quazip) # zip manipulation library
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,18 +101,19 @@ add_custom_target(tcversion echo "\\#\\#teamcity[setParameter name=\\'env.LAUNCH
 ################################ 3rd Party Libs ################################
 
 # Find the required Qt parts
-set(QT_VERSION_MAJOR ${Launcher_QT_VERSION_MAJOR})
-find_package(Qt${QT_VERSION_MAJOR}Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR}Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR}Concurrent REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR}Network REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR}Test REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR}Xml REQUIRED)
+if(Launcher_QT_VERSION_MAJOR EQUAL 5)
+    set(QT_VERSION_MAJOR 5)
+    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent Network Test Xml)
 
-if (NOT Launcher_FORCE_BUNDLED_LIBS)
-    find_package(QuaZip-Qt${QT_VERSION_MAJOR} REQUIRED)
+    if(NOT Launcher_FORCE_BUNDLED_LIBS)
+        find_package(QuaZip-Qt5 REQUIRED)
+    endif()
+    if (NOT QuaZip-Qt5_FOUND)
+        set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR} CACHE STRING "Qt version to use (4, 5 or 6), defaults to ${QT_VERSION_MAJOR}" FORCE)
+        set(FORCE_BUNDLED_QUAZIP 1)
+    endif()
 else()
-    MESSAGE(STATUS "Not looking for QuaZip via find_package")
+    message(FATAL_ERROR "Qt version ${Launcher_QT_VERSION_MAJOR} is not supported")
 endif()
 
 # The Qt5 cmake files don't provide its install paths, so ask qmake.
@@ -261,9 +262,8 @@ add_subdirectory(libraries/hoedown) # markdown parser
 add_subdirectory(libraries/launcher) # java based launcher part for Minecraft
 add_subdirectory(libraries/javacheck) # java compatibility checker
 add_subdirectory(libraries/xz-embedded) # xz compression
-if (NOT QuaZip-Qt${QT_VERSION_MAJOR}_FOUND)
-    set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
-    MESSAGE(STATUS "Adding QuaZip submodule, with QT_VERSION_MAJOR ${QUAZIP_QT_MAJOR_VERSION}")
+if (FORCE_BUNDLED_QUAZIP)
+    message(STATUS "Using bundled QuaZip")
     add_subdirectory(libraries/quazip) # zip manipulation library
 endif()
 add_subdirectory(libraries/rainbow) # Qt extension for colors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ set(Launcher_DISCORD_URL "https://discord.gg/Z52pwxWCHP" CACHE STRING "URL for t
 set(Launcher_SUBREDDIT_URL "" CACHE STRING "URL for the subreddit.")
 
 # Builds
-set(Launcher_FORCE_BUNDLED_LIBS OFF CACHE BOOL "Prevent using system libraries, if they are available as submodules")
+# TODO: Launcher_FORCE_BUNDLED_LIBS should be off in the future, but as of QuaZip 1.2, we can't do that yet.
+set(Launcher_FORCE_BUNDLED_LIBS ON CACHE BOOL "Prevent using system libraries, if they are available as submodules")
 set(Launcher_QT_VERSION_MAJOR "5" CACHE STRING "Major Qt version to build against")
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
 find_package(Qt5Xml REQUIRED)
 
+find_package(QuaZip-Qt5 REQUIRED)
+
 # The Qt5 cmake files don't provide its install paths, so ask qmake.
 include(QMakeQuery)
 query_qmake(QT_INSTALL_PLUGINS QT_PLUGINS_DIR)
@@ -249,7 +251,6 @@ add_subdirectory(libraries/hoedown) # markdown parser
 add_subdirectory(libraries/launcher) # java based launcher part for Minecraft
 add_subdirectory(libraries/javacheck) # java compatibility checker
 add_subdirectory(libraries/xz-embedded) # xz compression
-add_subdirectory(libraries/quazip) # zip manipulation library
 add_subdirectory(libraries/rainbow) # Qt extension for colors
 add_subdirectory(libraries/iconfix) # fork of Qt's QIcon loader
 add_subdirectory(libraries/LocalPeer) # fork of a library from Qt solutions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,11 @@ set(Launcher_DISCORD_URL "https://discord.gg/Z52pwxWCHP" CACHE STRING "URL for t
 # Subreddit URL
 set(Launcher_SUBREDDIT_URL "" CACHE STRING "URL for the subreddit.")
 
+# Builds
+set(Launcher_FORCE_BUNDLED_LIBS OFF CACHE BOOL "Prevent using system libraries, if they are available as submodules")
+set(Launcher_QT_VERSION_MAJOR "5" CACHE STRING "Major Qt version to build against")
+
+
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)
 get_git_head_revision(Launcher_GIT_REFSPEC Launcher_GIT_COMMIT)
@@ -96,14 +101,19 @@ add_custom_target(tcversion echo "\\#\\#teamcity[setParameter name=\\'env.LAUNCH
 ################################ 3rd Party Libs ################################
 
 # Find the required Qt parts
-find_package(Qt5Core REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5Concurrent REQUIRED)
-find_package(Qt5Network REQUIRED)
-find_package(Qt5Test REQUIRED)
-find_package(Qt5Xml REQUIRED)
+set(QT_VERSION_MAJOR ${Launcher_QT_VERSION_MAJOR})
+find_package(Qt${QT_VERSION_MAJOR}Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Widgets REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Concurrent REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Network REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Test REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR}Xml REQUIRED)
 
-find_package(QuaZip-Qt5 REQUIRED)
+if (NOT Launcher_FORCE_BUNDLED_LIBS)
+    find_package(QuaZip-Qt${QT_VERSION_MAJOR} REQUIRED)
+else()
+    MESSAGE(STATUS "Not looking for QuaZip via find_package")
+endif()
 
 # The Qt5 cmake files don't provide its install paths, so ask qmake.
 include(QMakeQuery)
@@ -251,6 +261,12 @@ add_subdirectory(libraries/hoedown) # markdown parser
 add_subdirectory(libraries/launcher) # java based launcher part for Minecraft
 add_subdirectory(libraries/javacheck) # java compatibility checker
 add_subdirectory(libraries/xz-embedded) # xz compression
+if (NOT QuaZip-Qt${QT_VERSION_MAJOR}_FOUND)
+    set(QUAZIP_QT_MAJOR_VERSION ${QT_VERSION_MAJOR})
+    add_compile_definitions(QUAZIP_USE_SUBMODULE)
+    MESSAGE(STATUS "Adding QuaZip submodule, with QT_VERSION_MAJOR ${QUAZIP_QT_MAJOR_VERSION}")
+    add_subdirectory(libraries/quazip) # zip manipulation library
+endif()
 add_subdirectory(libraries/rainbow) # Qt extension for colors
 add_subdirectory(libraries/iconfix) # fork of Qt's QIcon loader
 add_subdirectory(libraries/LocalPeer) # fork of a library from Qt solutions

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -899,7 +899,6 @@ endif()
 add_library(Launcher_logic STATIC ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${LAUNCHER_UI} ${LAUNCHER_RESOURCES})
 target_link_libraries(Launcher_logic
     systeminfo
-    Launcher_quazip
     Launcher_classparser
     ${NBT_NAME}
     ${ZLIB_LIBRARIES}
@@ -917,7 +916,7 @@ target_link_libraries(Launcher_logic
 )
 target_link_libraries(Launcher_logic
     Launcher_iconfix
-    ${QUAZIP_LIBRARIES}
+    QuaZip::QuaZip
     hoedown
     Launcher_rainbow
     LocalPeer

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -29,7 +29,7 @@
 #include "modplatform/flame/FileResolvingTask.h"
 #include "modplatform/flame/PackManifest.h"
 #include "Json.h"
-#include <quazipdir.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
 #include "modplatform/technic/TechnicPackProcessor.h"
 
 #include "icons/IconList.h"

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -29,12 +29,7 @@
 #include "modplatform/flame/FileResolvingTask.h"
 #include "modplatform/flame/PackManifest.h"
 #include "Json.h"
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazipdir.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
-#endif
 #include "modplatform/technic/TechnicPackProcessor.h"
 
 #include "icons/IconList.h"

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -29,7 +29,12 @@
 #include "modplatform/flame/FileResolvingTask.h"
 #include "modplatform/flame/PackManifest.h"
 #include "Json.h"
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazipdir.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
+#endif
 #include "modplatform/technic/TechnicPackProcessor.h"
 
 #include "icons/IconList.h"

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -13,17 +13,16 @@
  * limitations under the License.
  */
 
-#include <quazip.h>
-#include <quazipdir.h>
-#include <quazipfile.h>
-#include <JlCompress.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
 #include "MMCZip.h"
 #include "FileSystem.h"
 
 #include <QDebug>
 
 // ours
-bool MMCZip::mergeZipFiles(QuaZip *into, QFileInfo from, QSet<QString> &contained, const JlCompress::FilterFunction filter)
+bool MMCZip::mergeZipFiles(QuaZip *into, QFileInfo from, QSet<QString> &contained, const FilterFunction filter)
 {
     QuaZip modZip(from.filePath());
     modZip.open(QuaZip::mdUnzip);
@@ -70,99 +69,6 @@ bool MMCZip::mergeZipFiles(QuaZip *into, QFileInfo from, QSet<QString> &containe
         }
         zipOutFile.close();
         fileInsideMod.close();
-    }
-    return true;
-}
-
-// ours
-bool MMCZip::createModdedJar(QString sourceJarPath, QString targetJarPath, const QList<Mod>& mods)
-{
-    QuaZip zipOut(targetJarPath);
-    if (!zipOut.open(QuaZip::mdCreate))
-    {
-        QFile::remove(targetJarPath);
-        qCritical() << "Failed to open the minecraft.jar for modding";
-        return false;
-    }
-    // Files already added to the jar.
-    // These files will be skipped.
-    QSet<QString> addedFiles;
-
-    // Modify the jar
-    QListIterator<Mod> i(mods);
-    i.toBack();
-    while (i.hasPrevious())
-    {
-        const Mod &mod = i.previous();
-        // do not merge disabled mods.
-        if (!mod.enabled())
-            continue;
-        if (mod.type() == Mod::MOD_ZIPFILE)
-        {
-            if (!mergeZipFiles(&zipOut, mod.filename(), addedFiles))
-            {
-                zipOut.close();
-                QFile::remove(targetJarPath);
-                qCritical() << "Failed to add" << mod.filename().fileName() << "to the jar.";
-                return false;
-            }
-        }
-        else if (mod.type() == Mod::MOD_SINGLEFILE)
-        {
-            // FIXME: buggy - does not work with addedFiles
-            auto filename = mod.filename();
-            if (!JlCompress::compressFile(&zipOut, filename.absoluteFilePath(), filename.fileName()))
-            {
-                zipOut.close();
-                QFile::remove(targetJarPath);
-                qCritical() << "Failed to add" << mod.filename().fileName() << "to the jar.";
-                return false;
-            }
-            addedFiles.insert(filename.fileName());
-        }
-        else if (mod.type() == Mod::MOD_FOLDER)
-        {
-            // FIXME: buggy - does not work with addedFiles
-            auto filename = mod.filename();
-            QString what_to_zip = filename.absoluteFilePath();
-            QDir dir(what_to_zip);
-            dir.cdUp();
-            QString parent_dir = dir.absolutePath();
-            if (!JlCompress::compressSubDir(&zipOut, what_to_zip, parent_dir, addedFiles))
-            {
-                zipOut.close();
-                QFile::remove(targetJarPath);
-                qCritical() << "Failed to add" << mod.filename().fileName() << "to the jar.";
-                return false;
-            }
-            qDebug() << "Adding folder " << filename.fileName() << " from "
-                        << filename.absoluteFilePath();
-        }
-        else
-        {
-            // Make sure we do not continue launching when something is missing or undefined...
-            zipOut.close();
-            QFile::remove(targetJarPath);
-            qCritical() << "Failed to add unknown mod type" << mod.filename().fileName() << "to the jar.";
-            return false;
-        }
-    }
-
-    if (!mergeZipFiles(&zipOut, QFileInfo(sourceJarPath), addedFiles, [](const QString key){return !key.contains("META-INF");}))
-    {
-        zipOut.close();
-        QFile::remove(targetJarPath);
-        qCritical() << "Failed to insert minecraft.jar contents.";
-        return false;
-    }
-
-    // Recompress the jar
-    zipOut.close();
-    if (zipOut.getZipError() != 0)
-    {
-        QFile::remove(targetJarPath);
-        qCritical() << "Failed to finalize minecraft.jar!";
-        return false;
     }
     return true;
 }

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -12,15 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifdef QUAZIP_USE_SUBMODULE
+
 #include <quazip/quazip.h>
 #include <quazip/quazipdir.h>
 #include <quazip/quazipfile.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
-#endif
 #include "MMCZip.h"
 #include "FileSystem.h"
 

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -12,10 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipdir.h>
+#include <quazip/quazipfile.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
+#endif
 #include "MMCZip.h"
 #include "FileSystem.h"
 

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -90,4 +90,22 @@ namespace MMCZip
      */
     bool extractFile(QString fileCompressed, QString file, QString dir);
 
+    /**
+     * Populate a QFileInfoList with a directory tree recursively, while allowing to excludeFilter what shouldn't be included.
+     * \param rootDir directory to start off
+     * \param subDir subdirectory, should be nullptr for first invocation
+     * \param files resulting list of QFileInfo
+     * \param excludeFilter function to excludeFilter which files shouldn't be included (returning true means to excude)
+     * \return true for success or false for failure
+     */
+    bool collectFileListRecursively(const QString &rootDir, const QString &subDir, QFileInfoList *files, FilterFunction excludeFilter);
+
+    /**
+     * Compress directory, by providing a list of files to compress
+     * \param fileCompressed target archive file
+     * \param dir directory that will be compressed (to compress with relative paths)
+     * \param files list of files to compress
+     * \return true for success or false for failure
+     */
+    bool compressDirFiles(QString fileCompressed, QString dir, QFileInfoList files);
 }

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -19,14 +19,10 @@
 #include <QFileInfo>
 #include <QSet>
 #include "minecraft/mod/Mod.h"
-#include "nonstd/optional"
 #include <functional>
 
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/JlCompress.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/JlCompress.h>
-#endif
+#include <nonstd/optional>
 
 namespace MMCZip
 {

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -21,17 +21,21 @@
 #include "minecraft/mod/Mod.h"
 #include <functional>
 
-#include <JlCompress.h>
+//#include <QuaZip-Qt5-1.2/quazip/JlCompress.h>
+// TODO: Blocked by https://github.com/stachenov/quazip/pull/141
+// For now, checkout https://github.com/Scrumplex/quazip/tree/expose-jlcompress-fns at ../../quazip
+#include <../../quazip/quazip/JlCompress.h>
 #include <nonstd/optional>
 
 namespace MMCZip
 {
+    using FilterFunction = std::function<bool(const QString &)>;
 
     /**
      * Merge two zip files, using a filter function
      */
     bool mergeZipFiles(QuaZip *into, QFileInfo from, QSet<QString> &contained,
-                                            const JlCompress::FilterFunction filter = nullptr);
+                                            const FilterFunction filter = nullptr);
 
     /**
      * take a source jar, add mods to it, resulting in target jar

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -19,13 +19,14 @@
 #include <QFileInfo>
 #include <QSet>
 #include "minecraft/mod/Mod.h"
+#include "nonstd/optional"
 #include <functional>
 
-//#include <QuaZip-Qt5-1.2/quazip/JlCompress.h>
-// TODO: Blocked by https://github.com/stachenov/quazip/pull/141
-// For now, checkout https://github.com/Scrumplex/quazip/tree/expose-jlcompress-fns at ../../quazip
-#include <../../quazip/quazip/JlCompress.h>
-#include <nonstd/optional>
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/JlCompress.h>
+#else
+#include <QuaZip-Qt5-1.2/quazip/JlCompress.h>
+#endif
 
 namespace MMCZip
 {

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -35,6 +35,24 @@ namespace MMCZip
                                             const FilterFunction filter = nullptr);
 
     /**
+     * Compress directory, by providing a list of files to compress
+     * \param zip target archive
+     * \param dir directory that will be compressed (to compress with relative paths)
+     * \param files list of files to compress
+     * \return true for success or false for failure
+     */
+    bool compressDirFiles(QuaZip *zip, QString dir, QFileInfoList files);
+
+    /**
+     * Compress directory, by providing a list of files to compress
+     * \param fileCompressed target archive file
+     * \param dir directory that will be compressed (to compress with relative paths)
+     * \param files list of files to compress
+     * \return true for success or false for failure
+     */
+    bool compressDirFiles(QString fileCompressed, QString dir, QFileInfoList files);
+
+    /**
      * take a source jar, add mods to it, resulting in target jar
      */
     bool createModdedJar(QString sourceJarPath, QString targetJarPath, const QList<Mod>& mods);
@@ -99,13 +117,4 @@ namespace MMCZip
      * \return true for success or false for failure
      */
     bool collectFileListRecursively(const QString &rootDir, const QString &subDir, QFileInfoList *files, FilterFunction excludeFilter);
-
-    /**
-     * Compress directory, by providing a list of files to compress
-     * \param fileCompressed target archive file
-     * \param dir directory that will be compressed (to compress with relative paths)
-     * \param files list of files to compress
-     * \return true for success or false for failure
-     */
-    bool compressDirFiles(QString fileCompressed, QString dir, QFileInfoList files);
 }

--- a/launcher/minecraft/MinecraftLoadAndCheck.h
+++ b/launcher/minecraft/MinecraftLoadAndCheck.h
@@ -20,7 +20,12 @@
 #include <QUrl>
 
 #include "tasks/Task.h"
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#endif
 
 #include "QObjectPtr.h"
 

--- a/launcher/minecraft/MinecraftLoadAndCheck.h
+++ b/launcher/minecraft/MinecraftLoadAndCheck.h
@@ -20,12 +20,7 @@
 #include <QUrl>
 
 #include "tasks/Task.h"
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#endif
 
 #include "QObjectPtr.h"
 

--- a/launcher/minecraft/MinecraftLoadAndCheck.h
+++ b/launcher/minecraft/MinecraftLoadAndCheck.h
@@ -20,7 +20,7 @@
 #include <QUrl>
 
 #include "tasks/Task.h"
-#include <quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
 
 #include "QObjectPtr.h"
 

--- a/launcher/minecraft/MinecraftUpdate.h
+++ b/launcher/minecraft/MinecraftUpdate.h
@@ -22,12 +22,7 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 #include "minecraft/VersionFilterData.h"
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#endif
 
 class MinecraftVersion;
 class MinecraftInstance;

--- a/launcher/minecraft/MinecraftUpdate.h
+++ b/launcher/minecraft/MinecraftUpdate.h
@@ -22,7 +22,12 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 #include "minecraft/VersionFilterData.h"
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#endif
 
 class MinecraftVersion;
 class MinecraftInstance;

--- a/launcher/minecraft/MinecraftUpdate.h
+++ b/launcher/minecraft/MinecraftUpdate.h
@@ -22,7 +22,7 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 #include "minecraft/VersionFilterData.h"
-#include <quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
 
 class MinecraftVersion;
 class MinecraftInstance;

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -26,9 +26,9 @@
 #include <io/stream_reader.h>
 #include <tag_string.h>
 #include <tag_primitive.h>
-#include <quazip.h>
-#include <quazipfile.h>
-#include <quazipdir.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
 
 #include <QCoreApplication>
 

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -26,9 +26,16 @@
 #include <io/stream_reader.h>
 #include <tag_string.h>
 #include <tag_primitive.h>
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipfile.h>
+#include <quazip/quazipdir.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
+#endif
 
 #include <QCoreApplication>
 

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -26,16 +26,9 @@
 #include <io/stream_reader.h>
 #include <tag_string.h>
 #include <tag_primitive.h>
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
 #include <quazip/quazipfile.h>
 #include <quazip/quazipdir.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
-#endif
 
 #include <QCoreApplication>
 

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -17,8 +17,14 @@
 #include <minecraft/MinecraftInstance.h>
 #include <launch/LaunchTask.h>
 
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipdir.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
+#endif
+
 #include "MMCZip.h"
 #include "FileSystem.h"
 #include <QDir>

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -17,14 +17,8 @@
 #include <minecraft/MinecraftInstance.h>
 #include <launch/LaunchTask.h>
 
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
 #include <quazip/quazipdir.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
-#endif
-
 #include "MMCZip.h"
 #include "FileSystem.h"
 #include <QDir>

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -17,8 +17,8 @@
 #include <minecraft/MinecraftInstance.h>
 #include <launch/LaunchTask.h>
 
-#include <quazip.h>
-#include <quazipdir.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
 #include "MMCZip.h"
 #include "FileSystem.h"
 #include <QDir>

--- a/launcher/minecraft/launch/ModMinecraftJar.cpp
+++ b/launcher/minecraft/launch/ModMinecraftJar.cpp
@@ -42,7 +42,6 @@ void ModMinecraftJar::executeTask()
         emitFailed(tr("Couldn't remove stale jar file: %1").arg(finalJarPath));
     }
 
-    /*
     // create temporary modded jar, if needed
     auto components = m_inst->getPackProfile();
     auto profile = components->getProfile();
@@ -54,13 +53,12 @@ void ModMinecraftJar::executeTask()
         mainJar->getApplicableFiles(currentSystem, jars, temp1, temp2, temp3, m_inst->getLocalLibraryPath());
         auto sourceJarPath = jars[0];
         if(!MMCZip::createModdedJar(sourceJarPath, finalJarPath, jarMods))
-        { */
-            // TODO: add back support for modded jar
+        {
             emitFailed(tr("Failed to create the custom Minecraft jar file."));
             return;
-        /*}
+        }
     }
-    emitSucceeded();*/
+    emitSucceeded();
 }
 
 void ModMinecraftJar::finalize()

--- a/launcher/minecraft/launch/ModMinecraftJar.cpp
+++ b/launcher/minecraft/launch/ModMinecraftJar.cpp
@@ -42,6 +42,7 @@ void ModMinecraftJar::executeTask()
         emitFailed(tr("Couldn't remove stale jar file: %1").arg(finalJarPath));
     }
 
+    /*
     // create temporary modded jar, if needed
     auto components = m_inst->getPackProfile();
     auto profile = components->getProfile();
@@ -53,12 +54,13 @@ void ModMinecraftJar::executeTask()
         mainJar->getApplicableFiles(currentSystem, jars, temp1, temp2, temp3, m_inst->getLocalLibraryPath());
         auto sourceJarPath = jars[0];
         if(!MMCZip::createModdedJar(sourceJarPath, finalJarPath, jarMods))
-        {
+        { */
+            // TODO: add back support for modded jar
             emitFailed(tr("Failed to create the custom Minecraft jar file."));
             return;
-        }
+        /*}
     }
-    emitSucceeded();
+    emitSucceeded();*/
 }
 
 void ModMinecraftJar::finalize()

--- a/launcher/minecraft/mod/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/LocalModParseTask.cpp
@@ -4,8 +4,8 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonValue>
-#include <quazip.h>
-#include <quazipfile.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
 #include <toml.h>
 
 #include "settings/INIFile.h"

--- a/launcher/minecraft/mod/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/LocalModParseTask.cpp
@@ -4,8 +4,15 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonValue>
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipfile.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
+#endif
+
 #include <toml.h>
 
 #include "settings/INIFile.h"

--- a/launcher/minecraft/mod/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/LocalModParseTask.cpp
@@ -4,15 +4,8 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QJsonValue>
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
 #include <quazip/quazipfile.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
-#endif
-
 #include <toml.h>
 
 #include "settings/INIFile.h"

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -19,11 +19,7 @@
 
 #include <QtConcurrent/QtConcurrent>
 
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#endif
 
 #include "MMCZip.h"
 #include "minecraft/OneSixVersionFormat.h"

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -19,7 +19,11 @@
 
 #include <QtConcurrent/QtConcurrent>
 
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#endif
 
 #include "MMCZip.h"
 #include "minecraft/OneSixVersionFormat.h"

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -19,7 +19,7 @@
 
 #include <QtConcurrent/QtConcurrent>
 
-#include <quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
 
 #include "MMCZip.h"
 #include "minecraft/OneSixVersionFormat.h"

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.h
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.h
@@ -1,8 +1,15 @@
 #pragma once
 #include "InstanceTask.h"
 #include "net/NetJob.h"
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipdir.h>
+#else
 #include "QuaZip-Qt5-1.2/quazip/quazip.h"
 #include "QuaZip-Qt5-1.2/quazip/quazipdir.h"
+#endif
+
 #include "meta/Index.h"
 #include "meta/Version.h"
 #include "meta/VersionList.h"

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.h
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "InstanceTask.h"
 #include "net/NetJob.h"
-#include "quazip.h"
-#include "quazipdir.h"
+#include "QuaZip-Qt5-1.2/quazip/quazip.h"
+#include "QuaZip-Qt5-1.2/quazip/quazipdir.h"
 #include "meta/Index.h"
 #include "meta/Version.h"
 #include "meta/VersionList.h"

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.h
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.h
@@ -1,15 +1,8 @@
 #pragma once
 #include "InstanceTask.h"
 #include "net/NetJob.h"
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
 #include <quazip/quazipdir.h>
-#else
-#include "QuaZip-Qt5-1.2/quazip/quazip.h"
-#include "QuaZip-Qt5-1.2/quazip/quazipdir.h"
-#endif
-
 #include "meta/Index.h"
 #include "meta/Version.h"
 #include "meta/VersionList.h"

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.h
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.h
@@ -18,7 +18,7 @@
 #include "InstanceTask.h"
 #include "net/NetJob.h"
 
-#include "quazip.h"
+#include "QuaZip-Qt5-1.2/quazip/quazip.h"
 
 #include <QFutureWatcher>
 #include <QStringList>

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.h
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.h
@@ -18,11 +18,7 @@
 #include "InstanceTask.h"
 #include "net/NetJob.h"
 
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
-#else
-#include "QuaZip-Qt5-1.2/quazip/quazip.h"
-#endif
 
 #include <QFutureWatcher>
 #include <QStringList>

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.h
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.h
@@ -18,7 +18,11 @@
 #include "InstanceTask.h"
 #include "net/NetJob.h"
 
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#else
 #include "QuaZip-Qt5-1.2/quazip/quazip.h"
+#endif
 
 #include <QFutureWatcher>
 #include <QStringList>

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -19,17 +19,9 @@
 #include <Json.h>
 #include <minecraft/MinecraftInstance.h>
 #include <minecraft/PackProfile.h>
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazip.h>
 #include <quazip/quazipdir.h>
 #include <quazip/quazipfile.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazip.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
-#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
-#endif
-
 #include <settings/INISettingsObject.h>
 
 #include <memory>

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -19,9 +19,17 @@
 #include <Json.h>
 #include <minecraft/MinecraftInstance.h>
 #include <minecraft/PackProfile.h>
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazip.h>
+#include <quazip/quazipdir.h>
+#include <quazip/quazipfile.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazip.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
 #include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
+#endif
+
 #include <settings/INISettingsObject.h>
 
 #include <memory>

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -19,9 +19,9 @@
 #include <Json.h>
 #include <minecraft/MinecraftInstance.h>
 #include <minecraft/PackProfile.h>
-#include <quazip.h>
-#include <quazipdir.h>
-#include <quazipfile.h>
+#include <QuaZip-Qt5-1.2/quazip/quazip.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipdir.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
 #include <settings/INISettingsObject.h>
 
 #include <memory>

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -378,7 +378,6 @@ void SaveIcon(InstancePtr m_instance)
 
 bool ExportInstanceDialog::doExport()
 {
-    /*
     auto name = FS::RemoveInvalidFilenameChars(m_instance->name());
 
     const QString output = QFileDialog::getSaveFileName(
@@ -404,12 +403,15 @@ bool ExportInstanceDialog::doExport()
 
     auto & blocked = proxyModel->blockedPaths();
     using std::placeholders::_1;
+    QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
+    return false;
+    // TODO Reimplement custom compressDir:
     if (!JlCompress::compressDir(output, m_instance->instanceRoot(), name, std::bind(&SeparatorPrefixTree<'/'>::covers, blocked, _1)))
-    { */
+    {
         QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
         return false;
-    /*}
-    return true;*/
+    }
+    return true;
 }
 
 void ExportInstanceDialog::done(int result)

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -403,10 +403,13 @@ bool ExportInstanceDialog::doExport()
 
     auto & blocked = proxyModel->blockedPaths();
     using std::placeholders::_1;
-    QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
-    return false;
-    // TODO Reimplement custom compressDir:
-    if (!JlCompress::compressDir(output, m_instance->instanceRoot(), name, std::bind(&SeparatorPrefixTree<'/'>::covers, blocked, _1)))
+    auto files = QFileInfoList();
+    if (!MMCZip::collectFileListRecursively(m_instance->instanceRoot(), nullptr, &files,
+                                    std::bind(&SeparatorPrefixTree<'/'>::covers, blocked, _1))) {
+        QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
+        return false;
+    }
+    if (!MMCZip::compressDirFiles(output, m_instance->instanceRoot(), files))
     {
         QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
         return false;

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -378,6 +378,7 @@ void SaveIcon(InstancePtr m_instance)
 
 bool ExportInstanceDialog::doExport()
 {
+    /*
     auto name = FS::RemoveInvalidFilenameChars(m_instance->name());
 
     const QString output = QFileDialog::getSaveFileName(
@@ -404,11 +405,11 @@ bool ExportInstanceDialog::doExport()
     auto & blocked = proxyModel->blockedPaths();
     using std::placeholders::_1;
     if (!JlCompress::compressDir(output, m_instance->instanceRoot(), name, std::bind(&SeparatorPrefixTree<'/'>::covers, blocked, _1)))
-    {
+    { */
         QMessageBox::warning(this, tr("Error"), tr("Unable to export instance"));
         return false;
-    }
-    return true;
+    /*}
+    return true;*/
 }
 
 void ExportInstanceDialog::done(int result)

--- a/libraries/classparser/CMakeLists.txt
+++ b/libraries/classparser/CMakeLists.txt
@@ -38,4 +38,4 @@ add_definitions(-DCLASSPARSER_LIBRARY)
 
 add_library(Launcher_classparser STATIC ${CLASSPARSER_SOURCES} ${CLASSPARSER_HEADERS})
 target_include_directories(Launcher_classparser PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(Launcher_classparser Launcher_quazip Qt5::Core)
+target_link_libraries(Launcher_classparser QuaZip::QuaZip Qt5::Core)

--- a/libraries/classparser/src/classparser.cpp
+++ b/libraries/classparser/src/classparser.cpp
@@ -18,13 +18,7 @@
 #include "classparser.h"
 
 #include <QFile>
-
-#ifdef QUAZIP_USE_SUBMODULE
 #include <quazip/quazipfile.h>
-#else
-#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
-#endif
-
 #include <QDebug>
 
 namespace classparser

--- a/libraries/classparser/src/classparser.cpp
+++ b/libraries/classparser/src/classparser.cpp
@@ -18,7 +18,7 @@
 #include "classparser.h"
 
 #include <QFile>
-#include <quazipfile.h>
+#include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
 #include <QDebug>
 
 namespace classparser

--- a/libraries/classparser/src/classparser.cpp
+++ b/libraries/classparser/src/classparser.cpp
@@ -18,7 +18,13 @@
 #include "classparser.h"
 
 #include <QFile>
+
+#ifdef QUAZIP_USE_SUBMODULE
+#include <quazip/quazipfile.h>
+#else
 #include <QuaZip-Qt5-1.2/quazip/quazipfile.h>
+#endif
+
 #include <QDebug>
 
 namespace classparser


### PR DESCRIPTION
Let's move off our custom QuaZip.

Nowadays it's maintained officially on GitHub: https://github.com/stachenov/quazip (See message on http://quazip.sourceforge.net/)

TODOs:
- [x] Support modded JARs again
- [x] Support exporting instances again
- [x] Blocked by https://github.com/stachenov/quazip/pull/141
- [x] Fallback to Git submodule of Quazip if not available on system.
- [ ] Cleanup
  - [x] More compact includes regardless of QuaZip source (system vs. submodule)