### PR TITLE
Define JARs path relative to application root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,8 @@ elseif(UNIX)
         set(LAUNCHER_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
         set(LAUNCHER_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
 
-        set(Launcher_APP_BINARY_DEFS "-DMULTIMC_JARS_LOCATION=${CMAKE_INSTALL_PREFIX}/${JARS_DEST_DIR}")
+        # jars path is determined on runtime, relative to "Application root path", generally /usr for Launcher_PORTABLE=0
+        set(Launcher_APP_BINARY_DEFS "-DLAUNCHER_JARS_LOCATION=${JARS_DEST_DIR}")
 
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${LAUNCHER_DESKTOP_DEST_DIR})
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${LAUNCHER_METAINFO_DEST_DIR})

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -515,8 +515,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         FS::updateTimestamp(m_rootPath);
 #endif
 
-#ifdef MULTIMC_JARS_LOCATION
-        m_jarsPath = TOSTRING(MULTIMC_JARS_LOCATION);
+#ifdef LAUNCHER_JARS_LOCATION
+        m_jarsPath = TOSTRING(LAUNCHER_JARS_LOCATION);
 #endif
 
         qDebug() << BuildConfig.LAUNCHER_DISPLAYNAME << ", (c) 2013-2021 " << BuildConfig.LAUNCHER_COPYRIGHT;
@@ -1494,7 +1494,7 @@ QString Application::getJarsPath()
     {
         return FS::PathCombine(QCoreApplication::applicationDirPath(), "jars");
     }
-    return m_jarsPath;
+    return FS::PathCombine(m_rootPath, m_jarsPath);
 }
 
 QString Application::getMSAClientID() 


### PR DESCRIPTION
Closes #117

Instead of forcing `CMAKE_INSTALL_PREFIX`, which will be different when packaged with AppImage, figure out the jar path on runtime.