### PR TITLE
Fix missing space in "No Accounts" message

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -56,7 +56,7 @@ void LaunchController::decideAccount()
             m_parentWidget,
             tr("No Accounts"),
             tr("In order to play Minecraft, you must have at least one Mojang or Minecraft "
-               "account logged in."
+               "account logged in. "
                "Would you like to open the account manager to add an account now?"),
             QMessageBox::Information,
             QMessageBox::Yes | QMessageBox::No


### PR DESCRIPTION
Small change to add a missing space between two sentences in the "No Accounts" message (displayed when you try to launch an instance without setting up an account).