### PR TITLE
Fixed segfault in mod download

### DIFF
--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -113,13 +113,12 @@ void FlameModPage::onSelectionChanged(QModelIndex first, QModelIndex second)
     {
         qDebug() << "Loading flame mod versions";
         auto netJob = new NetJob(QString("Flame::ModVersions(%1)").arg(current.name), APPLICATION->network());
-        std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+        auto response = new QByteArray();
         int addonId = current.addonId;
-        netJob->addNetAction(Net::Download::makeByteArray(QString("https://addons-ecs.forgesvc.net/api/v2/addon/%1/files").arg(addonId), response.get()));
+        netJob->addNetAction(Net::Download::makeByteArray(QString("https://addons-ecs.forgesvc.net/api/v2/addon/%1/files").arg(addonId), response));
 
-        QObject::connect(netJob, &NetJob::succeeded, this, [this, response, netJob]
+        QObject::connect(netJob, &NetJob::succeeded, this, [this, response]
         {
-            netJob->deleteLater();
             QJsonParseError parse_error;
             QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
             if(parse_error.error != QJsonParseError::NoError) {
@@ -150,8 +149,12 @@ void FlameModPage::onSelectionChanged(QModelIndex first, QModelIndex second)
             if(ui->versionSelectionBox->count() == 0){
                 ui->versionSelectionBox->addItem(tr("No Valid Version found!"), QVariant(-1));
             }
-
             suggestCurrent();
+        });
+        QObject::connect(netJob, &NetJob::finished, this, [response, netJob]
+        {
+            netJob->deleteLater();
+            delete response;
         });
         netJob->start();
     }


### PR DESCRIPTION
This pr makes sure that the version download netjobs are correctly deleted after use, fixing crashes if the window is closed when the versions are still loading.
Fixes #182 