### PR TITLE
rebase with upstream

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -111,7 +111,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
         auto parts = line.split('=', QString::SkipEmptyParts);
         if(parts.size() != 2 || parts[0].isEmpty() || parts[1].isEmpty())
         {
-            success = false;
+            continue;
         }
         else
         {

--- a/launcher/minecraft/auth/AuthRequest.cpp
+++ b/launcher/minecraft/auth/AuthRequest.cpp
@@ -44,7 +44,7 @@ void AuthRequest::onRequestFinished() {
     if (reply_ != qobject_cast<QNetworkReply *>(sender())) {
         return;
     }
-    httpStatus_ = 200;
+    httpStatus_ = reply_->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     finish();
 }
 

--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -94,7 +94,7 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
         return false;
     }
     if(!getString(obj.value("Token"), output.token)) {
-        qWarning() << "User Token is not a timestamp";
+        qWarning() << "User Token is not a string";
         return false;
     }
     auto arrayVal = obj.value("DisplayClaims").toObject().value("xui");

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -56,6 +56,11 @@ void MinecraftProfileStep::onRequestDone(
         return;
     }
     if (error != QNetworkReply::NoError) {
+        qWarning() << "Error getting profile:";
+        qWarning() << " HTTP Status:        " << requestor->httpStatus_;
+        qWarning() << " Internal error no.: " << error;
+        qWarning() << " Error string:       " << requestor->errorString_;
+
         emit finished(
             AccountTaskState::STATE_FAILED_SOFT,
             tr("Minecraft Java profile acquisition failed.")

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -61,6 +61,9 @@ void MinecraftProfileStep::onRequestDone(
         qWarning() << " Internal error no.: " << error;
         qWarning() << " Error string:       " << requestor->errorString_;
 
+        qWarning() << " Response:";
+        qWarning() << QString::fromUtf8(data);
+
         emit finished(
             AccountTaskState::STATE_FAILED_SOFT,
             tr("Minecraft Java profile acquisition failed.")


### PR DESCRIPTION
- Fix error message 
- log server response when failing to fetch profile
- correctly set http status code in auth reply
- in java checker, ignore invalid lines altogether 
- add some logging to profile fetching failures