### PR TITLE
CI: Build AppImages

### DIFF
--- a/.github/scripts/prepare_JREs.sh
+++ b/.github/scripts/prepare_JREs.sh
@@ -13,33 +13,25 @@ for file in *;
 do
     mkdir temp
 
-    # Handle OpenJDK17 archive
-    re='(OpenJDK17U-jre_x64_linux_hotspot_17.(.*).tar.gz)'
+    re='(OpenJDK([[:digit:]]+)U-jre_x64_linux_hotspot_([[:digit:]]+)(.*).tar.gz)'
     if [[ $file =~ $re ]];
     then
-        version=${BASH_REMATCH[2]}
-        version_edit=$(echo $version | sed -e 's/_/+/g')
-        dir_name=jdk-17.$version_edit-jre
-        echo $dir_name
-        mkdir jre17
+        version_major=${BASH_REMATCH[2]}
+        version_trailing=${BASH_REMATCH[4]}
+
+        if [ $version_major = 17 ];
+        then
+            hyphen='-'
+        else
+            hyphen=''
+        fi
+
+        version_edit=$(echo $version_trailing | sed -e 's/_/+/g' | sed -e 's/b/-b/g')
+        dir_name=jdk$hyphen$version_major$version_edit-jre
+        mkdir jre$version_major
         tar -xzf $file -C temp
         pushd temp/$dir_name
-        cp -r . ../../jre17
-        popd
-
-    fi
-
-    # Handle OpenJDK8 archive
-    re='(OpenJDK8U-jre_x64_linux_hotspot_8(.*).tar.gz)'
-    if [[ $file =~ $re ]];
-    then
-        version=${BASH_REMATCH[2]}
-        version_edit=$(echo $version | sed -e 's/b/-b/g')
-        dir_name=jdk8$version_edit-jre
-        mkdir jre8
-        tar -xzf $file -C temp
-        pushd temp/$dir_name
-        cp -r . ../../jre8
+        cp -r . ../../jre$version_major
         popd
     fi
 

--- a/.github/scripts/prepare_JREs.sh
+++ b/.github/scripts/prepare_JREs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+URL_JDK8="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jre/hotspot/normal/eclipse"
+URL_JDK17="https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jre/hotspot/normal/eclipse"
+
+mkdir -p JREs
+pushd JREs
+
+wget --content-disposition "$URL_JDK8"
+wget --content-disposition "$URL_JDK17"
+
+for file in *;
+do
+    mkdir temp
+
+    # Handle OpenJDK17 archive
+    re='(OpenJDK17U-jre_x64_linux_hotspot_17.(.*).tar.gz)'
+    if [[ $file =~ $re ]];
+    then
+        version=${BASH_REMATCH[2]}
+        version_edit=$(echo $version | sed -e 's/_/+/g')
+        dir_name=jdk-17.$version_edit-jre
+        echo $dir_name
+        mkdir jre17
+        tar -xzf $file -C temp
+        pushd temp/$dir_name
+        cp -r . ../../jre17
+        popd
+
+    fi
+
+    # Handle OpenJDK8 archive
+    re='(OpenJDK8U-jre_x64_linux_hotspot_8(.*).tar.gz)'
+    if [[ $file =~ $re ]];
+    then
+        version=${BASH_REMATCH[2]}
+        version_edit=$(echo $version | sed -e 's/b/-b/g')
+        dir_name=jdk8$version_edit-jre
+        mkdir jre8
+        tar -xzf $file -C temp
+        pushd temp/$dir_name
+        cp -r . ../../jre8
+        popd
+    fi
+
+    rm -rf temp
+done
+
+popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,6 @@ jobs:
       - name: Install OpenJDK
         uses: AdoptOpenJDK/install-jdk@v1
         with:
-          version: '8'
-
-      - name: Install OpenJDK
-        uses: AdoptOpenJDK/install-jdk@v1
-        with:
           version: '17'
 
       - name: Cache Qt
@@ -103,6 +98,12 @@ jobs:
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 
+      - name: Download JREs for AppImage
+        if: matrix.app_image == true
+        shell: bash
+        run: |
+          ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
+
       - name: AppImage magic
         if: matrix.app_image == true
         shell: bash
@@ -110,8 +111,8 @@ jobs:
           export OUTPUT="PolyMC-${{ github.sha }}-x86_64.AppImage"
           chmod +x linuxdeploy-*.AppImage
           mkdir -p ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-{8,17}-openjdk
