### PR TITLE
Bump Qt requirement to 5.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,15 @@ set(CMAKE_C_STANDARD_REQUIRED true)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
-set(CMAKE_CXX_FLAGS " -Wall -pedantic -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS " -Wall -pedantic -Werror -Wno-deprecated-declarations -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
 if(UNIX AND APPLE)
     set(CMAKE_CXX_FLAGS " -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror=return-type")
+
+# Fix build with Qt 5.13
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
 
 option(ENABLE_LTO "Enable Link Time Optimization" off)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)  # minimum version required by QuaZip
 
 if(WIN32)
     # In Qt 5.1+ we have our own main() function, don't autolink to qtmain on Windows
@@ -34,14 +34,12 @@ set(CMAKE_C_STANDARD_REQUIRED true)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
-set(CMAKE_CXX_FLAGS " -Wall -pedantic -Werror -Wno-deprecated-declarations -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS " -Wall -pedantic -D_GLIBCXX_USE_CXX11_ABI=0 -fstack-protector-strong --param=ssp-buffer-size=4 -O3 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS}")
 if(UNIX AND APPLE)
     set(CMAKE_CXX_FLAGS " -stdlib=libc++ ${CMAKE_CXX_FLAGS}")
 endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Werror=return-type")
-
-# Fix build with Qt 5.13
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_DISABLE_DEPRECATED_BEFORE=0x050C00")
 
 option(ENABLE_LTO "Enable Link Time Optimization" off)
 

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -223,9 +223,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     setApplicationName(BuildConfig.LAUNCHER_NAME);
     setApplicationDisplayName(BuildConfig.LAUNCHER_DISPLAYNAME);
     setApplicationVersion(BuildConfig.printableVersionString());
-    #if (QT_VERSION >= QT_VERSION_CHECK(5,7,0))
-        setDesktopFileName(BuildConfig.LAUNCHER_DESKTOPFILENAME);
-    #endif
+    setDesktopFileName(BuildConfig.LAUNCHER_DESKTOPFILENAME);
     startTime = QDateTime::currentDateTime();
 
     // Don't quit on hiding the last window

--- a/launcher/UpdateController.cpp
+++ b/launcher/UpdateController.cpp
@@ -138,20 +138,6 @@ void UpdateController::installUpdates()
                 }
 #endif
                 QFileInfo destination (FS::PathCombine(m_root, op.destination));
-#ifdef Q_OS_WIN32
-                if(QSysInfo::windowsVersion() < QSysInfo::WV_VISTA)
-                {
-                    if(destination.fileName() == windowsExeName)
-                    {
-                        QDir rootDir(m_root);
-                        exeOrigin = rootDir.relativeFilePath(op.source);
-                        exePath = rootDir.relativeFilePath(op.destination);
-                        exeBackup = rootDir.relativeFilePath(FS::PathCombine(backupPath, destination.fileName()));
-                        useXPHack = true;
-                        continue;
-                    }
-                }
-#endif
                 if(destination.exists())
                 {
                     QString backupName = op.destination;

--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -24,10 +24,8 @@ int main(int argc, char *argv[])
     return 42;
 #endif
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -117,7 +117,7 @@ public:
             flags |= Qt::ItemIsUserCheckable;
             if (sourceIndex.model()->hasChildren(sourceIndex))
             {
-                flags |= Qt::ItemIsTristate;
+                flags |= Qt::ItemIsAutoTristate;
             }
         }
 
@@ -210,7 +210,7 @@ public:
                 QStack<QModelIndex> todo;
                 while (1)
                 {
-                    auto node = doing.child(row, 0);
+                    auto node = fsm->index(row, 0, doing);
                     if (!node.isValid())
                     {
                         if (!todo.size())
@@ -259,7 +259,7 @@ public:
             QStack<QModelIndex> todo;
             while (1)
             {
-                auto node = doing.child(row, 0);
+                auto node = this->index(row, 0, doing);
                 if (!node.isValid())
                 {
                     if (!todo.size())
@@ -460,7 +460,7 @@ void ExportInstanceDialog::rowsInserted(QModelIndex parent, int top, int bottom)
     //WARNING: possible off-by-one?
     for(int i = top; i < bottom; i++)
     {
-        auto node = parent.child(i, 0);
+        auto node = proxyModel->index(i, 0, parent);
         if(proxyModel->shouldExpand(node))
         {
             auto expNode = node.parent();

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -54,9 +54,7 @@ ExternalToolsPage::ExternalToolsPage(QWidget *parent) :
     ui->setupUi(this);
     ui->tabWidget->tabBar()->hide();
 
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
     ui->jsonEditorTextBox->setClearButtonEnabled(true);
-    #endif
 
     ui->mceditLink->setOpenExternalLinks(true);
     ui->jvisualvmLink->setOpenExternalLinks(true);


### PR DESCRIPTION
This PR drops support for Qt versions below 5.12.

Also: This bumps minimum CMake version to 3.15, as QuaZip requires this as well.

This effectively means that the following platforms are supported:
- Alpine 3.11 or later
- Arch
- Debian 11 (bullseye) or later
- Fedora 30 or later
- macOS 10.12 (Sierra) or later
- NixOS 21.05 or later
- openSUSE Leap 15.2
- openSUSE Tumbleweed
- Ubuntu 20.04 or later
- Void
- Windows 7 or later

Notable unsupported platforms:
- Debian 10 (doesn't support Qt 5.12)
- Ubuntu 18.04 (doesn't support Qt 5.12 nor CMake 3.15)

NOTE: This does not mean that it will be impossible to run PolyMC on those platforms. A packager could patch PolyMC to build on a slightly older Qt or just use the AppImage / Flatpak 
