### PR TITLE
Fix Ubuntu system Qt failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Install System Qt on Linux
         if: runner.os == 'Linux' && matrix.app_image != true
         run: |
+          sudo apt-get -y update
           sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
 
       - name: Install Ninja


### PR DESCRIPTION
GHA has been failing since yesterday or so.

This needs to be merged before 1.1.0 or the workflow will fail and a GH Release won't be created.