### PR TITLE
Improve mod versions request to Modrinth

### DIFF
--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QString>
+#include <QList>
 
 namespace ModPlatform {
 class ListModel;
@@ -25,5 +26,13 @@ class ModAPI {
     };
 
     virtual void searchMods(CallerType* caller, SearchArgs&& args) const = 0;
-    virtual void getVersions(CallerType* caller, const QString& addonId) const = 0;
+
+
+    struct VersionSearchArgs {
+        QString addonId;
+        QList<QString> mcVersions;
+        ModLoaderType loader;
+    };
+
+    virtual void getVersions(CallerType* caller, VersionSearchArgs&& args) const = 0;
 };

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -25,8 +25,8 @@ class FlameAPI : public NetworkModAPI {
             .arg(args.version);
     };
 
-    inline auto getVersionsURL(const QString& addonId) const -> QString override
+    inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {
-        return QString("https://addons-ecs.forgesvc.net/api/v2/addon/%1/files").arg(addonId);
+        return QString("https://addons-ecs.forgesvc.net/api/v2/addon/%1/files").arg(args.addonId);
     };
 };

--- a/launcher/modplatform/helpers/NetworkModAPI.cpp
+++ b/launcher/modplatform/helpers/NetworkModAPI.cpp
@@ -31,14 +31,14 @@ void NetworkModAPI::searchMods(CallerType* caller, SearchArgs&& args) const
     netJob->start();
 }
 
-void NetworkModAPI::getVersions(CallerType* caller, const QString& addonId) const
+void NetworkModAPI::getVersions(CallerType* caller, VersionSearchArgs&& args) const
 {
-    auto netJob = new NetJob(QString("%1::ModVersions(%2)").arg(caller->debugName()).arg(addonId), APPLICATION->network());
+    auto netJob = new NetJob(QString("%1::ModVersions(%2)").arg(caller->debugName()).arg(args.addonId), APPLICATION->network());
     auto response = new QByteArray();
 
-    netJob->addNetAction(Net::Download::makeByteArray(getVersionsURL(addonId), response));
+    netJob->addNetAction(Net::Download::makeByteArray(getVersionsURL(args), response));
 
-    QObject::connect(netJob, &NetJob::succeeded, caller, [response, caller, addonId] {
+    QObject::connect(netJob, &NetJob::succeeded, caller, [response, caller, args] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -48,7 +48,7 @@ void NetworkModAPI::getVersions(CallerType* caller, const QString& addonId) cons
             return;
         }
 
-        caller->versionRequestSucceeded(doc, addonId);
+        caller->versionRequestSucceeded(doc, args.addonId);
     });
 
     QObject::connect(netJob, &NetJob::finished, caller, [response, netJob] {

--- a/launcher/modplatform/helpers/NetworkModAPI.h
+++ b/launcher/modplatform/helpers/NetworkModAPI.h
@@ -5,9 +5,9 @@
 class NetworkModAPI : public ModAPI {
    public:
     void searchMods(CallerType* caller, SearchArgs&& args) const override;
-    void getVersions(CallerType* caller, const QString& addonId) const override;
+    void getVersions(CallerType* caller, VersionSearchArgs&& args) const override;
 
    protected:
     virtual auto getModSearchURL(SearchArgs& args) const -> QString = 0;
-    virtual auto getVersionsURL(const QString& addonId) const -> QString = 0;
+    virtual auto getVersionsURL(VersionSearchArgs& args) const -> QString = 0;
 };

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -30,10 +30,26 @@ class ModrinthAPI : public NetworkModAPI {
             .arg(args.version);
     };
 
-    inline auto getVersionsURL(const QString& addonId) const -> QString override
+    inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {
-        return QString("https://api.modrinth.com/v2/project/%1/version").arg(addonId);
+        return QString("https://api.modrinth.com/v2/project/%1/version?"
+                "game_versions=[%2]"
+                "loaders=[%3]")
+            .arg(args.addonId)
+            .arg(getGameVersionsString(args.mcVersions))
+            .arg(getModLoaderString(args.loader));
     };
+
+    inline auto getGameVersionsString(QList<QString> mcVersions) const -> QString
+    {
+        QString s;
+        for(int i = 0; i < mcVersions.count(); i++){
+            s += mcVersions.at(i);
+            if(i < mcVersions.count() - 1)
+                s += ",";
+        }
+        return s;
+    }
 
     inline auto getModLoaderString(ModLoaderType modLoader) const -> QString
     {

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -30,7 +30,6 @@ void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                                        BaseInstance* inst)
 {
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
-    bool hasFabric = !(static_cast<MinecraftInstance*>(inst))->getPackProfile()->getComponentVersion("net.fabricmc.fabric-loader").isEmpty();
     QString mcVersion = (static_cast<MinecraftInstance*>(inst))->getPackProfile()->getComponentVersion("net.minecraft");
 
     for (auto versionIter : arr) {
@@ -60,17 +59,6 @@ void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
         while (i < files.count() - 1){ 
             auto parent = files[i].toObject();
             auto fileName = Json::requireString(parent, "filename");
-
-            // Grab the correct mod loader
-            if(hasFabric){
-                if(fileName.contains("forge",Qt::CaseInsensitive)){
-                    i++;
-                    continue;
-                }
-            } else if(fileName.contains("fabric", Qt::CaseInsensitive)){
-                i++;
-                continue;
-            }
 
             // Grab the primary file, if available
             if(Json::requireBoolean(parent, "primary"))

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -62,6 +62,9 @@ class ListModel : public QAbstractListModel {
 
     void requestLogo(QString file, QString url);
 
+    inline auto hasFabric() const -> bool;
+    inline auto getMineVersions() const -> QList<QString>;
+
    protected:
     ModPage* m_parent;
 


### PR DESCRIPTION
When asking for mod version on Modrinth, we were not using all available arguments. Particularly, by using them, we can:
1. Get only the versions available for the minecraft versions we want, instead of all possible mod versions
2. Get only the versions for the modloader we want

This reduces the bandwidth usage when requesting versions, so that there's less load on Modrinth servers :^)

Also, in theory, this reduces the time taken for mod versions to load, but since most of it is related to ping times (at least where I live), it's not that huge of a improvement in that area.