### PR TITLE
Improve the About page

### DIFF
--- a/launcher/ui/dialogs/AboutDialog.cpp
+++ b/launcher/ui/dialogs/AboutDialog.cpp
@@ -32,6 +32,12 @@ QString getCreditsHtml()
     QTextStream stream(&output);
     stream.setCodec(QTextCodec::codecForName("UTF-8"));
     stream << "<center>\n";
+
+    stream << "<h3>" << QObject::tr("PolyMC Developers", "About Credits") << "</h3>\n";
+    stream << "<p>swirl &lt;<a href='mailto:swurl@swurl.xyz'>swurl@swurl.xyz </a>&gt;</p>\n";
+    stream << "<p>LennyMcLennington &lt;<a href='mailto:lenny@sneed.church'>lenny@sneed.church</a>&gt;</p>\n";
+    stream << "<br />\n";
+
     // TODO: possibly retrieve from git history at build time?
     stream << "<h3>" << QObject::tr("MultiMC Developers", "About Credits") << "</h3>\n";
     stream << "<p>Andrew Okin &lt;<a href='mailto:forkk@forkk.net'>forkk@forkk.net</a>&gt;</p>\n";
@@ -47,6 +53,7 @@ QString getCreditsHtml()
     stream << "<p>Kilobyte &lt;<a href='mailto:stiepen22@gmx.de'>stiepen22@gmx.de</a>&gt;</p>\n";
     stream << "<p>Rootbear75 &lt;<a href='https://twitter.com/rootbear75'>@rootbear75</a>&gt;</p>\n";
     stream << "<p>Zeker Zhayard &lt;<a href='https://twitter.com/zeker_zhayard'>@Zeker_Zhayard</a>&gt;</p>\n";
+    stream << "<p>Everyone else who <a href='https://github.com/PolyMC/PolyMC/graphs/contributors'>contributed</a>!</p>\n";
     stream << "<br />\n";
 
     stream << "</center>\n";

--- a/launcher/ui/dialogs/AboutDialog.cpp
+++ b/launcher/ui/dialogs/AboutDialog.cpp
@@ -33,7 +33,7 @@ QString getCreditsHtml()
     stream.setCodec(QTextCodec::codecForName("UTF-8"));
     stream << "<center>\n";
     // TODO: possibly retrieve from git history at build time?
-    stream << "<h3>" << QObject::tr("Developers", "About Credits") << "</h3>\n";
+    stream << "<h3>" << QObject::tr("MultiMC Developers", "About Credits") << "</h3>\n";
     stream << "<p>Andrew Okin &lt;<a href='mailto:forkk@forkk.net'>forkk@forkk.net</a>&gt;</p>\n";
     stream << "<p>Petr Mrázek &lt;<a href='mailto:peterix@gmail.com'>peterix@gmail.com</a>&gt;</p>\n";
     stream << "<p>Sky Welch &lt;<a href='mailto:multimc@bunnies.io'>multimc@bunnies.io</a>&gt;</p>\n";
@@ -83,8 +83,12 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent), ui(new Ui::AboutDia
     ui->icon->setPixmap(APPLICATION->getThemedIcon("logo").pixmap(64));
     ui->title->setText(launcherName);
 
-    ui->versionLabel->setText(tr("Version") +": " + BuildConfig.printableVersionString());
-    ui->platformLabel->setText(tr("Platform") +": " + BuildConfig.BUILD_PLATFORM);
+    ui->versionLabel->setText(BuildConfig.printableVersionString());
+
+    if (!BuildConfig.BUILD_PLATFORM.isEmpty())
+        ui->platformLabel->setText(tr("Platform") +": " + BuildConfig.BUILD_PLATFORM);
+    else
+        ui->platformLabel->setVisible(false);
 
     if (BuildConfig.VERSION_BUILD >= 0)
         ui->buildNumLabel->setText(tr("Build Number") +": " + QString::number(BuildConfig.VERSION_BUILD));

--- a/launcher/ui/dialogs/AboutDialog.ui
+++ b/launcher/ui/dialogs/AboutDialog.ui
@@ -87,6 +87,13 @@
      </property>
     </widget>
    </item>
+      <item>
+    <widget class="QLabel" name="versionLabel">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
@@ -148,16 +155,6 @@
         <widget class="Line" name="line">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="versionLabel">
-         <property name="text">
-          <string>Version:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
          </property>
         </widget>
        </item>

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(Launcher_CommonName "PolyMC")
 
-set(Launcher_Copyright "PolyMC Contributors" PARENT_SCOPE)
+set(Launcher_Copyright "PolyMC Contributors\\n© 2012-2021 MultiMC Contributors" PARENT_SCOPE)
 set(Launcher_Domain "polymc.org" PARENT_SCOPE)
 set(Launcher_Name "${Launcher_CommonName}" PARENT_SCOPE)
 set(Launcher_DisplayName "${Launcher_CommonName}" PARENT_SCOPE)


### PR DESCRIPTION
Improves #106.

# What did I change?
This more clearly marks the original MultiMC contributors, and now correctly hides the "Build Platform" if this is set as empty. The version label is now moved under the "PolyMC" title so it looks just a little bit better (and matches other applications). The copyright on the "About" page now correctly attributes the MultiMC contributors just like on the "License" page.

# What is the user facing changes?
The old about page:
![image](https://user-images.githubusercontent.com/54911369/151464189-5f2fcc93-65c6-4a1b-8acd-92146cbb1ead.png)
![image](https://user-images.githubusercontent.com/54911369/151464318-334547af-55bb-41fc-9ef3-a7362be220ed.png)

And the new:
![image](https://user-images.githubusercontent.com/54911369/151464088-2a39eaf5-261b-493a-a45e-c4cbcaf36b27.png)
![image](https://user-images.githubusercontent.com/54911369/151464342-93fbfb0f-eece-4eeb-b3e1-5a82a514bb63.png)

# What needs review and feedback?
I would like to know if you wanted me to add anything under "PolyMC Contributors", as I could add on another commit, otherwise I think it's just fine to leave it as it is and we'll add them later. In a future PR, I'd also like to overhaul the about page on a technical level, as `getCreditsHtml()` is an absolute mess, I'm not sure why we're not reading this from a file. Setting the copyright info in CMake also seems wrong, this is something that should be handled somewhere else I feel like (or just hardcoded in the `.ui` file)

It's a small but nice change I think :-) In the future I think we should remove the "channel" property entirely (this seems to be something the MultiMC maintainers cared a lot about) as that always seems to be set as "custom".