### PR TITLE
Switch to msys2 for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,12 @@ jobs:
             ninja:p
             qt5:p
 
+      - name: Set short version
+        shell: bash
+        run: |
+          ver_short=`git rev-parse --short HEAD`
+          echo "VERSION=$ver_short" >> $GITHUB_ENV
+
       - name: Install OpenJDK
         uses: actions/setup-java@v3
         with:
@@ -231,7 +237,7 @@ jobs:
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
-          name: PolyMC-${{ matrix.name }}-${{ inputs.build_type }}
+          name: PolyMC-${{ matrix.name }}-${{ env.VERSION }}-${{ inputs.build_type }}
           path: ${{ env.INSTALL_DIR }}/**
 
       - name: Upload package for macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,10 @@ jobs:
             qt5:p
 
       - name: Install OpenJDK
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '17'
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Cache Qt
         if: runner.os != 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,12 @@ jobs:
             app_image: true
 
           - os: windows-2022
-            qt_version: 5.15.2
-            qt_host: windows
-            qt_arch: win32_mingw81
+            name: "Windows-i686"
+            msystem: mingw32
+
+          - os: windows-2022
+            name: "Windows-x86_64"
+            msystem: mingw64
 
           - os: macos-11
             qt_version: 5.12.12
@@ -42,38 +45,24 @@ jobs:
       BUILD_DIR: "build"
 
     steps:
-      - name: Install 32bit mingw on Windows
-        if: runner.os == 'Windows'
-        uses: egor-tensin/setup-mingw@v2
-        with:
-          platform: x86
-
-      - name: Install 32bit zlib via Strawberry on Windows
-        if: runner.os == 'Windows'
-        run: |
-          choco install strawberryperl -y --force --x86
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: 'true'
 
-      # We need to do this here because it inexplicably fails if we split the step
-      - name: Download and install OpenSSL libs on Windows
+      - name: 'Setup MSYS2'
         if: runner.os == 'Windows'
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install aqtinstall==2.0.5
-          python -m aqt install-tool -O "${{ github.workspace }}\Qt\" windows desktop tools_openssl_x86
-          mkdir ${{ env.INSTALL_DIR }}
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libssl-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
-          copy "${{ github.workspace }}\Qt\Tools\OpenSSL\Win_x86\bin\libcrypto-1_1.dll" "${{ github.workspace }}\${{ env.INSTALL_DIR }}\"
-
-      - name: Set short version
-        shell: bash
-        run: |
-          ver_short=`git rev-parse --short HEAD`
-          echo "VERSION=$ver_short" >> $GITHUB_ENV
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.msystem }}
+          update: true
+          install: >-
+            git
+          pacboy: >-
+            toolchain:p
+            cmake:p
+            ninja:p
+            qt5:p
 
       - name: Install OpenJDK
         uses: AdoptOpenJDK/install-jdk@v1
@@ -81,6 +70,7 @@ jobs:
           version: '17'
 
       - name: Cache Qt
+        if: runner.os != 'Windows'
         id: cache-qt
         uses: actions/cache@v2
         with:
@@ -88,7 +78,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.qt_version }}-${{ matrix.qt_arch }}-qt_cache
 
       - name: Install Qt
-        if: runner.os != 'Linux' || matrix.app_image == true
+        if: runner.os != 'Linux' && runner.os != 'Windows' || matrix.app_image == true
         uses: jurplel/install-qt-action@v2
         with:
           version: ${{ matrix.qt_version }}
@@ -104,6 +94,7 @@ jobs:
           sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
 
       - name: Install Ninja
+        if: runner.os != 'Windows'
         uses: urkle/action-get-ninja@v1
 
       - name: Download linuxdeploy family for AppImage on Linux
@@ -120,7 +111,13 @@ jobs:
           ${{ github.workspace }}/.github/scripts/prepare_JREs.sh
 
       - name: Configure CMake
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && runner.os != 'Windows'
+        run: |
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -G Ninja
+
+      - name: Configure CMake on Windows
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
         run: |
           cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -G Ninja
 
@@ -130,11 +127,24 @@ jobs:
           cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DLauncher_PORTABLE=OFF -G Ninja
 
       - name: Build
+        if: runner.os != 'Windows'
+        run: |
+          cmake --build ${{ env.BUILD_DIR }}
+
+      - name: Build on Windows
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
         run: |
           cmake --build ${{ env.BUILD_DIR }}
 
       - name: Install
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && runner.os != 'Windows'
+        run: |
+          cmake --install ${{ env.BUILD_DIR }}
+
+      - name: Install on Windows
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
         run: |
           cmake --install ${{ env.BUILD_DIR }}
 
@@ -164,11 +174,6 @@ jobs:
           LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_DIR }}/usr/lib/jvm/java-17-openjdk/lib"
 
           ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_DIR }} --output appimage --plugin qt -i ${{ env.INSTALL_DIR }}/usr/share/icons/hicolor/scalable/apps/org.polymc.PolyMC.svg
-
-      - name: Run windeployqt
-        if: runner.os == 'Windows'
-        run: |
-          windeployqt --no-translations --no-system-d3d-compiler --no-opengl-sw "${{ env.INSTALL_DIR }}/polymc.exe"
 
       - name: Run macdeployqt
         if: runner.os == 'macOS'
@@ -207,11 +212,25 @@ jobs:
           name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
           path: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
 
+      - name: Copy OpenSSL libs on Windows x86
+        if: runner.os == 'Windows' && matrix.msystem == 'mingw32'
+        shell: msys2 {0}
+        run: |
+          cp /mingw32/bin/libcrypto-1_1.dll ${{ env.INSTALL_DIR }}/
+          cp /mingw32/bin/libssl-1_1.dll ${{ env.INSTALL_DIR }}/
+
+      - name: Copy OpenSSL libs on Windows x86_64
+        if: runner.os == 'Windows' && matrix.msystem == 'mingw64'
+        shell: msys2 {0}
+        run: |
+          cp /mingw64/bin/libcrypto-1_1-x64.dll ${{ env.INSTALL_DIR }}/
+          cp /mingw64/bin/libssl-1_1-x64.dll ${{ env.INSTALL_DIR }}/
+
       - name: Upload package for Windows
         if: runner.os == 'Windows'
         uses: actions/upload-artifact@v2
         with:
-          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}
+          name: PolyMC-${{ matrix.name }}-${{ inputs.build_type }}
           path: ${{ env.INSTALL_DIR }}/**
 
       - name: Upload package for macOS


### PR DESCRIPTION
This switches Windows builds to use dependencies from msys2/mingw64. Benefits are updated/patched QT and OpenSSL, *probably* working x86_64 builds and *hopefully* no more weird issues. The only downside so far is the increased binary size, plus build times for i686 are abysmal.

AdoptOpenJDK is also replaced by Eclipse Temurin since the former is no longer supported.

Closes #222
Closes #276 