### PR TITLE
Allow users to move toolbars to different places

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -273,8 +273,8 @@ public:
     {
         mainToolBar = TranslatedToolbar(MainWindow);
         mainToolBar->setObjectName(QStringLiteral("mainToolBar"));
-        mainToolBar->setMovable(false);
-        mainToolBar->setAllowedAreas(Qt::TopToolBarArea);
+        mainToolBar->setMovable(true);
+        mainToolBar->setAllowedAreas(Qt::TopToolBarArea | Qt::BottomToolBarArea);
         mainToolBar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         mainToolBar->setFloatable(false);
         mainToolBar.setWindowTitleId(QT_TRANSLATE_NOOP("MainWindow", "Main Toolbar"));
@@ -442,8 +442,8 @@ public:
     {
         newsToolBar = TranslatedToolbar(MainWindow);
         newsToolBar->setObjectName(QStringLiteral("newsToolBar"));
-        newsToolBar->setMovable(false);
-        newsToolBar->setAllowedAreas(Qt::BottomToolBarArea);
+        newsToolBar->setMovable(true);
+        newsToolBar->setAllowedAreas(Qt::TopToolBarArea | Qt::BottomToolBarArea);
         newsToolBar->setIconSize(QSize(16, 16));
         newsToolBar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         newsToolBar->setFloatable(false);
@@ -467,6 +467,7 @@ public:
         instanceToolBar->setObjectName(QStringLiteral("instanceToolBar"));
         // disabled until we have an instance selected
         instanceToolBar->setEnabled(false);
+        instanceToolBar->setMovable(true);
         instanceToolBar->setAllowedAreas(Qt::LeftToolBarArea | Qt::RightToolBarArea);
         instanceToolBar->setToolButtonStyle(Qt::ToolButtonTextOnly);
         instanceToolBar->setFloatable(false);


### PR DESCRIPTION
This allows users to move different toolbars to different places, as follows:
- The main toolbar can be either on the top (default) or the bottom area.
- The news toolbar can be either on the top or the bottom (default) area.
- The instance management toolbar can be either to the left or to the right (default) area.

Example of non-default placements (main toolbar on the bottom, news toolbar on the top and instance toolbar on the left):
![image](https://user-images.githubusercontent.com/9145768/159138382-994f7d2c-b42b-4c31-b531-4136bfdcb0f4.png)

If you have another suggestion of placement, feel free to say it! :)