### PR TITLE
Link internal libraries statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,11 +260,9 @@ endif()
 include(ExternalProject)
 set_directory_properties(PROPERTIES EP_BASE External)
 
-option(NBT_BUILD_SHARED "Build NBT shared library" ON)
+option(NBT_BUILD_SHARED "Build NBT shared library" OFF)
 option(NBT_USE_ZLIB "Build NBT library with zlib support" OFF)
 option(NBT_BUILD_TESTS "Build NBT library tests" OFF) #FIXME: fix unit tests.
-set(NBT_NAME Launcher_nbt++)
-set(NBT_DEST_DIR ${LIBRARY_DEST_DIR})
 add_subdirectory(libraries/libnbtplusplus)
 
 add_subdirectory(libraries/systeminfo) # system information library

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -941,7 +941,7 @@ add_library(Launcher_logic STATIC ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${LAUNCHE
 target_link_libraries(Launcher_logic
     systeminfo
     Launcher_classparser
-    ${NBT_NAME}
+    nbt++
     ${ZLIB_LIBRARIES}
     optional-bare
     tomlc99

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -959,7 +959,7 @@ target_link_libraries(Launcher_logic
     Launcher_iconfix
     QuaZip::QuaZip
     hoedown
-    Launcher_rainbow
+    PolyMC_rainbow
     LocalPeer
 )
 

--- a/libraries/iconfix/CMakeLists.txt
+++ b/libraries/iconfix/CMakeLists.txt
@@ -12,17 +12,9 @@ internal/qiconloader.cpp
 internal/qiconloader_p.h
 )
 
-add_library(Launcher_iconfix SHARED ${ICONFIX_SOURCES})
+add_library(Launcher_iconfix ${ICONFIX_SOURCES})
 target_include_directories(Launcher_iconfix PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_BINARY_DIR}" )
 
 target_link_libraries(Launcher_iconfix Qt5::Core Qt5::Widgets)
 
-set_target_properties(Launcher_iconfix PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN 1)
 generate_export_header(Launcher_iconfix)
-
-# Install it
-install(
-    TARGETS Launcher_iconfix
-    RUNTIME DESTINATION ${LIBRARY_DEST_DIR}
-    LIBRARY DESTINATION ${LIBRARY_DEST_DIR}
-)

--- a/libraries/rainbow/CMakeLists.txt
+++ b/libraries/rainbow/CMakeLists.txt
@@ -8,10 +8,15 @@ set(RAINBOW_SOURCES
 src/rainbow.cpp
 )
 
-add_library(Launcher_rainbow ${RAINBOW_SOURCES})
-target_compile_definitions(Launcher_rainbow PRIVATE RAINBOW_LIBRARY)
-target_compile_definitions(Launcher_rainbow PRIVATE RAINBOW_STATIC)
-target_include_directories(Launcher_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}")
+add_definitions(-DRAINBOW_LIBRARY)
+add_library(Launcher_rainbow SHARED ${RAINBOW_SOURCES})
+target_include_directories(Launcher_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 target_link_libraries(Launcher_rainbow Qt5::Core Qt5::Gui)
 
+# Install it
+install(
+    TARGETS Launcher_rainbow
+    RUNTIME DESTINATION ${LIBRARY_DEST_DIR}
+    LIBRARY DESTINATION ${LIBRARY_DEST_DIR}
+)

--- a/libraries/rainbow/CMakeLists.txt
+++ b/libraries/rainbow/CMakeLists.txt
@@ -8,15 +8,10 @@ set(RAINBOW_SOURCES
 src/rainbow.cpp
 )
 
-add_definitions(-DRAINBOW_LIBRARY)
-add_library(Launcher_rainbow SHARED ${RAINBOW_SOURCES})
-target_include_directories(Launcher_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+add_library(Launcher_rainbow ${RAINBOW_SOURCES})
+target_compile_definitions(Launcher_rainbow PRIVATE RAINBOW_LIBRARY)
+target_compile_definitions(Launcher_rainbow PRIVATE RAINBOW_STATIC)
+target_include_directories(Launcher_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_BINARY_DIR}")
 
 target_link_libraries(Launcher_rainbow Qt5::Core Qt5::Gui)
 
-# Install it
-install(
-    TARGETS Launcher_rainbow
-    RUNTIME DESTINATION ${LIBRARY_DEST_DIR}
-    LIBRARY DESTINATION ${LIBRARY_DEST_DIR}
-)

--- a/libraries/rainbow/CMakeLists.txt
+++ b/libraries/rainbow/CMakeLists.txt
@@ -9,14 +9,14 @@ src/rainbow.cpp
 )
 
 add_definitions(-DRAINBOW_LIBRARY)
-add_library(Launcher_rainbow SHARED ${RAINBOW_SOURCES})
-target_include_directories(Launcher_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+add_library(PolyMC_rainbow SHARED ${RAINBOW_SOURCES})
+target_include_directories(PolyMC_rainbow PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-target_link_libraries(Launcher_rainbow Qt5::Core Qt5::Gui)
+target_link_libraries(PolyMC_rainbow Qt5::Core Qt5::Gui)
 
 # Install it
 install(
-    TARGETS Launcher_rainbow
+    TARGETS PolyMC_rainbow
     RUNTIME DESTINATION ${LIBRARY_DEST_DIR}
     LIBRARY DESTINATION ${LIBRARY_DEST_DIR}
 )


### PR DESCRIPTION
There is no reason to dynamically link nbt++. Let's just link it statically.