### PR TITLE
nix: refactor flake (drop flake-utils)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1646955661,
-        "narHash": "sha256-AYLta1PubJnrkv15+7G+6ErW5m9NcI9wSdJ+n7pKAe0=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e9545762b032559c27d8ec9141ed63ceca1aa1ac",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,21 +16,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "libnbtplusplus": {
       "flake": false,
       "locked": {
@@ -49,16 +34,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643169865,
-        "narHash": "sha256-+KIpNRazbc8Gac9jdWCKQkFv9bjceaLaLhlwqUEYu8c=",
+        "lastModified": 1646955661,
+        "narHash": "sha256-AYLta1PubJnrkv15+7G+6ErW5m9NcI9wSdJ+n7pKAe0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "945ec499041db73043f745fad3b2a3a01e826081",
+        "rev": "e9545762b032559c27d8ec9141ed63ceca1aa1ac",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -82,7 +67,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "libnbtplusplus": "libnbtplusplus",
         "nixpkgs": "nixpkgs",
         "quazip": "quazip"

--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -14,10 +14,11 @@
 , libGL
 , msaClientID ? ""
 
-# flake
+  # flake
 , self
-, submoduleNbt
-, submoduleQuazip
+, version
+, libnbtplusplus
+, quazip
 }:
 
 let
@@ -30,7 +31,7 @@ let
     libXxf86vm
     libpulseaudio
     libGL
-  ]; 
+  ];
 
   # This variable will be passed to Minecraft by PolyMC
   gameLibraryPath = libpath + ":/run/opengl-driver/lib";
@@ -38,7 +39,7 @@ in
 
 mkDerivation rec {
   pname = "polymc";
-  version = "nightly";
+  inherit version;
 
   src = lib.cleanSource self;
 
@@ -57,8 +58,8 @@ mkDerivation rec {
     # Copy submodules inputs
     rm -rf source/libraries/{libnbtplusplus,quazip}
     mkdir source/libraries/{libnbtplusplus,quazip}
-    cp -a ${submoduleNbt}/* source/libraries/libnbtplusplus
-    cp -a ${submoduleQuazip}/* source/libraries/quazip
+    cp -a ${libnbtplusplus}/* source/libraries/libnbtplusplus
+    cp -a ${quazip}/* source/libraries/quazip
     chmod a+r+w source/libraries/{libnbtplusplus,quazip}/*
   '';
 

--- a/packages/nix/polymc/default.nix
+++ b/packages/nix/polymc/default.nix
@@ -44,7 +44,7 @@ mkDerivation rec {
   src = lib.cleanSource self;
 
   nativeBuildInputs = [ cmake ninja file makeWrapper ];
-  buildInputs = [ qtbase jdk8 zlib ];
+  buildInputs = [ qtbase jdk zlib ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
- Dropped flake-utils, the flake is now less dependent on other flakes with less useless abstractions.
- Changed version from `nightly` to last modified date of the repo.
- No longer use `import nixpkgs` to reduce doubled evaluation

Another question is if quazip from the input/master needed? can we not use the quazip package on nixpkgs (v1.2)?
also is `jdk` version **8** needed? can we not use newer versions available in nixpkgs?

~~I will undraft the PR once the questions above have been answered.~~

`nix flake check` passes and I managed to launch the program.
output of `nix flake show`
```
├───apps
│   ├───aarch64-linux
│   │   └───polymc: app
│   ├───x86_64-darwin
│   │   └───polymc: app
│   └───x86_64-linux
│       └───polymc: app
├───defaultApp
│   ├───aarch64-linux: app
│   ├───x86_64-darwin: app
│   └───x86_64-linux: app
├───defaultPackage
│   ├───aarch64-linux: package 'polymc-20220313'
│   ├───x86_64-darwin: package 'polymc-20220313'
│   └───x86_64-linux: package 'polymc-20220313'
├───overlay: Nixpkgs overlay
└───packages
    ├───aarch64-linux
    │   └───polymc: package 'polymc-20220313'
    ├───x86_64-darwin
    │   └───polymc: package 'polymc-20220313'
    └───x86_64-linux
        └───polymc: package 'polymc-20220313'
```

CC: @Kloenk @starcraft66