### PR TITLE
Fix icons changing when exiting the settings window

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -246,33 +246,32 @@ void LauncherPage::applySettings()
     //FIXME: make generic
     switch (ui->themeComboBox->currentIndex())
     {
-    case 1:
+    case 0:
         s->set("IconTheme", "pe_dark");
         break;
-    case 2:
+    case 1:
         s->set("IconTheme", "pe_light");
         break;
-    case 3:
+    case 2:
         s->set("IconTheme", "pe_blue");
         break;
-    case 4:
-        s->set("IconTheme", "multimc");
+    case 3:
+        s->set("IconTheme", "pe_colored");
         break;
-    case 5:
+    case 4:
         s->set("IconTheme", "OSX");
         break;
-    case 6:
+    case 5:
         s->set("IconTheme", "iOS");
         break;
-    case 7:
+    case 6:
         s->set("IconTheme", "flat");
         break;
-    case 8:
+    case 7:
         s->set("IconTheme", "custom");
         break;
-    case 0:
-    default:
-        s->set("IconTheme", "pe_colored");
+    case 8:
+        s->set("IconTheme", "multimc");
         break;
     }
 
@@ -327,39 +326,39 @@ void LauncherPage::loadSettings()
     auto theme = s->get("IconTheme").toString();
     if (theme == "pe_dark")
     {
-        ui->themeComboBox->setCurrentIndex(1);
+        ui->themeComboBox->setCurrentIndex(0);
     }
     else if (theme == "pe_light")
     {
-        ui->themeComboBox->setCurrentIndex(2);
+        ui->themeComboBox->setCurrentIndex(1);
     }
     else if (theme == "pe_blue")
     {
-        ui->themeComboBox->setCurrentIndex(3);
+        ui->themeComboBox->setCurrentIndex(2);
     }
     else if (theme == "pe_colored")
     {
-        ui->themeComboBox->setCurrentIndex(4);
+        ui->themeComboBox->setCurrentIndex(3);
     }
     else if (theme == "OSX")
     {
-        ui->themeComboBox->setCurrentIndex(5);
+        ui->themeComboBox->setCurrentIndex(4);
     }
     else if (theme == "iOS")
     {
-        ui->themeComboBox->setCurrentIndex(6);
+        ui->themeComboBox->setCurrentIndex(5);
     }
     else if (theme == "flat")
+    {
+        ui->themeComboBox->setCurrentIndex(6);
+    }
+    else if (theme == "multimc")
     {
         ui->themeComboBox->setCurrentIndex(7);
     }
     else if (theme == "custom")
     {
         ui->themeComboBox->setCurrentIndex(8);
-    }
-    else
-    {
-        ui->themeComboBox->setCurrentIndex(0);
     }
 
     {

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -264,11 +264,6 @@
             </property>
             <item>
              <property name="text">
-              <string>Default</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
               <string>Simple (Dark Icons)</string>
              </property>
             </item>
@@ -305,6 +300,11 @@
             <item>
              <property name="text">
               <string>Custom</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>MultiMC</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Fixes #98.

## What does this change?
The quick debranding caused us to miss changing the relevant parts in `LauncherPage::loadSettings()` which matches up the `IconTheme` setting (where `pe_dark`, `multimc`, etc show up). In the previous commit, we simply switched the `multimc` theme and the `pe_colored` theme around in `LauncherPage::saveSettings()` but not here in this method - thus each time you reopened the settings window they would "switch".

So while changing this I made it a little bit cleaner, now the "MultiMC" icon theme is it's own dedicated selection in the combo box instead of just being called "Default", and there's no longer a "Default" option because that just brings in a lot of issues. As before, `pe_colored` is the default icon theme, and I shifted all of the combo box indexes in `loadSettings()` down to make up for the missing "Default" option.

## What needs to be tested?
I think this is a pretty simple change, and your existing config is not affected as the whole name of the icon theme is stored there (`pe_colored`, `multimc`, etc). However, in the future we should probably rename/remove the `multimc` icon theme (is this even their original icons? it could be a public domain pack repurposed here) but this isn't relevant for this PR but I would like feedback on this idea. Also in the future we should allow people to use system icons instead, as I think the current "custom" option is pointless.