### PR TITLE
Add MSA-Client-ID override in UI

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -14,7 +14,7 @@
 #include "ui/pages/global/ProxyPage.h"
 #include "ui/pages/global/ExternalToolsPage.h"
 #include "ui/pages/global/AccountListPage.h"
-#include "ui/pages/global/PastePage.h"
+#include "ui/pages/global/APIPage.h"
 #include "ui/pages/global/CustomCommandsPage.h"
 
 #include "ui/themes/ITheme.h"
@@ -719,6 +719,9 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
         m_settings->registerSetting("CloseAfterLaunch", false);
 
+        // Custom MSA credentials
+        m_settings->registerSetting("MSAClientIDOverride", "");
+
         // Init page provider
         {
             m_globalSettingsProvider = std::make_shared<GenericPageProvider>(tr("Settings"));
@@ -730,7 +733,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
             m_globalSettingsProvider->addPage<ProxyPage>();
             m_globalSettingsProvider->addPage<ExternalToolsPage>();
             m_globalSettingsProvider->addPage<AccountListPage>();
-            m_globalSettingsProvider->addPage<PastePage>();
+            m_globalSettingsProvider->addPage<APIPage>();
         }
         qDebug() << "<> Settings loaded.";
     }

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1519,3 +1519,13 @@ QString Application::getJarsPath()
     }
     return m_jarsPath;
 }
+
+QString Application::getMSAClientID() 
+{
+    QString clientIDOverride = m_settings->get("MSAClientIDOverride").toString();
+    if (!clientIDOverride.isEmpty()) {
+        return clientIDOverride;
+    }
+
+    return BuildConfig.MSA_CLIENT_ID;
+}

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -117,6 +117,8 @@ public:
 
     QString getJarsPath();
 
