### PR TITLE
[MACOS] Move app data to Application Support

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -311,7 +311,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         dataPath = xdgDataHome + "/polymc";
         adjustedBy += "XDG standard " + dataPath;
 #elif defined(Q_OS_MAC)
-        QDir foo(FS::PathCombine(applicationDirPath(), "../../Data"));
+        QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         dataPath = foo.absolutePath();
         adjustedBy += "Fallback to special Mac location " + dataPath;
 #else
@@ -529,10 +529,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 #elif defined(Q_OS_WIN32)
         m_rootPath = binPath;
 #elif defined(Q_OS_MAC)
-        QDir foo(FS::PathCombine(binPath, "../.."));
+        QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         m_rootPath = foo.absolutePath();
-        // on macOS, touch the root to force Finder to reload the .app metadata (and fix any icon change issues)
-        FS::updateTimestamp(m_rootPath);
 #endif
 
 #ifdef MULTIMC_JARS_LOCATION


### PR DESCRIPTION
This is a fix that has been ported from [ManyMC](https://github.com/MinecraftMachina/ManyMC), this fixes MacOS data location so app updates dont delete instances and use the proper Application Support folder

GHA shows it builds fine. I would like someone with a Mac to test this first, as I don't have one