### PR TITLE
Limit offline username to 16 characters with override

### DIFF
--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -42,6 +42,15 @@ void OfflineLoginDialog::setUserInputsEnabled(bool enable)
     ui->buttonBox->setEnabled(enable);
 }
 
+void OfflineLoginDialog::on_allowLongUsernames_stateChanged(int value)
+{
+    if (value == Qt::Checked) {
+        ui->userTextBox->setMaxLength(INT_MAX);
+    } else {
+        ui->userTextBox->setMaxLength(16);
+    }
+}
+
 // Enable the OK button only when the textbox contains something.
 void OfflineLoginDialog::on_userTextBox_textEdited(const QString &newText)
 {

--- a/launcher/ui/dialogs/OfflineLoginDialog.h
+++ b/launcher/ui/dialogs/OfflineLoginDialog.h
@@ -35,6 +35,7 @@ slots:
     void onTaskProgress(qint64 current, qint64 total);
 
     void on_userTextBox_textEdited(const QString &newText);
+    void on_allowLongUsernames_stateChanged(int value);
 
 private:
     Ui::OfflineLoginDialog *ui;

--- a/launcher/ui/dialogs/OfflineLoginDialog.ui
+++ b/launcher/ui/dialogs/OfflineLoginDialog.ui
@@ -35,8 +35,21 @@
    </item>
    <item>
     <widget class="QLineEdit" name="userTextBox">
+     <property name="maxLength">
+      <number>16</number>
+     </property>
      <property name="placeholderText">
       <string>Username</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="allowLongUsernames">
+     <property name="toolTip">
+      <string>Usernames longer than 16 characters cannot be used for LAN games or offline-mode servers.</string>
+     </property>
+     <property name="text">
+      <string>Allow long usernames</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Offline usernames longer than 16 characters won't be able to connect to
LAN games or offline-mode servers, so just don't let it happen.

Add a checkbox to allow people to unrestrict usernames if they want.

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>

Fixes #291
