### PR TITLE
Remove paste.polymc.org

### DIFF
--- a/launcher/ui/pages/global/APIPage.ui
+++ b/launcher/ui/pages/global/APIPage.ui
@@ -74,11 +74,6 @@
               <string>https://0x0.st</string>
              </property>
             </item>
-            <item>
-             <property name="text">
-              <string>https://paste.polymc.org</string>
-             </property>
-            </item>
            </widget>
           </item>
           <item>


### PR DESCRIPTION
Removes option for using https://paste.polymc.org in the API page, since it no longer works!