### PR TITLE
Replace build layouts with Launcher_PORTABLE cmake flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Configure CMake on Linux
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLauncher_LAYOUT=lin-system -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLAUNCHER_PORTABLE=OFF -G Ninja
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Configure CMake on Linux
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLAUNCHER_PORTABLE=OFF -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLauncher_PORTABLE=OFF -G Ninja
 
       - name: Build
         run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -56,7 +56,7 @@ This is the preferred method for installation, and is suitable for packages.
 cmake -S . -B build \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="/usr" \ # Use "/usr" when building Linux packages. If building on FreeBSD or not for package, use "/usr/local"
-   -DLauncher_LAYOUT=lin-system
+   -DLAUNCHER_PORTABLE=OFF
 cd build
 make -j$(nproc) install # Optionally specify DESTDIR for packages (i.e. DESTDIR=${pkgdir})
 ```
@@ -250,10 +250,11 @@ zlib1.dll
 1. If you installed Qt with the web installer, there should be a shortcut called `Qt 5.4 for Desktop (MinGW 4.9 32-bit)` in the Start menu on Windows 7 and 10. Best way to find it is to search for it. Do note you cannot just use cmd.exe, you have to use the shortcut, otherwise the proper MinGW software will not be on the PATH.
 2. Once that is open, change into your user directory, and clone PolyMC by doing `git clone --recursive https://github.com/PolyMC/PolyMC.git`, and change directory to the folder you cloned to.
 3. Make a build directory, and change directory to the directory and do `cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=C:\Path\that\makes\sense\for\you`. By default, it will install to C:\Program Files (x86), which you might not want, if you want a local installation. If you want to install it to that directory, make sure to run the command window as administrator.
-4. Do `mingw32-make -jX`, where X is the number of cores your CPU has plus one.
-5. Now to wait for it to compile. This could take some time. Hopefully it compiles properly.
-6. Run the command `mingw32-make install`, and it should install PolyMC, to whatever the `-DCMAKE_INSTALL_PREFIX` was.
-7. In most cases, whenever compiling, the OpenSSL dll's aren't put into the directory to where PolyMC installs, meaning you cannot log in. The best way to fix this is just to do `copy C:\OpenSSL-Win32\*.dll C:\Where\you\installed\PolyMC\to`. This should copy the required OpenSSL dll's to log in.
+4. If you want PolyMC to store its data in `%APPDATA%`, append `-DLAUNCHER_PORTABLE=OFF` to the previous command.
+5. Do `mingw32-make -jX`, where X is the number of cores your CPU has plus one.
+6. Now to wait for it to compile. This could take some time. Hopefully it compiles properly.
+7. Run the command `mingw32-make install`, and it should install PolyMC, to whatever the `-DCMAKE_INSTALL_PREFIX` was.
+8. In most cases, whenever compiling, the OpenSSL dll's aren't put into the directory to where PolyMC installs, meaning you cannot log in. The best way to fix this is just to do `copy C:\OpenSSL-Win32\*.dll C:\Where\you\installed\PolyMC\to`. This should copy the required OpenSSL dll's to log in.
 
 # macOS
 
@@ -288,7 +289,6 @@ cmake \
  -DCMAKE_INSTALL_PREFIX:PATH="$(dirname $PWD)/dist/" \
  -DCMAKE_PREFIX_PATH="/path/to/Qt/" \
  -DQt5_DIR="/path/to/Qt/" \
- -DLauncher_LAYOUT=mac-bundle \
  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 \
  ..
 make install
@@ -335,7 +335,7 @@ This is the preferred method for installation, and is suitable for packages.
 cmake -S . -B build \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="/usr/local" \ # /usr/local is default in OpenBSD and FreeBSD
