### PR TITLE
nix: fix quazip input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,15 +66,15 @@
     "quazip": {
       "flake": false,
       "locked": {
-        "lastModified": 1633895098,
-        "narHash": "sha256-+Of0M2IAoTf1CyC0teCpsyurv6xfqiBo84V49dSeNTA=",
-        "owner": "multimc",
+        "lastModified": 1643049383,
+        "narHash": "sha256-LcJY6yd6GyeL7X5MP4L94diceM1TYespWByliBsjK98=",
+        "owner": "stachenov",
         "repo": "quazip",
-        "rev": "b1a72ac0bb5a732bf887a535ab75c6f9bedb6b6b",
+        "rev": "09ec1d10c6d627f895109b21728dda000cbfa7d1",
         "type": "github"
       },
       "original": {
-        "owner": "multimc",
+        "owner": "stachenov",
         "repo": "quazip",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     flake = false;
   };
   inputs.quazip = {
-    url = "github:multimc/quazip";
+    url = "github:stachenov/quazip";
     flake = false;
   };
 


### PR DESCRIPTION
076efc4cb2586edbc11868bd93f48cfe03eb5a6d broke the nix package