### PR TITLE
Fix default locale selection on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 [submodule "libraries/quazip"]
 	path = libraries/quazip
 	url = https://github.com/stachenov/quazip.git
+[submodule "Translations"]
+	path = Translations
+	url = https://github.com/PolyMC/Translations.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,13 @@ if(UNIX AND APPLE)
     # Add the icon
     install(FILES ${Launcher_Branding_ICNS} DESTINATION ${RESOURCES_DEST_DIR} RENAME ${Launcher_Name}.icns)
 
+    # Add translation directories
+    file(GLOB TRANSLATIONS RELATIVE "${CMAKE_SOURCE_DIR}/Translations" "${CMAKE_SOURCE_DIR}/Translations/*.ts")
+    list(REMOVE_ITEM TRANSLATIONS ".template.ts")
+    list(TRANSFORM TRANSLATIONS REPLACE "\.ts" ".lproj")
+    list(TRANSFORM TRANSLATIONS PREPEND "${CMAKE_INSTALL_PREFIX}/${RESOURCES_DEST_DIR}/")
+    file(MAKE_DIRECTORY ${TRANSLATIONS})
+
 elseif(UNIX)
     set(BINARY_DEST_DIR "bin")
     if(Launcher_PORTABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ if(UNIX AND APPLE)
     # Add translation directories
     file(GLOB TRANSLATIONS RELATIVE "${CMAKE_SOURCE_DIR}/Translations" "${CMAKE_SOURCE_DIR}/Translations/*.ts")
     list(REMOVE_ITEM TRANSLATIONS ".template.ts")
+    list(APPEND TRANSLATIONS "en_US.ts")
     list(TRANSFORM TRANSLATIONS REPLACE "\.ts" ".lproj")
     list(TRANSFORM TRANSLATIONS PREPEND "${CMAKE_INSTALL_PREFIX}/${RESOURCES_DEST_DIR}/")
     file(MAKE_DIRECTORY ${TRANSLATIONS})


### PR DESCRIPTION
This should make the default locale selection work on macOS, see https://bugreports.qt.io/browse/QTBUG-72491 for specifics.
Sadly, I did not think of a better way than importing Translations as a submodule, although it only needs to be updated when new languages are added. I can move Translations to a different directory if needed.