-   -DLauncher_LAYOUT=lin-system -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake # use linux layout and point to qt5 libs
+   -DLAUNCHER_PORTABLE=OFF -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake # use linux layout and point to qt5 libs
 cd build
 make -j$(nproc) install # Optionally specify DESTDIR for packages (i.e. DESTDIR=${pkgdir})
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -56,7 +56,7 @@ This is the preferred method for installation, and is suitable for packages.
 cmake -S . -B build \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="/usr" \ # Use "/usr" when building Linux packages. If building on FreeBSD or not for package, use "/usr/local"
-   -DLAUNCHER_PORTABLE=OFF
+   -DLauncher_PORTABLE=OFF
 cd build
 make -j$(nproc) install # Optionally specify DESTDIR for packages (i.e. DESTDIR=${pkgdir})
 ```
@@ -250,8 +250,8 @@ zlib1.dll
 1. If you installed Qt with the web installer, there should be a shortcut called `Qt 5.4 for Desktop (MinGW 4.9 32-bit)` in the Start menu on Windows 7 and 10. Best way to find it is to search for it. Do note you cannot just use cmd.exe, you have to use the shortcut, otherwise the proper MinGW software will not be on the PATH.
 2. Once that is open, change into your user directory, and clone PolyMC by doing `git clone --recursive https://github.com/PolyMC/PolyMC.git`, and change directory to the folder you cloned to.
 3. Make a build directory, and change directory to the directory and do `cmake -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=C:\Path\that\makes\sense\for\you`. By default, it will install to C:\Program Files (x86), which you might not want, if you want a local installation. If you want to install it to that directory, make sure to run the command window as administrator.
-4. If you want PolyMC to store its data in `%APPDATA%`, append `-DLAUNCHER_PORTABLE=OFF` to the previous command.
-5. Do `mingw32-make -jX`, where X is the number of cores your CPU has plus one.
+4. If you want PolyMC to store its data in `%APPDATA%`, append `-DLauncher_PORTABLE=OFF` to the previous command.
+5. Do `mingw32-make -j$(nproc)`, where X is the number of cores your CPU has plus one.
 6. Now to wait for it to compile. This could take some time. Hopefully it compiles properly.
 7. Run the command `mingw32-make install`, and it should install PolyMC, to whatever the `-DCMAKE_INSTALL_PREFIX` was.
 8. In most cases, whenever compiling, the OpenSSL dll's aren't put into the directory to where PolyMC installs, meaning you cannot log in. The best way to fix this is just to do `copy C:\OpenSSL-Win32\*.dll C:\Where\you\installed\PolyMC\to`. This should copy the required OpenSSL dll's to log in.
@@ -335,7 +335,7 @@ This is the preferred method for installation, and is suitable for packages.
 cmake -S . -B build \
    -DCMAKE_BUILD_TYPE=Release \
    -DCMAKE_INSTALL_PREFIX="/usr/local" \ # /usr/local is default in OpenBSD and FreeBSD
-   -DLAUNCHER_PORTABLE=OFF -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake # use linux layout and point to qt5 libs
+   -DLauncher_PORTABLE=OFF -DCMAKE_PREFIX_PATH=/usr/local/lib/qt5/cmake # use linux layout and point to qt5 libs
 cd build
 make -j$(nproc) install # Optionally specify DESTDIR for packages (i.e. DESTDIR=${pkgdir})
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ add_subdirectory(program_info)
 ####################################### Install layout #######################################
 
 # Install the build results according to platform
-set(LAUNCHER_PORTABLE 1 CACHE BOOL "The type of installation (Portable or System)")
+set(Launcher_PORTABLE 1 CACHE BOOL "The type of installation (Portable or System)")
 
 
 if(UNIX AND APPLE)
@@ -183,13 +183,13 @@ if(UNIX AND APPLE)
 
 elseif(UNIX)
     set(BINARY_DEST_DIR "bin")
-    if(LAUNCHER_PORTABLE)
+    if(Launcher_PORTABLE)
         set(LIBRARY_DEST_DIR "bin")
         set(BUNDLE_DEST_DIR ".")
         set(JARS_DEST_DIR "bin/jars")
 
         # launcher/Application.cpp will use this value
