### PR TITLE
Hopefully fix JavaChecker

### DIFF
--- a/libraries/javacheck/JavaCheck.java
+++ b/libraries/javacheck/JavaCheck.java
@@ -1,11 +1,9 @@
-import java.lang.Integer;
-
 public class JavaCheck
 {
     private static final String[] keys = {"os.arch", "java.version", "java.vendor"};
     public static void main (String [] args)
     {
-        int ret = 0;
+        boolean error = false;
         for(String key : keys)
         {
             String property = System.getProperty(key);
@@ -15,10 +13,13 @@ public class JavaCheck
             }
             else
             {
-                ret = 1;
+                error = true;
+                break;
             }
         }
         
-        System.exit(ret);
+        if (error) {
+            System.exit(1);
+        }
     }
 }


### PR DESCRIPTION
I replaced the int for the status code with a bool, which is then just checked.

Also, the checker exits early now, if one of the properties isn't available, which isn't a necessary change but whatever.

The return code also only needs to be explicitly set, if it isn't 0.