### PR TITLE
move fabric up the modloader list

### DIFF
--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -176,14 +176,6 @@
     <string>Revert the selected package to default.</string>
    </property>
   </action>
-  <action name="actionInstall_Forge">
-   <property name="text">
-    <string>Install Forge</string>
-   </property>
-   <property name="toolTip">
-    <string>Install the Minecraft Forge package.</string>
-   </property>
-  </action>
   <action name="actionInstall_Fabric">
    <property name="text">
     <string>Install Fabric</string>
@@ -192,6 +184,15 @@
     <string>Install the Fabric Loader package.</string>
    </property>
   </action>
+  <action name="actionInstall_Forge">
+   <property name="text">
+    <string>Install Forge</string>
+   </property>
+   <property name="toolTip">
+    <string>Install the Minecraft Forge package.</string>
+   </property>
+  </action>
+  
   <action name="actionInstall_LiteLoader">
    <property name="text">
     <string>Install LiteLoader</string>

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -105,8 +105,8 @@
    <addaction name="actionEdit"/>
    <addaction name="actionRevert"/>
    <addaction name="separator"/>
-   <addaction name="actionInstall_Forge"/>
    <addaction name="actionInstall_Fabric"/>
+   <addaction name="actionInstall_Forge"/>
    <addaction name="actionInstall_LiteLoader"/>
    <addaction name="actionInstall_mods"/>
    <addaction name="separator"/>

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -192,7 +192,6 @@
     <string>Install the Minecraft Forge package.</string>
    </property>
   </action>
-  
   <action name="actionInstall_LiteLoader">
    <property name="text">
     <string>Install LiteLoader</string>


### PR DESCRIPTION
Fabric is a more user-respecting mod loader, as a FOSS launcher I think we should put it above forge