-        set(Launcher_APP_BINARY_DEFS "-DLAUNCHER_PORTABLE=1")
+        set(Launcher_APP_BINARY_DEFS "-DLauncher_PORTABLE=1")
 
         # Install basic runner script
         configure_file(launcher/Launcher.in "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" @ONLY)
@@ -201,7 +201,7 @@ elseif(UNIX)
         set(LAUNCHER_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
         set(LAUNCHER_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
 
-        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}" "-DLAUNCHER_PORTABLE=0")
+        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}" "-DLauncher_PORTABLE=0")
 
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${LAUNCHER_DESKTOP_DEST_DIR})
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${LAUNCHER_METAINFO_DEST_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,25 +146,11 @@ add_subdirectory(program_info)
 
 ####################################### Install layout #######################################
 
-# How to install the build results
-set(Launcher_LAYOUT "auto" CACHE STRING "The layout for the launcher installation (auto, win-bundle, lin-nodeps, lin-system, mac-bundle)")
-set_property(CACHE Launcher_LAYOUT PROPERTY STRINGS auto win-bundle lin-nodeps lin-system mac-bundle)
+# Install the build results according to platform
+set(LAUNCHER_PORTABLE 1 CACHE BOOL "The type of installation (Portable or System)")
 
-if(Launcher_LAYOUT STREQUAL "auto")
-    if(UNIX AND APPLE)
-        set(Launcher_LAYOUT_REAL "mac-bundle")
-    elseif(UNIX)
-        set(Launcher_LAYOUT_REAL "lin-nodeps")
-    elseif(WIN32)
-        set(Launcher_LAYOUT_REAL "win-bundle")
-    else()
-        message(FATAL_ERROR "Cannot choose a sensible install layout for your platform.")
-    endif()
-else()
-    set(Launcher_LAYOUT_REAL ${Launcher_LAYOUT})
-endif()
 
-if(Launcher_LAYOUT_REAL STREQUAL "mac-bundle")
+if(UNIX AND APPLE)
     set(BINARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
     set(LIBRARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
     set(PLUGIN_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
@@ -195,13 +181,32 @@ if(Launcher_LAYOUT_REAL STREQUAL "mac-bundle")
     # Add the icon
     install(FILES ${Launcher_Branding_ICNS} DESTINATION ${RESOURCES_DEST_DIR} RENAME ${Launcher_Name}.icns)
 
-elseif(Launcher_LAYOUT_REAL STREQUAL "lin-nodeps")
+elseif(UNIX)
     set(BINARY_DEST_DIR "bin")
-    set(LIBRARY_DEST_DIR "bin")
-    set(PLUGIN_DEST_DIR "plugins")
-    set(BUNDLE_DEST_DIR ".")
-    set(RESOURCES_DEST_DIR ".")
-    set(JARS_DEST_DIR "bin/jars")
+    if(LAUNCHER_PORTABLE)
+        set(LIBRARY_DEST_DIR "bin")
+        set(BUNDLE_DEST_DIR ".")
+        set(JARS_DEST_DIR "bin/jars")
+
+        # launcher/Application.cpp will use this value
+        set(Launcher_APP_BINARY_DEFS "-DLAUNCHER_PORTABLE=1")
+
+        # Install basic runner script
+        configure_file(launcher/Launcher.in "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" @ONLY)
+        install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" DESTINATION ${BUNDLE_DEST_DIR} RENAME ${Launcher_Name})
+    else()
+        set(LIBRARY_DEST_DIR "lib${LIB_SUFFIX}")
+        set(JARS_DEST_DIR "share/jars")
+        set(LAUNCHER_DESKTOP_DEST_DIR "share/applications" CACHE STRING "Path to the desktop file directory")
+        set(LAUNCHER_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
+        set(LAUNCHER_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
+
+        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}" "-DLAUNCHER_PORTABLE=0")
+
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${LAUNCHER_DESKTOP_DEST_DIR})
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${LAUNCHER_METAINFO_DEST_DIR})
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_SVG} DESTINATION ${LAUNCHER_ICON_DEST_DIR})
+    endif()
 
     # install as bundle with no dependencies included
     set(INSTALL_BUNDLE "nodeps")
@@ -209,33 +214,7 @@ elseif(Launcher_LAYOUT_REAL STREQUAL "lin-nodeps")
     # Set RPATH
     SET(Launcher_BINARY_RPATH "$ORIGIN/")
 
-    # Install basic runner script
-    configure_file(launcher/Launcher.in "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" @ONLY)
-    install(PROGRAMS "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" DESTINATION ${BUNDLE_DEST_DIR} RENAME ${Launcher_Name})
-
-elseif(Launcher_LAYOUT_REAL STREQUAL "lin-system")
-    set(Launcher_BINARY_DEST_DIR "bin" CACHE STRING "Path to the binary directory")
-    set(Launcher_LIBRARY_DEST_DIR "lib${LIB_SUFFIX}" CACHE STRING "Path to the library directory")
-    set(Launcher_SHARE_DEST_DIR "share/polymc" CACHE STRING "Path to the shared data directory")
-    set(JARS_DEST_DIR "${Launcher_SHARE_DEST_DIR}/jars")
-    set(Launcher_DESKTOP_DEST_DIR "share/applications" CACHE STRING "Path to the desktop file directory")
-    set(Launcher_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
-    set(Launcher_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
-
-    set(BINARY_DEST_DIR ${Launcher_BINARY_DEST_DIR})
-    set(LIBRARY_DEST_DIR ${Launcher_LIBRARY_DEST_DIR})
-
-    MESSAGE(STATUS "Compiling for linux system with ${Launcher_SHARE_DEST_DIR} and LAUNCHER_LINUX_DATADIR")
-    SET(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}" "-DLAUNCHER_LINUX_DATADIR")
-
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${Launcher_DESKTOP_DEST_DIR})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${Launcher_METAINFO_DEST_DIR})
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_SVG} DESTINATION ${Launcher_ICON_DEST_DIR})
-
-    # install as bundle with no dependencies included
-    set(INSTALL_BUNDLE "nodeps")
-
-elseif(Launcher_LAYOUT_REAL STREQUAL "win-bundle")
+elseif(WIN32)
     set(BINARY_DEST_DIR ".")
     set(LIBRARY_DEST_DIR ".")
     set(PLUGIN_DEST_DIR ".")
