### PR TITLE
Fix Gentoo Command Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A Gentoo ebuild is available in the [swirl](https://git.swurl.xyz/swirl/ebuilds)
 ```sh
 # as root:
 emerge --oneshot eselect-repository
-eselect-repository enable swirl
+eselect repository enable swirl
 emaint sync -r swirl
 emerge polymc
 # to use latest git version:


### PR DESCRIPTION
The proper syntax for adding repos is `eselect repository enable <repo>`