### PR TITLE
Limit instance names to 128 chars

### DIFF
--- a/launcher/ui/dialogs/NewInstanceDialog.ui
+++ b/launcher/ui/dialogs/NewInstanceDialog.ui
@@ -44,7 +44,11 @@
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLineEdit" name="instNameTextBox"/>
+      <widget class="QLineEdit" name="instNameTextBox">
+       <property name="maxLength">
+        <number>128</number>
+       </property>
+      </widget>
      </item>
      <item row="0" column="1">
       <widget class="QLabel" name="nameLabel">

--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -405,6 +405,8 @@ void ListViewDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, 
     QString text = realeditor->toPlainText();
     text.replace(QChar('\n'), QChar(' '));
     text = text.trimmed();
+    // Prevent instance names longer than 128 chars
+    text.truncate(128);
     if(text.size() != 0)
     {
         model->setData(index, text);


### PR DESCRIPTION
Closes #197

This makes it a little better than keeping it unlimited.