@@ -252,7 +231,7 @@ elseif(Launcher_LAYOUT_REAL STREQUAL "win-bundle")
     # install as bundle
     set(INSTALL_BUNDLE "full")
 else()
-    message(FATAL_ERROR "No sensible install layout set.")
+    message(FATAL_ERROR "Platform not supported")
 endif()
 
 ################################ Included Libs ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ elseif(UNIX)
         set(JARS_DEST_DIR "bin/jars")
 
         # launcher/Application.cpp will use this value
-        set(Launcher_APP_BINARY_DEFS "-DLauncher_PORTABLE=1")
+        set(Launcher_APP_BINARY_DEFS "-DLAUNCHER_PORTABLE")
 
         # Install basic runner script
         configure_file(launcher/Launcher.in "${CMAKE_CURRENT_BINARY_DIR}/LauncherScript" @ONLY)
@@ -201,7 +201,7 @@ elseif(UNIX)
         set(LAUNCHER_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
         set(LAUNCHER_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
 
-        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}" "-DLauncher_PORTABLE=0")
+        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}")
 
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${LAUNCHER_DESKTOP_DEST_DIR})
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${LAUNCHER_METAINFO_DEST_DIR})

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -294,7 +294,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
     else
     {
-#if !Launcher_PORTABLE || defined(Q_OS_MAC)
+#if !defined(LAUNCHER_PORTABLE) || defined(Q_OS_MAC)
         QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         dataPath = foo.absolutePath();
         adjustedBy += dataPath;

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -294,8 +294,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
     else
     {
-        // qDebug() << LAUNCHER_PORTABLE;
-#if !LAUNCHER_PORTABLE || defined(Q_OS_MAC)
+#if !Launcher_PORTABLE || defined(Q_OS_MAC)
         QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         dataPath = foo.absolutePath();
         adjustedBy += dataPath;

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -298,6 +298,16 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         dataPath = foo.absolutePath();
         adjustedBy += dataPath;
+
+#ifdef Q_OS_LINUX
+        // TODO: this should be removed in a future version
+        // TODO: provide a migration path similar to macOS migration
+        QDir bar(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation), "polymc"));
+        if (bar.exists()) {
+            dataPath = bar.absolutePath();
+            adjustedBy += "Legacy data path " + dataPath;
+        }
+#endif
 #else
         dataPath = applicationDirPath();
         adjustedBy += "Fallback to binary path " + dataPath;

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -294,16 +294,11 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
     else
     {
-#ifdef LAUNCHER_LINUX_DATADIR
-        QString xdgDataHome = QFile::decodeName(qgetenv("XDG_DATA_HOME"));
-        if (xdgDataHome.isEmpty())
-            xdgDataHome = QDir::homePath() + QLatin1String("/.local/share");
-        dataPath = xdgDataHome + "/polymc";
-        adjustedBy += "XDG standard " + dataPath;
-#elif defined(Q_OS_MAC)
+        // qDebug() << LAUNCHER_PORTABLE;
+#if !LAUNCHER_PORTABLE || defined(Q_OS_MAC)
         QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         dataPath = foo.absolutePath();
-        adjustedBy += "Fallback to special Mac location " + dataPath;
+        adjustedBy += dataPath;
 #else
         dataPath = applicationDirPath();
         adjustedBy += "Fallback to binary path " + dataPath;
@@ -505,8 +500,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 #elif defined(Q_OS_WIN32)
         m_rootPath = binPath;
 #elif defined(Q_OS_MAC)
-        QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
+        QDir foo(FS::PathCombine(binPath, "../.."));
         m_rootPath = foo.absolutePath();
+        // on macOS, touch the root to force Finder to reload the .app metadata (and fix any icon change issues)
+        FS::updateTimestamp(m_rootPath);
 #endif
 
 #ifdef MULTIMC_JARS_LOCATION

--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -69,7 +69,7 @@ mkDerivation rec {
 
   cmakeFlags = [
     "-GNinja"
-    "-DLauncher_LAYOUT=lin-system"
+    "-DLAUNCHER_PORTABLE=OFF"
   ];
 
   postInstall = ''

--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -69,7 +69,7 @@ mkDerivation rec {
 
   cmakeFlags = [
     "-GNinja"
-    "-DLAUNCHER_PORTABLE=OFF"
+    "-DLauncher_PORTABLE=OFF"
   ];
 
   postInstall = ''


### PR DESCRIPTION
~~Allows Windows to start using %APPDATA% to store PolyMC data instead of the `cwd`.~~

~~One step closer to an installer.~~

Okay `Launcher_PORTABLE` is now a build flag. It is `ON` by default.

Data path defaults to bin dir by default, except on macOS.
On Windows and Linux, if `LAUNCHER_PORTABLE=OFF`, then `QStandardPaths::AppDataLocation` is used instead.
EDIT: On any other OS, not just Windows and Linux.

This replaces the build layouts that were in place earlier, so external build scripts will have to be updated. I've taken care of BUILD.md and the nix thing.

EDIT: Also, the linux system directory was previously hardcoded to use `polymc` in `XDG_DATA_HOME`. However, `QStandardPaths::AppDataLocation` outputs `PolyMC`, which is how it is —how it should be— on other OSes. Looking for inputs on how to handle this.

EDIT: Also reverts the `m_rootPath` from #146 