+    QString getMSAClientID();
+
     /// this is the root of the 'installation'. Used for automatic updates
     const QString &root() {
         return m_rootPath;

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -723,8 +723,8 @@ SET(LAUNCHER_SOURCES
     ui/pages/global/LauncherPage.h
     ui/pages/global/ProxyPage.cpp
     ui/pages/global/ProxyPage.h
-    ui/pages/global/PastePage.cpp
-    ui/pages/global/PastePage.h
+    ui/pages/global/APIPage.cpp
+    ui/pages/global/APIPage.h
 
     # GUI - platform pages
     ui/pages/modplatform/VanillaPage.cpp
@@ -871,7 +871,7 @@ qt5_wrap_ui(LAUNCHER_UI
     ui/pages/global/AccountListPage.ui
     ui/pages/global/JavaPage.ui
     ui/pages/global/LauncherPage.ui
-    ui/pages/global/PastePage.ui
+    ui/pages/global/APIPage.ui
     ui/pages/global/ProxyPage.ui
     ui/pages/global/MinecraftPage.ui
     ui/pages/global/ExternalToolsPage.ui

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -14,7 +14,7 @@ using Activity = Katabasis::Activity;
 MSAStep::MSAStep(AccountData* data, Action action) : AuthStep(data), m_action(action) {
     OAuth2::Options opts;
     opts.scope = "XboxLive.signin offline_access";
-    opts.clientIdentifier = BuildConfig.MSA_CLIENT_ID;
+    opts.clientIdentifier = APPLICATION->getMSAClientID();
     opts.authorizationUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode";
     opts.accessTokenUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token";
 

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include "PastePage.h"
-#include "ui_PastePage.h"
+#include "APIPage.h"
+#include "ui_APIPage.h"
 
 #include <QMessageBox>
 #include <QFileDialog>
@@ -26,9 +26,9 @@
 #include "tools/BaseProfiler.h"
 #include "Application.h"
 
-PastePage::PastePage(QWidget *parent) :
+APIPage::APIPage(QWidget *parent) :
     QWidget(parent),
-    ui(new Ui::PastePage)
+    ui(new Ui::APIPage)
 {
     static QRegularExpression validUrlRegExp("https?://.+");
     ui->setupUi(this);
@@ -37,26 +37,30 @@ PastePage::PastePage(QWidget *parent) :
     loadSettings();
 }
 
-PastePage::~PastePage()
+APIPage::~APIPage()
 {
     delete ui;
 }
 
-void PastePage::loadSettings()
+void APIPage::loadSettings()
 {
     auto s = APPLICATION->settings();
     QString pastebinURL = s->get("PastebinURL").toString();
     ui->urlChoices->setCurrentText(pastebinURL);
+    QString msaClientID = s->get("MSAClientIDOverride").toString();
+    ui->msaClientID->setText(msaClientID);
 }
 
-void PastePage::applySettings()
+void APIPage::applySettings()
 {
     auto s = APPLICATION->settings();
     QString pastebinURL = ui->urlChoices->currentText();
     s->set("PastebinURL", pastebinURL);
+    QString msaClientID = ui->msaClientID->text();
+    s->set("MSAClientIDOverride", msaClientID);
 }
 
-bool PastePage::apply()
+bool APIPage::apply()
 {
     applySettings();
     return true;

--- a/launcher/ui/pages/global/APIPage.h
+++ b/launcher/ui/pages/global/APIPage.h
@@ -21,32 +21,32 @@
 #include <Application.h>
 
 namespace Ui {
-class PastePage;
+class APIPage;
 }
 
-class PastePage : public QWidget, public BasePage
+class APIPage : public QWidget, public BasePage
 {
     Q_OBJECT
 
 public:
-    explicit PastePage(QWidget *parent = 0);
-    ~PastePage();
+    explicit APIPage(QWidget *parent = 0);
+    ~APIPage();
 
     QString displayName() const override
     {
-        return tr("Log Upload");
+        return tr("APIs");
     }
     QIcon icon() const override
     {
-        return APPLICATION->getThemedIcon("log");
+        return APPLICATION->getThemedIcon("worlds");
     }
     QString id() const override
     {
-        return "log-upload";
+        return "apis";
     }
     QString helpPage() const override
     {
-        return "Log-Upload";
+        return "APIs";
     }
     virtual bool apply() override;
 
@@ -55,6 +55,6 @@ private:
     void applySettings();
 
 private:
-    Ui::PastePage *ui;
+    Ui::APIPage *ui;
 };
 

--- a/launcher/ui/pages/global/APIPage.ui
+++ b/launcher/ui/pages/global/APIPage.ui
@@ -103,7 +103,7 @@
        <item>
         <widget class="QGroupBox" name="groupBox_msa">
          <property name="title">
-          <string>Microsoft Secured Account</string>
+          <string>Microsoft Authentication</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
@@ -116,7 +116,7 @@
           <item>
            <widget class="QLabel" name="label_3">
             <property name="text">
-             <string>Note: you probably don't need to set this if logging in via Microsoft Secured Account already works.</string>
+             <string>Note: you probably don't need to set this if logging in via Microsoft Authentication already works.</string>
             </property>
             <property name="textFormat">
              <enum>Qt::RichText</enum>
@@ -136,7 +136,7 @@
           <item>
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Enter a custom client ID for Microsoft Secured Account here. </string>
+             <string>Enter a custom client ID for Microsoft Authentication here. </string>
             </property>
             <property name="textFormat">
              <enum>Qt::RichText</enum>

--- a/launcher/ui/pages/global/APIPage.ui
+++ b/launcher/ui/pages/global/APIPage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PastePage</class>
- <widget class="QWidget" name="PastePage">
+ <class>APIPage</class>
+ <widget class="QWidget" name="APIPage">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -34,7 +34,7 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="groupBox_paste">
          <property name="title">
           <string>Pastebin URL</string>
          </property>
@@ -101,6 +101,58 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBox_msa">
+         <property name="title">
+          <string>Microsoft Secured Account</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Note: you probably don't need to set this if logging in via Microsoft Secured Account already works.</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="msaClientID">
+            <property name="placeholderText">
+             <string>(Default)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Enter a custom client ID for Microsoft Secured Account here. </string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -108,7 +160,7 @@
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
-           <height>216</height>
+           <height>40</height>
           </size>
          </property>
         </spacer>

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -73,7 +73,7 @@ AccountListPage::AccountListPage(QWidget *parent)
     updateButtonStates();
 
     // Xbox authentication won't work without a client identifier, so disable the button if it is missing
-    ui->actionAddMicrosoft->setVisible(BuildConfig.MSA_CLIENT_ID.size() != 0);
+    ui->actionAddMicrosoft->setVisible(!APPLICATION->getMSAClientID().isEmpty());
 }
 
 AccountListPage::~AccountListPage()

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -73,7 +73,10 @@ AccountListPage::AccountListPage(QWidget *parent)
     updateButtonStates();
 
     // Xbox authentication won't work without a client identifier, so disable the button if it is missing
-    ui->actionAddMicrosoft->setVisible(!APPLICATION->getMSAClientID().isEmpty());
+    if (APPLICATION->getMSAClientID().isEmpty()) {
+        ui->actionAddMicrosoft->setVisible(false);
+        ui->actionAddMicrosoft->setToolTip(tr("No Microsoft Secured Account client ID was set."));
+    }
 }
 
 AccountListPage::~AccountListPage()

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -75,7 +75,7 @@ AccountListPage::AccountListPage(QWidget *parent)
     // Xbox authentication won't work without a client identifier, so disable the button if it is missing
     if (APPLICATION->getMSAClientID().isEmpty()) {
         ui->actionAddMicrosoft->setVisible(false);
-        ui->actionAddMicrosoft->setToolTip(tr("No Microsoft Secured Account client ID was set."));
+        ui->actionAddMicrosoft->setToolTip(tr("No Microsoft Authentication client ID was set."));
     }
 }
 


### PR DESCRIPTION
Closes #11.

The user can now override the MSA client ID provided at build time with their own. If neither build environment nor the user provide a client ID, the MSA login option will be disabled as usual.

Additionally, this PR renames the "Log Upload" settings page to "APIs".

![Settings page](https://scrumplex.rocks/img/1644694718.png)

![Settings page but based](https://scrumplex.rocks/img/1644694816.png)