### PR TITLE
Fix Weblate link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ In general, in order of importance:
 
 ## Translations
 
-The translation effort for PolyMC is hosted on [Weblate](https://hosted.weblate.org/polymc/polymc) and information about translating PolyMC is available at https://github.com/PolyMC/Translations
+The translation effort for PolyMC is hosted on [Weblate](https://hosted.weblate.org/projects/polymc/polymc/) and information about translating PolyMC is available at https://github.com/PolyMC/Translations
 
 ## Forking/Redistributing/Custom builds policy
 


### PR DESCRIPTION
original link was missing /projects/ dir and leading to a nonexistent page