### PR TITLE
bundle jre8u312 instead of latest on appimage

### DIFF
--- a/.github/scripts/prepare_JREs.sh
+++ b/.github/scripts/prepare_JREs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-URL_JDK8="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jre/hotspot/normal/eclipse"
+URL_JDK8="https://api.adoptium.net/v3/binary/version/jdk8u312-b07/linux/x64/jre/hotspot/normal/eclipse"
 URL_JDK17="https://api.adoptium.net/v3/binary/latest/17/ga/linux/x64/jre/hotspot/normal/eclipse"
 
 mkdir -p JREs


### PR DESCRIPTION
8u320 or higher breaks old forge. This pr makes the java 8 jre appimage bundled version to 8u312.