### PR TITLE
Fix Freedesktop icons

### DIFF
--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -88,7 +88,7 @@ mkDerivation rec {
 
   postInstall = ''
     install -Dm644 ../launcher/resources/multimc/scalable/launcher.svg $out/share/pixmaps/polymc.svg
-    install -Dm644 ${desktopItem}/share/applications/polymc.desktop $out/share/applications/org.polymc.PolyMC.desktop
+    install -Dm644 ${desktopItem}/share/applications/polymc.desktop $out/share/applications/org.polymc.polymc.desktop
 
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapProgram $out/bin/polymc \

--- a/packages/rpm/polymc.spec
+++ b/packages/rpm/polymc.spec
@@ -123,8 +123,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.polymc.polymc.des
 %{_libdir}/%{name}/*
 %{_datadir}/%{name}/*
 %{_datadir}/metainfo/org.polymc.PolyMC.metainfo.xml
-%{_datadir}/icons/hicolor/scalable/apps/org.polymc.polymC.svg
-%{_datadir}/applications/org.polymc.PolyMC.desktop
+%{_datadir}/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
+%{_datadir}/applications/org.polymc.polymc.desktop
 %config %{_sysconfdir}/ld.so.conf.d/*
 
 

--- a/packages/rpm/polymc.spec
+++ b/packages/rpm/polymc.spec
@@ -112,7 +112,7 @@ echo "%{_libdir}/%{name}" > "%{buildroot}%{_sysconfdir}/ld.so.conf.d/%{name}-%{_
 # skip tests on systems that aren't officially supported
 %if ! 0%{?suse_version}
 %ctest
-desktop-file-validate %{buildroot}%{_datadir}/applications/org.polymc.PolyMC.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/org.polymc.polymc.desktop
 %endif
 
 
@@ -123,7 +123,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.polymc.PolyMC.des
 %{_libdir}/%{name}/*
 %{_datadir}/%{name}/*
 %{_datadir}/metainfo/org.polymc.PolyMC.metainfo.xml
-%{_datadir}/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
+%{_datadir}/icons/hicolor/scalable/apps/org.polymc.polymC.svg
 %{_datadir}/applications/org.polymc.PolyMC.desktop
 %config %{_sysconfdir}/ld.so.conf.d/*
 

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -1,19 +1,19 @@
 set(Launcher_CommonName "PolyMC")
 
 set(Launcher_Copyright "PolyMC Contributors" PARENT_SCOPE)
-set(Launcher_Domain "github.com/PolyMC" PARENT_SCOPE)
+set(Launcher_Domain "polymc.org" PARENT_SCOPE)
 set(Launcher_Name "${Launcher_CommonName}" PARENT_SCOPE)
 set(Launcher_DisplayName "${Launcher_CommonName}" PARENT_SCOPE)
 set(Launcher_UserAgent "${Launcher_CommonName}/${Launcher_RELEASE_VERSION_NAME}" PARENT_SCOPE)
 set(Launcher_ConfigFile "polymc.cfg" PARENT_SCOPE)
 set(Launcher_Git "https://github.com/PolyMC/PolyMC" PARENT_SCOPE)
 
-set(Launcher_Desktop "program_info/org.polymc.PolyMC.desktop" PARENT_SCOPE)
+set(Launcher_Desktop "program_info/org.polymc.polymc.desktop" PARENT_SCOPE)
 set(Launcher_MetaInfo "program_info/org.polymc.PolyMC.metainfo.xml" PARENT_SCOPE)
 set(Launcher_SVG "program_info/org.polymc.PolyMC.svg" PARENT_SCOPE)
 set(Launcher_Branding_ICNS "program_info/polymc.icns" PARENT_SCOPE)
 set(Launcher_Branding_WindowsRC "program_info/polymc.rc" PARENT_SCOPE)
 set(Launcher_Branding_LogoQRC "program_info/polymc.qrc" PARENT_SCOPE)
 
-configure_file(org.polymc.PolyMC.desktop.in org.polymc.PolyMC.desktop)
+configure_file(org.polymc.polymc.desktop.in org.polymc.polymc.desktop)
 configure_file(org.polymc.PolyMC.metainfo.xml.in org.polymc.PolyMC.metainfo.xml)

--- a/program_info/org.polymc.polymc.desktop.in
+++ b/program_info/org.polymc.polymc.desktop.in
@@ -10,4 +10,3 @@ Icon=org.polymc.PolyMC
 PrefersNonDefaultGPU=true
 Categories=Game;
 Keywords=game;minecraft;launcher;
-StartupWMClass=PolyMC


### PR DESCRIPTION
This fixes #51. The desktop file is now exactly the same as the window class, which is also now corrected to `org.polymc.polymc`. If you test this out in native wayland (KDE being the troubled child here) the app icon is now correctly set not only in the taskbar but also in the window titlebar.

## What was wrong in the first place?
Because the `LAUNCHER_DOMAIN` was set to `github.com/PolyMC` (which doesn't make sense? [polymc.org](https://polymc.org) exists... although maybe the debranding predated that ;-p) the window class (and in Qt, also the application info) was actually getting set to something crazy like `com/ org.polymc.PolyMC` instead. Because some desktop environments (such as KDE) match by the **exact** name of the application desktop file with the application info Qt provides, this fails and shows the generic Wayland icon (this seems to differ from their normal X11 behavior, because window classes don't really exist in Wayland).

As such, everything in Linux is case-sensitive so the capitalization of the file was changed as well. I changed most of the cases I've found, but if there's any I missed feel free to poke me about them. Of course, any packages not maintained in this repository (AUR? COPR?) must also be checked to see if they reference the old naming of `org.polymc.PolyMC.desktop`. The file capitalization is now also consistent with other Freedesktop application files as well.

## What needs to be reviewed further?
This is just a quick fix, and I'm not entirely confident this doesn't break something e.g. config files. If someone who is more familiar where `LAUNCHER_DOMAIN` is used (this gets set as QCoreApplication::setOrganizationDomain at startup btw, which `QSettings` uses by default) that would be great. If possible, I'd like to avoid moving the settings directory as that involves a bunch of corner cases, but I think setting a correct `LAUNCHER_DOMAIN` is more important :-)

Also, debugging PolyMC and installing in `/usr/local` also made me find a related issue in KDE, filed [here](https://bugs.kde.org/show_bug.cgi?id=449224) :-)