### PR TITLE
Add GITDIR-NOTFOUND check

### DIFF
--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -28,7 +28,11 @@ Config::Config()
 
     GIT_COMMIT = "@Launcher_GIT_COMMIT@";
     GIT_REFSPEC = "@Launcher_GIT_REFSPEC@";
-    if(GIT_REFSPEC.startsWith("refs/heads/"))
+    if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND"))
+    {
+        VERSION_CHANNEL = QStringLiteral("stable");
+    }
+    else if(GIT_REFSPEC.startsWith("refs/heads/"))
     {
         VERSION_CHANNEL = GIT_REFSPEC;
         VERSION_CHANNEL.remove("refs/heads/");


### PR DESCRIPTION
This adds a check for a GIT_REFSPEC value of "GITDIR-NOTFOUND" and sets
the VERSION_CHANNEL to stable in that case. Without this change,
"GITDIR-N" is appended to the version string when building from a source
archive instead of a git checkout.