-          cp -r /opt/hostedtoolcache/jdk-8-hotspot/1.0.0/x64/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk
-          cp -r /opt/hostedtoolcache/jdk-17-hotspot/1.0.0/x64/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk
+          cp -r ${{ github.workspace }}/JREs/jre8/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk
+          cp -r ${{ github.workspace }}/JREs/jre17/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk
           LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib" \
           ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -d ${{ env.INSTALL_DIR }}/usr/share/applications/org.polymc.polymc.desktop -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,13 @@ jobs:
         run: |
           choco install strawberryperl -y --force --x86
 
+      - name: Download OpenSSL libs on Windows
+        if: runner.os == 'Windows'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install aqtinstall==2.0.5
+          python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x86
+
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -141,12 +148,9 @@ jobs:
         run: |
           windeployqt "${{ env.INSTALL_DIR }}/polymc.exe"
 
-      - name: Install OpenSSL libs
+      - name: Install OpenSSL libs on Windows
         if: runner.os == 'Windows'
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install aqtinstall==2.0.5
-          python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x86
           copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libssl-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
           copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libcrypto-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,6 @@ jobs:
         include:
 
           - os: ubuntu-20.04
-            qt_version: 5.12.8
-            qt_host: linux
-
-          - os: ubuntu-20.04
             qt_version: 5.15.2
             qt_host: linux
             app_image: true
@@ -85,25 +81,25 @@ jobs:
         uses: urkle/action-get-ninja@v1
 
       - name: Download linuxdeploy family
-        if: matrix.app_image == true
+        if: runner.os == 'Linux'
         run: |
           wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 
-      - name: Download JREs for AppImage
-        if: matrix.app_image == true
+      - name: Download JREs for AppImage on Linux
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
 
       - name: Configure CMake
-        if: matrix.app_image != true
+        if: runner.os != 'Linux'
         run: |
           cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=Debug -G Ninja
 
-      - name: Configure CMake for AppImage
-        if: matrix.app_image == true
+      - name: Configure CMake on Linux
+        if: runner.os == 'Linux'
         run: |
           cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DLauncher_LAYOUT=lin-system -G Ninja
 
@@ -116,13 +112,13 @@ jobs:
         run: |
           cmake --install ${{ env.BUILD_DIR }}
 
-      - name: Install for AppImage
-        if: matrix.app_image == true
+      - name: Install for AppImage on Linux
+        if: runner.os == 'Linux'
         run: |
           DESTDIR=${{ env.INSTALL_DIR }} cmake --install ${{ env.BUILD_DIR }}
 
       - name: Bundle AppImage
-        if: matrix.app_image == true
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           export OUTPUT="PolyMC-${{ github.sha }}-x86_64.AppImage"
@@ -171,15 +167,15 @@ jobs:
           cd ${{ env.INSTALL_DIR }}
           tar -czf ../polymc.tar.gz *
 
-      - name: Upload AppImage
-        if: matrix.app_image == true
+      - name: Upload AppImage for Linux
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v2
         with:
           name: PolyMC-${{ github.sha }}-x86_64.AppImage
           path: PolyMC-${{ github.sha }}-x86_64.AppImage
 
-      - name: Upload package for Linux and Windows
-        if: runner.os != 'macOS' && matrix.app_image != true
+      - name: Upload package for Windows
+        if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
           name: polymc-${{ runner.os }}-${{ github.sha }}-portable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
           - os: ubuntu-20.04
             qt_version: 5.15.2
             qt_host: linux
-            app_image: true
 
           - os: windows-2022
             qt_version: 5.15.2
@@ -108,7 +107,7 @@ jobs:
           cmake --build ${{ env.BUILD_DIR }}
 
       - name: Install
