### PR TITLE
Always tell Flame API which ModLoader we are using

### DIFF
--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -81,9 +81,8 @@ void FlameMod::loadIndexedPackVersions(FlameMod::IndexedPack & pack, QJsonArray 
                     break;
                 }
             }
-            else if(fname == "mcmod.info"){ //this cannot check for the recent mcmod.toml formats
-                break;
-            }
+            else break;
+            // NOTE: Since we're not validating forge versions, we can just skip this loop.
         }
 
         if(hasFabric && !is_valid_fabric_version)

--- a/launcher/ui/pages/modplatform/flame/FlameModModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModModel.cpp
@@ -175,13 +175,13 @@ void ListModel::performPaginatedSearch()
         "pageSize=25&"
         "searchFilter=%2&"
         "sort=%3&"
-        "%4"
+        "modLoaderType=%4&"
         "gameVersion=%5"
     )
         .arg(nextSearchOffset)
         .arg(currentSearchTerm)
         .arg(sorts[currentSort])
-        .arg(hasFabric ? "modLoaderType=4&" : "")
+        .arg(hasFabric ? 4 : 1) // Enum: https://docs.curseforge.com/?http#tocS_ModLoaderType
         .arg(mcVersion);
 
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));


### PR DESCRIPTION
Fixes #206 partially. Although with these changes we don't list mods that have no compatibility with the mod loader we are using anymore, mods that have support for both loaders still show up, and the versions for both the loaders are still shown.

From what I could tell, there's no way to filter this information in the API request, and the information it gives us back about the versions does not contain the mod loader that version supports. The only thing I can think of in this case is to inspect the `fabric.mod.json` and `mcmod.info` for that information, but I never did any of these so I can't be sure. 

Also this simplifies a little the logic in `FlameModIndex::loadIndexedPackVersions`.