### PR TITLE
Convert \s in Windows POLYMC_JAVA_PATHS

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -153,7 +153,7 @@ QStringList addJavasFromEnv(QList<QString> javas)
 {
     QByteArray env = qgetenv("POLYMC_JAVA_PATHS");
 #if defined(Q_OS_WIN32)
-    QList<QString> javaPaths = QString::fromLocal8Bit(env).split(QLatin1String(";"));
+    QList<QString> javaPaths = QString::fromLocal8Bit(env).replace("\\", "/").split(QLatin1String(";"));
 #else
     QList<QString> javaPaths = QString::fromLocal8Bit(env).split(QLatin1String(":"));
 #endif


### PR DESCRIPTION
Allows you to use either `\` or `/` on Windows for POLYMC_JAVA_PATHS