### PR TITLE
CI: Release builds and workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
-name: build_portable
+name: Build
 
 on:
-  [push, pull_request, workflow_dispatch]
+  workflow_call:
+    inputs:
+      build_type:
+        description: Type of build (Debug, Release, RelWithDebInfo, MinSizeRel)
+        type: string
+        default: Debug
 
 jobs:
   build:
@@ -59,6 +64,12 @@ jobs:
           copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libssl-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
           copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libcrypto-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
 
+      - name: Set short version
+        shell: bash
+        run: |
+          ver_short=`git rev-parse --short HEAD`
+          echo "VERSION=$ver_short" >> $GITHUB_ENV
+
       - name: Install OpenJDK
         uses: AdoptOpenJDK/install-jdk@v1
         with:
@@ -99,12 +110,12 @@ jobs:
       - name: Configure CMake
         if: runner.os != 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=Debug -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -G Ninja
 
       - name: Configure CMake on Linux
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DLauncher_LAYOUT=lin-system -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLauncher_LAYOUT=lin-system -G Ninja
 
       - name: Build
         run: |
@@ -124,7 +135,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
-          export OUTPUT="PolyMC-${{ github.sha }}-x86_64.AppImage"
+          export OUTPUT="PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage"
 
           chmod +x linuxdeploy-*.AppImage
 
@@ -145,13 +156,13 @@ jobs:
       - name: Run windeployqt
         if: runner.os == 'Windows'
         run: |
-          windeployqt --no-translations "${{ env.INSTALL_DIR }}/polymc.exe"
+          windeployqt --no-translations --no-system-d3d-compiler --no-opengl-sw "${{ env.INSTALL_DIR }}/polymc.exe"
 
       - name: Run macdeployqt
         if: runner.os == 'macOS'
         run: |
           cd ${{ env.INSTALL_DIR }}
-          macdeployqt "PolyMC.app" -executable="PolyMC.app/Contents/MacOS/polymc" -always-overwrite -use-debug-libs
+          macdeployqt "PolyMC.app" -executable="PolyMC.app/Contents/MacOS/polymc" -always-overwrite
 
       - name: chmod binary on macOS
         if: runner.os == 'macOS'
@@ -162,25 +173,25 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           cd ${{ env.INSTALL_DIR }}
-          tar -czf ../polymc.tar.gz *
+          tar -czf ../PolyMC.tar.gz *
 
       - name: Upload AppImage for Linux
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v2
         with:
