### PR TITLE
Draft: Initial M1 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,8 @@ set(Launcher_UPDATER_BASE "" CACHE STRING "Base URL for the updater.")
 set(Launcher_NOTIFICATION_URL "" CACHE STRING "URL for checking for notifications.")
 
 # The metadata server
-set(Launcher_META_URL "https://meta.polymc.org/v1/" CACHE STRING "URL to fetch Launcher's meta files from.")
+set(Launcher_META_URL "https://meta.polymc.org/v1/" CACHE STRING "URL to fetch PolyMC's meta files from.")
+set(Launcher_M1_META_URL "https://minecraftmachina.github.io/meta-multimc-arm64/" CACHE STRING "URL to fetch PolyMC's meta files from when using M1 hardware.")
 
 # Imgur API Client ID
 set(Launcher_IMGUR_CLIENT_ID "5b97b0713fba4a3" CACHE STRING "Client ID you can get from Imgur when you register an application")

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -45,6 +45,7 @@ Config::Config()
     IMGUR_CLIENT_ID = "@Launcher_IMGUR_CLIENT_ID@";
     MSA_CLIENT_ID = "@Launcher_MSA_CLIENT_ID@";
     META_URL = "@Launcher_META_URL@";
+    META_M1_URL = "@Launcher_M1_META_URL@";
 
     BUG_TRACKER_URL = "@Launcher_BUG_TRACKER_URL@";
     DISCORD_URL = "@Launcher_DISCORD_URL@";

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -81,6 +81,7 @@ public:
      * Metadata repository URL prefix
      */
     QString META_URL;
+    QString META_M1_URL;
 
     QString BUG_TRACKER_URL;
     QString DISCORD_URL;

--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -23,9 +23,6 @@
 #include "BuildConfig.h"
 #include "Application.h"
 #ifdef Q_OS_MACOS
-#include <stdio.h>
-#include <stdint.h>
-#include <sys/types.h>
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
This adds support for M1 macs. When using an M1 mac, it will use the mmachina meta server from [ManyMC](https://github.com/MinecraftMachina/ManyMC) [meta-multimc-arm64](https://github.com/MinecraftMachina/meta-multimc-arm64)

Checklist:
- [ ] Get permission from ManyMC and possibly host our own M1 meta repo to integrate with the current setup
- [X] Initial test on M1
- [X] Test X86 build on M1
- [ ] ~~Test native M1 build~~ not happening until Qt6 which will fix the various build errors
- [x] Test game launch on M1
- [X] Test for side effects on other platforms
- [x] Test on x86 macs for side effects