### PR TITLE
Reorganize icon themes

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -247,16 +247,16 @@ void LauncherPage::applySettings()
     switch (ui->themeComboBox->currentIndex())
     {
     case 0:
-        s->set("IconTheme", "pe_dark");
+        s->set("IconTheme", "pe_colored");
         break;
     case 1:
         s->set("IconTheme", "pe_light");
         break;
     case 2:
-        s->set("IconTheme", "pe_blue");
+        s->set("IconTheme", "pe_dark");
         break;
     case 3:
-        s->set("IconTheme", "pe_colored");
+        s->set("IconTheme", "pe_blue");
         break;
     case 4:
         s->set("IconTheme", "OSX");
@@ -268,10 +268,10 @@ void LauncherPage::applySettings()
         s->set("IconTheme", "flat");
         break;
     case 7:
-        s->set("IconTheme", "custom");
+        s->set("IconTheme", "multimc");
         break;
     case 8:
-        s->set("IconTheme", "multimc");
+        s->set("IconTheme", "custom");
         break;
     }
 
@@ -324,7 +324,7 @@ void LauncherPage::loadSettings()
     m_currentUpdateChannel = s->get("UpdateChannel").toString();
     //FIXME: make generic
     auto theme = s->get("IconTheme").toString();
-    if (theme == "pe_dark")
+    if (theme == "pe_colored")
     {
         ui->themeComboBox->setCurrentIndex(0);
     }
@@ -332,11 +332,11 @@ void LauncherPage::loadSettings()
     {
         ui->themeComboBox->setCurrentIndex(1);
     }
-    else if (theme == "pe_blue")
+    else if (theme == "pe_dark")
     {
         ui->themeComboBox->setCurrentIndex(2);
     }
-    else if (theme == "pe_colored")
+    else if (theme == "pe_blue")
     {
         ui->themeComboBox->setCurrentIndex(3);
     }

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -264,7 +264,7 @@
             </property>
             <item>
              <property name="text">
-              <string>Simple (Dark Icons)</string>
+              <string>Simple (Colored Icons)</string>
              </property>
             </item>
             <item>
@@ -274,12 +274,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Simple (Blue Icons)</string>
+              <string>Simple (Dark Icons)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Simple (Colored Icons)</string>
+              <string>Simple (Blue Icons)</string>
              </property>
             </item>
             <item>
@@ -294,17 +294,17 @@
             </item>
             <item>
              <property name="text">
-              <string notr="true">Flat</string>
+              <string>Flat</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Legacy</string>
              </property>
             </item>
             <item>
              <property name="text">
               <string>Custom</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>MultiMC</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
Closes #225
Closes #189

- Rename MultiMC to Legacy
- Simple (Colored) is now the first icon theme
- Custom is now the last icon theme, which also fixes a loading issue when Legacy was selected
- Fix loading of Legacy theme