-          name: PolyMC-${{ github.sha }}-x86_64.AppImage
-          path: PolyMC-${{ github.sha }}-x86_64.AppImage
+          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
+          path: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
 
       - name: Upload package for Windows
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
-          name: polymc-${{ runner.os }}-${{ github.sha }}-portable
+          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}
           path: ${{ env.INSTALL_DIR }}/**
 
       - name: Upload package for macOS
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v2
         with:
-          name: polymc-${{ runner.os }}-${{ github.sha }}-portable
-          path: polymc.tar.gz
+          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}
+          path: PolyMC.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,13 @@ jobs:
         include:
 
           - os: ubuntu-20.04
+            qt_version: 5.12.8
+            qt_host: linux
+
+          - os: ubuntu-20.04
             qt_version: 5.15.2
             qt_host: linux
+            app_image: true
 
           - os: windows-2022
             qt_version: 5.15.2
@@ -94,15 +99,15 @@ jobs:
       - name: Install Ninja
         uses: urkle/action-get-ninja@v1
 
-      - name: Download linuxdeploy family
-        if: runner.os == 'Linux'
+      - name: Download linuxdeploy family for AppImage on Linux
+        if: matrix.app_image == true
         run: |
           wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 
       - name: Download JREs for AppImage on Linux
-        if: runner.os == 'Linux'
+        if: matrix.app_image == true
         shell: bash
         run: |
           ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
@@ -126,13 +131,13 @@ jobs:
         run: |
           cmake --install ${{ env.BUILD_DIR }}
 
-      - name: Install for AppImage on Linux
+      - name: Install on Linux
         if: runner.os == 'Linux'
         run: |
           DESTDIR=${{ env.INSTALL_DIR }} cmake --install ${{ env.BUILD_DIR }}
 
       - name: Bundle AppImage
-        if: runner.os == 'Linux'
+        if: matrix.app_image == true
         shell: bash
         run: |
           export OUTPUT="PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage"
@@ -175,8 +180,21 @@ jobs:
           cd ${{ env.INSTALL_DIR }}
           tar -czf ../PolyMC.tar.gz *
 
+      - name: tar on Linux
+        if: runner.os == 'Linux' && matrix.app_image != true
+        run: |
+          cd ${{ env.INSTALL_DIR }}
+          tar -czf ../PolyMC.tar.gz *
+
+      - name: Upload Linux tar.gz
+        if: runner.os == 'Linux' && matrix.app_image != true
+        uses: actions/upload-artifact@v2
+        with:
+          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}
+          path: PolyMC.tar.gz
+
       - name: Upload AppImage for Linux
-        if: runner.os == 'Linux'
+        if: matrix.app_image == true
         uses: actions/upload-artifact@v2
         with:
           name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.qt_version }}-${{ matrix.qt_arch }}-qt_cache
 
       - name: Install Qt
+        if: runner.os != 'Linux' || matrix.app_image == true
         uses: jurplel/install-qt-action@v2
         with:
           version: ${{ matrix.qt_version }}
@@ -95,6 +96,11 @@ jobs:
           arch: ${{ matrix.qt_arch }}
           cached: ${{ steps.cache-qt.outputs.cache-hit }}
           dir: "${{ github.workspace }}/Qt/"
+
+      - name: Install System Qt on Linux
+        if: runner.os == 'Linux' && matrix.app_image != true
+        run: |
+          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
 
       - name: Install Ninja
         uses: urkle/action-get-ninja@v1

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -1,7 +1,11 @@
 name: Build Application
 
 on:
-  [push, pull_request, workflow_dispatch]
+  push:
+    branches-ignore:
+      - 'stable'
+  pull_request:
+  workflow_dispatch:
 
 jobs:
 
@@ -16,91 +20,3 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build_type: Release
-
-  create_release:
-    if: contains(github.base_ref, 'refs/heads/stable') && startsWith(github.ref, 'refs/tags/')
-    needs: build_release
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-      - name: Grab and store version
-        run: |
-          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
-          echo "VERSION=$tag_name" >> $GITHUB_ENV
-      - name: Create release
-        id: create_release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          name: PolyMC ${{ env.VERSION }}
-          draft: true
-          prerelease: false
-
-  upload_release:
-    needs: create_release
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Grab and store version
-        run: |
-          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
-          echo "VERSION=$tag_name" >> $GITHUB_ENV
-
-      - name: Package artifacts properly
-        run: |
-          rm -rf *Debug*
-
-          mv PolyMC-Linux*/PolyMC.tar.gz PolyMC-Linux-${{ env.VERSION }}.tar.gz
-          mv PolyMC-*.AppImage/PolyMC-*.AppImage PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
-          mv PolyMC-Windows* PolyMC-Windows-${{ env.VERSION }}
-          mv PolyMC-macOS*/PolyMC.tar.gz PolyMC-macOS-${{ env.VERSION }}.tar.gz
-
-          cd PolyMC-Windows-${{ env.VERSION }}
-          zip -r -9 ../PolyMC-Windows-${{ env.VERSION }}.zip *
-          cd ..
-
-      - name: Upload Linux asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: PolyMC-Linux-${{ env.VERSION }}.tar.gz
-          asset_path: PolyMC-Linux-${{ env.VERSION }}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload Linux AppImage asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
-          asset_path: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
-          asset_content_type: application/x-executable
-
-      - name: Upload Windows asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: PolyMC-Windows-${{ env.VERSION }}.zip
-          asset_path: PolyMC-Windows-${{ env.VERSION }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload macOS asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: PolyMC-macOS-${{ env.VERSION }}.tar.gz
-          asset_path: PolyMC-macOS-${{ env.VERSION }}.tar.gz
-          asset_content_type: application/gzip

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -24,6 +24,10 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Grab and store version
+        run: |
+          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
+          echo "VERSION=$tag_name" >> $GITHUB_ENV
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -31,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          name: PolyMC ${{ github.ref }}
+          name: PolyMC ${{ env.VERSION }}
           draft: true
           prerelease: false
 

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           rm -rf *Debug*
 
+          mv PolyMC-Linux*/PolyMC.tar.gz PolyMC-Linux-${{ env.VERSION }}.tar.gz
           mv PolyMC-*.AppImage/PolyMC-*.AppImage PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
           mv PolyMC-Windows* PolyMC-Windows-${{ env.VERSION }}
           mv PolyMC-macOS*/PolyMC.tar.gz PolyMC-macOS-${{ env.VERSION }}.tar.gz
@@ -63,6 +64,16 @@ jobs:
           cd PolyMC-Windows-${{ env.VERSION }}
           zip -r -9 ../PolyMC-Windows-${{ env.VERSION }}.zip *
           cd ..
+
+      - name: Upload Linux asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Linux-${{ env.VERSION }}.tar.gz
+          asset_path: PolyMC-Linux-${{ env.VERSION }}.tar.gz
+          asset_content_type: application/gzip
 
       - name: Upload Linux AppImage asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -1,0 +1,91 @@
+name: Build Application
+
+on:
+  [push, pull_request, workflow_dispatch]
+
+jobs:
+
+  build_debug:
+    name: Build Debug
+    uses: ./.github/workflows/build.yml
+    with:
+      build_type: Debug
+
+  build_release:
+    name: Build Release
+    uses: ./.github/workflows/build.yml
+    with:
+      build_type: Release
+
+  create_release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build_release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          name: PolyMC ${{ github.ref }}
+          draft: true
+          prerelease: false
+
+  upload_release:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Grab and store version
+        run: |
+          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
+          echo "VERSION=$tag_name" >> $GITHUB_ENV
+
+      - name: Package artifacts properly
+        run: |
+          rm -rf *Debug*
+
+          mv PolyMC-*.AppImage/PolyMC-*.AppImage PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          mv PolyMC-Windows* PolyMC-Windows-${{ env.VERSION }}
+          mv PolyMC-macOS*/PolyMC.tar.gz PolyMC-macOS-${{ env.VERSION }}.tar.gz
+
+          cd PolyMC-Windows-${{ env.VERSION }}
+          zip -r -9 ../PolyMC-Windows-${{ env.VERSION }}.zip *
+          cd ..
+
+      - name: Upload Linux AppImage asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          asset_path: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          asset_content_type: application/x-executable
+
+      - name: Upload Windows asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Windows-${{ env.VERSION }}.zip
+          asset_path: PolyMC-Windows-${{ env.VERSION }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload macOS asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-macOS-${{ env.VERSION }}.tar.gz
+          asset_path: PolyMC-macOS-${{ env.VERSION }}.tar.gz
+          asset_content_type: application/gzip

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -18,7 +18,7 @@ jobs:
       build_type: Release
 
   create_release:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: contains(github.base_ref, 'refs/heads/stable') && startsWith(github.ref, 'refs/tags/')
     needs: build_release
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -1,0 +1,99 @@
+name: Build Application and Make Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  build_release:
+    name: Build Release
+    uses: ./.github/workflows/build.yml
+    with:
+      build_type: Release
+
+  create_release:
+    needs: build_release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Grab and store version
+        run: |
+          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
+          echo "VERSION=$tag_name" >> $GITHUB_ENV
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          name: PolyMC ${{ env.VERSION }}
+          draft: true
+          prerelease: false
+
+  upload_release:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Grab and store version
+        run: |
+          tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
+          echo "VERSION=$tag_name" >> $GITHUB_ENV
+
+      - name: Package artifacts properly
+        run: |
+          mv PolyMC-Linux*/PolyMC.tar.gz PolyMC-Linux-${{ env.VERSION }}.tar.gz
+          mv PolyMC-*.AppImage/PolyMC-*.AppImage PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          mv PolyMC-Windows* PolyMC-Windows-${{ env.VERSION }}
+          mv PolyMC-macOS*/PolyMC.tar.gz PolyMC-macOS-${{ env.VERSION }}.tar.gz
+
+          cd PolyMC-Windows-${{ env.VERSION }}
+          zip -r -9 ../PolyMC-Windows-${{ env.VERSION }}.zip *
+          cd ..
+
+      - name: Upload Linux asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Linux-${{ env.VERSION }}.tar.gz
+          asset_path: PolyMC-Linux-${{ env.VERSION }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload Linux AppImage asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          asset_path: PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          asset_content_type: application/x-executable
+
+      - name: Upload Windows asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-Windows-${{ env.VERSION }}.zip
+          asset_path: PolyMC-Windows-${{ env.VERSION }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload macOS asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_name: PolyMC-macOS-${{ env.VERSION }}.tar.gz
+          asset_path: PolyMC-macOS-${{ env.VERSION }}.tar.gz
+          asset_content_type: application/gzip


### PR DESCRIPTION
Commits and PRs now trigger builds of, both, type Debug and Release, for Linux, Windows, and macOS, for a total of 6 artifacts.

If a tag is pushed, a GH Release is created in Draft mode, and the artifacts are packaged properly and then attached to the GH Release. We can then assimilate a changelog and make it public. The name of the tag is used as the version in the filenames.

Due to GH limitations, one tag can only be operated on once. If a tag is deleted and recreated, GH will not operate on it.