### PR TITLE
Update translations URL

### DIFF
--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -98,7 +98,7 @@ public:
     QString AUTH_BASE = "https://authserver.mojang.com/";
     QString IMGUR_BASE_URL = "https://api.imgur.com/3/";
     QString FMLLIBS_BASE_URL = "https://files.multimc.org/fmllibs/";
-    QString TRANSLATIONS_BASE_URL = "https://meta.polymc.org/translations/";
+    QString TRANSLATIONS_BASE_URL = "https://i18n.polymc.org/";
 
     QString MODPACKSCH_API_BASE_URL = "https://api.modpacks.ch/";
 


### PR DESCRIPTION
This is interesting for packages who backported translations to 1.0.6.


AFAIK only Void packaging backports translations, so CC @oynqr
https://github.com/void-linux/void-packages/pull/34979