### PR TITLE
Enable WSL support

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -192,27 +192,6 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     #endif
     startTime = QDateTime::currentDateTime();
 
-#ifdef Q_OS_LINUX
-    {
-        QFile osrelease("/proc/sys/kernel/osrelease");
-        if (osrelease.open(QFile::ReadOnly | QFile::Text)) {
-            QTextStream in(&osrelease);
-            auto contents = in.readAll();
-            if(
-                contents.contains("WSL", Qt::CaseInsensitive) ||
-                contents.contains("Microsoft", Qt::CaseInsensitive)
-            ) {
-                showFatalErrorMessage(
-                    "Unsupported system detected!",
-                    "Linux-on-Windows distributions are not supported.\n\n"
-                    "Please use the Windows binary when playing on Windows."
-                );
-                return;
-            }
-        }
-    }
-#endif
-
     // Don't quit on hiding the last window
     this->setQuitOnLastWindowClosed(false);
 


### PR DESCRIPTION
There doesn't currently seem to be any technical reason for this change. There isn't even a reason to make this a warning; (unless, perhaps, significantly modified by a poweruser) Minecraft is essentially unplayable anyway, so it's not as if people are coming in droves to run PolyMC under WSL.

Ultimately, this "feature" just makes development + testing on a Windows/WSL platform slightly more annoying than it needs to be.