-        if: matrix.app_image != true
+        if: runner.os != 'Linux'
         run: |
           cmake --install ${{ env.BUILD_DIR }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,19 @@ jobs:
       - name: Install Ninja
         uses: urkle/action-get-ninja@v1
 
+      - name: Download linuxdeploy family
+        if: matrix.app_image == true
+        run: |
+          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+      - name: Download JREs for AppImage
+        if: matrix.app_image == true
+        shell: bash
+        run: |
+          ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
+
       - name: Configure CMake
         if: matrix.app_image != true
         run: |
@@ -91,20 +104,7 @@ jobs:
         run: |
           DESTDIR=${{ env.INSTALL_DIR }} cmake --install ${{ env.BUILD_DIR }}
 
-      - name: Download linuxdeploy family
-        if: matrix.app_image == true
-        run: |
-          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
-          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
-
-      - name: Download JREs for AppImage
-        if: matrix.app_image == true
-        shell: bash
-        run: |
-          ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
-
-      - name: AppImage magic
+      - name: Bundle AppImage
         if: matrix.app_image == true
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ jobs:
             qt_version: 5.12.8
             qt_host: linux
 
+          - os: ubuntu-20.04
+            qt_version: 5.15.2
+            qt_host: linux
+            app_image: true
+
           - os: windows-2022
             qt_version: 5.15.2
             qt_host: windows
@@ -27,7 +32,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      MACOSX_DEPLOYMENT_TARGET: ${{matrix.macosx_deployment_target}}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
+      INSTALL_DIR: "install"
+      BUILD_DIR: "build"
 
     steps:
 
@@ -35,6 +42,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'true'
+
+      - name: Install OpenJDK
+        uses: AdoptOpenJDK/install-jdk@v1
+        with:
+          version: '8'
 
       - name: Install OpenJDK
         uses: AdoptOpenJDK/install-jdk@v1
@@ -61,16 +73,52 @@ jobs:
         uses: urkle/action-get-ninja@v1
 
       - name: Configure CMake
+        if: matrix.app_image != true
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Debug -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=Debug -G Ninja
+
+      - name: Configure CMake for AppImage
+        if: matrix.app_image == true
+        run: |
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DLauncher_LAYOUT=lin-system -G Ninja
 
       - name: Build
         run: |
-          cmake --build build
+          cmake --build ${{ env.BUILD_DIR }}
 
       - name: Install
+        if: matrix.app_image != true
         run: |
-          cmake --install build
+          cmake --install ${{ env.BUILD_DIR }}
+
+      - name: Install for AppImage
+        if: matrix.app_image == true
+        run: |
+          DESTDIR=${{ env.INSTALL_DIR }} cmake --install ${{ env.BUILD_DIR }}
+
+      - name: Download linuxdeploy family
+        if: matrix.app_image == true
+        run: |
+          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+
+      - name: AppImage magic
+        if: matrix.app_image == true
+        shell: bash
+        run: |
+          export OUTPUT="PolyMC-${{ github.sha }}-x86_64.AppImage"
+          chmod +x linuxdeploy-*.AppImage
+          mkdir -p ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-{8,17}-openjdk
+          cp -r /opt/hostedtoolcache/jdk-8-hotspot/1.0.0/x64/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk
+          cp -r /opt/hostedtoolcache/jdk-17-hotspot/1.0.0/x64/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib" \
+          ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -d ${{ env.INSTALL_DIR }}/usr/share/applications/org.polymc.polymc.desktop -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
+
+      - name: Run windeployqt
+        if: runner.os == 'Windows'
+        run: |
+          windeployqt "${{ env.INSTALL_DIR }}/polymc.exe"
 
       - name: Install OpenSSL libs
         if: runner.os == 'Windows'
@@ -78,30 +126,43 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install aqtinstall==2.0.5
           python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x64
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libssl-1_1-x64.dll" "${{ github.workspace }}\install\"
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libcrypto-1_1-x64.dll" "${{ github.workspace }}\install\"
+          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libssl-1_1-x64.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
+          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libcrypto-1_1-x64.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
+
+      - name: Run macdeployqt
+        if: runner.os == 'macOS'
+        run: |
+          cd ${{ env.INSTALL_DIR }}
+          macdeployqt "PolyMC.app" -executable="PolyMC.app/Contents/MacOS/polymc" -always-overwrite
 
       - name: chmod binary on macOS
         if: runner.os == 'macOS'
         run: |
-          chmod +x "${{ github.workspace }}/install/PolyMC.app/Contents/MacOS/polymc"
+          chmod +x "${{ github.workspace }}/${{ env.INSTALL_DIR }}/PolyMC.app/Contents/MacOS/polymc"
 
       - name: tar bundle on macOS
         if: runner.os == 'macOS'
         run: |
-          cd install
+          cd ${{ env.INSTALL_DIR }}
           tar -czf ../polymc.tar.gz *
 
-      - name: Upload package for Linux and Windows
-        if: runner.os != 'macOS'
+      - name: Upload AppImage
+        if: matrix.app_image == true
         uses: actions/upload-artifact@v2
         with:
-          name: polymc-${{ matrix.os }}-portable
-          path: install/**
+          name: PolyMC-${{ github.sha }}-x86_64.AppImage
+          path: PolyMC-${{ github.sha }}-x86_64.AppImage
+
+      - name: Upload package for Linux and Windows
+        if: runner.os != 'macOS' && matrix.app_image != true
+        uses: actions/upload-artifact@v2
+        with:
+          name: polymc-${{ runner.os }}-${{ github.sha }}-portable
+          path: ${{ env.INSTALL_DIR }}/**
 
       - name: Upload package for macOS
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v2
         with:
-          name: polymc-${{ matrix.os }}-portable
+          name: polymc-${{ runner.os }}-${{ github.sha }}-portable
           path: polymc.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,11 +109,21 @@ jobs:
         shell: bash
         run: |
           export OUTPUT="PolyMC-${{ github.sha }}-x86_64.AppImage"
+
           chmod +x linuxdeploy-*.AppImage
+
           mkdir -p ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-{8,17}-openjdk
+
           cp -r ${{ github.workspace }}/JREs/jre8/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk
+
           cp -r ${{ github.workspace }}/JREs/jre17/* ${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk
-          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/jre/lib/amd64:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib/server:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib" \
+
+          export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/lib/amd64/server"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-8-openjdk/lib/amd64"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib/server"
+          LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib"
+
           ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -d ${{ env.INSTALL_DIR }}/usr/share/applications/org.polymc.polymc.desktop -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
 
       - name: Run windeployqt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - os: windows-2022
             qt_version: 5.15.2
             qt_host: windows
-            qt_arch: win64_mingw81
+            qt_arch: win32_mingw81
 
           - os: macos-11
             qt_version: 5.12.12
@@ -37,6 +37,16 @@ jobs:
       BUILD_DIR: "build"
 
     steps:
+      - name: Install 32bit mingw on Windows
+        if: runner.os == 'Windows'
+        uses: egor-tensin/setup-mingw@v2
+        with:
+          platform: x86
+
+      - name: Install 32bit zlib via Strawberry on Windows
+        if: runner.os == 'Windows'
+        run: |
+          choco install strawberryperl -y --force --x86
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,7 +63,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "${{ github.workspace }}/Qt/"
-          key: ${{ runner.os }}-${{ matrix.qt_version }}-qt_cache
+          key: ${{ runner.os }}-${{ matrix.qt_version }}-${{ matrix.qt_arch }}-qt_cache
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v2
@@ -136,9 +146,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install aqtinstall==2.0.5
-          python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x64
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libssl-1_1-x64.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x64\bin\libcrypto-1_1-x64.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
+          python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x86
+          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libssl-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
+          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libcrypto-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
 
       - name: Run macdeployqt
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Run windeployqt
         if: runner.os == 'Windows'
         run: |
-          windeployqt "${{ env.INSTALL_DIR }}/polymc.exe"
+          windeployqt --no-translations "${{ env.INSTALL_DIR }}/polymc.exe"
 
       - name: Install OpenSSL libs on Windows
         if: runner.os == 'Windows'
@@ -154,7 +154,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           cd ${{ env.INSTALL_DIR }}
-          macdeployqt "PolyMC.app" -executable="PolyMC.app/Contents/MacOS/polymc" -always-overwrite
+          macdeployqt "PolyMC.app" -executable="PolyMC.app/Contents/MacOS/polymc" -always-overwrite -use-debug-libs
 
       - name: chmod binary on macOS
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib/server"
           LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib"
 
-          ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -d ${{ env.INSTALL_DIR }}/usr/share/applications/org.polymc.polymc.desktop -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
+          ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
 
       - name: Run windeployqt
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ sudo dnf install polymc
 
 MacOS currently does not have any packages. We are still working on setting up MacOS packaging. Meanwhile, you can [build](https://github.com/PolyMC/PolyMC/blob/develop/BUILD.md#macos) it for yourself.
 
+## Development Builds
+
+There are per-commit development builds available [here](https://github.com/PolyMC/PolyMC/actions). These have debug information in the binaries, so their file sizes are relatively larger.
+Builds are provided for Linux, AppImage on Linux, Windows, and macOS.
+
 # Help & Support
 
 Feel free to create an issue if you need help. However, you might find it easier to ask in the Discord server.

--- a/program_info/org.polymc.PolyMC.desktop.in
+++ b/program_info/org.polymc.PolyMC.desktop.in
@@ -7,7 +7,6 @@ Terminal=false
 Exec=@Launcher_APP_BINARY_NAME@
 StartupNotify=true
 Icon=org.polymc.PolyMC
-PrefersNonDefaultGPU=true
 Categories=Game;
 Keywords=game;minecraft;launcher;
 StartupWMClass=PolyMC


### PR DESCRIPTION
This PR makes it possible to start building AppImages on GHA.
The AppImages include the latest builds of jre8 and jre17, pulled directly from Adoptium via their [API](https://api.adoptium.net/q/swagger-ui/).
The AppImage building requires for a change in the .desktop file which is being discussed here #136.

It also changes the Windows and macOS builds to use Qt's `windeployqt` and `macdeployqt` tools respectively.

Additionally, it adds the commit SHA in the filenames.

EDIT: Adds a `Development Builds` section in `README.md`.
EDIT2: Now also builds 32bit PolyMC for Windows, instead of 64bit which fails to run for unknown reasons.
EDIT3: Also closes #136
EDIT4: Removes generic Linux builds because they don't necessarily work on all distros.

As always, please test the builds thoroughly before merging.