### PR TITLE
Don't build when updating non-code

### DIFF
--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches-ignore:
       - 'stable'
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - 'flake.lock'
+      - '**.nix'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**/LICENSE'
+      - 'flake.lock'
+      - '**.nix'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This makes it so that commits to `.md` files and such that aren't compiled don't trigger a workflow build.