### PR TITLE
Notify about needed AppBSD version

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ MacOS has experimental development builds available [here](https://github.com/Po
 
 There are community-maintained binary packages available:
 
-- [AppBSD Image](http://glowiak.github.io/file/polymc-latest-fbsd64-appbsd) - a portable application, requires [AppBSD](https://codeberg.org/glowiak/appbsd/) to be installed.
+- [AppBSD Image](http://glowiak.github.io/file/polymc-latest-fbsd64-appbsd) - a portable application, requires [AppBSD](https://codeberg.org/glowiak/appbsd/) (0.4.9 or newer) to be installed.
 
 - [Gzipped binaries](http://glowiak.github.io/file/polymc-latest-fbsd64-raw) - traditional way to distribute, unpack and run.
 


### PR DESCRIPTION
Today I've released AppBSD version 0.4.9, which adds support for running apps as binaries, and updated the Image to the New Format.

This PR will add a notification that version 0.4.9 of AppBSD is needed to run