### PR TITLE
Avoid building per-commit release type builds

### DIFF
--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -9,12 +9,16 @@ on:
       - '**/LICENSE'
       - 'flake.lock'
       - '**.nix'
+      - 'packages/**'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     paths-ignore:
       - '**.md'
       - '**/LICENSE'
       - 'flake.lock'
       - '**.nix'
+      - 'packages/**'
+      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -28,9 +28,3 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build_type: Debug
-
-  build_release:
-    name: Build Release
-    uses: ./.github/workflows/build.yml
-    with:
-      build_type: Release


### PR DESCRIPTION
This will make it so that PRs and pushes will only build debug type builds.

Also, adds a few paths to `ignore-paths` so non-code does not trigger builds.