### PR TITLE
Use primary file for mod downloading on Modrinth

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -51,31 +51,32 @@ void Modrinth::loadIndexedPackVersions(Modrinth::IndexedPack & pack, QJsonArray 
 
         auto files = Json::requireArray(obj, "files");
         int i = 0;
-        while (files.count() > 1 && i < files.count()){
-            //try to resolve the correct file
+        
+        // Find correct file (needed in cases where one version may have multiple files)
+        // Will default to the last one if there's no primary (though I think Modrinth requires that
+        // at least one file is primary, idk)
+        while (i < files.count()){
             auto parent = files[i].toObject();
             auto fileName = Json::requireString(parent, "filename");
-            //avoid grabbing "dev" files
-            if(fileName.contains("javadocs",Qt::CaseInsensitive) || fileName.contains("sources",Qt::CaseInsensitive)){
+
+            // Grab the correct mod loader
+            if(hasFabric){
+                if(fileName.contains("forge",Qt::CaseInsensitive)){
+                    i++;
+                    continue;
+                }
+            } else if(fileName.contains("fabric", Qt::CaseInsensitive)){
                 i++;
                 continue;
             }
-            //grab the correct mod loader
-            if(fileName.contains("forge",Qt::CaseInsensitive) || fileName.contains("fabric",Qt::CaseInsensitive)  ){
-                if(hasFabric){
-                    if(fileName.contains("forge",Qt::CaseInsensitive)){
-                        i++;
-                        continue;
-                    }
-                }else{
-                    if(fileName.contains("fabric",Qt::CaseInsensitive)){
-                        i++;
-                        continue;
-                    }
-                }
-            }
-            break;
+
+            // Grab the primary file, if available
+            if(Json::requireBoolean(parent, "primary"))
+                break;
+
+            i++;
         }
+
         auto parent = files[i].toObject();
         if(parent.contains("url")) {
             file.downloadUrl = Json::requireString(parent, "url");


### PR DESCRIPTION
Closes #212. This is by no means an awesome solution, but it works. Ideally we would give the user the freedom to choose different filters for what mods / files show up, as proposes issue 279's comments!

This is just a fix for the 1.1.1 release, I'd like to wait until 1.2.0 (or when, and if, #220 gets merged) to implement those more sophisticated filter things.