### PR TITLE
feat: track and display world size

### DIFF
--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -198,7 +198,8 @@ int64_t calculateWorldSize(const QFileInfo &file)
     {
         QDirIterator it(file.absolutePath(), QDirIterator::Subdirectories);
         int64_t total = 0;
-        while (it.hasNext()) {        
+        while (it.hasNext())
+        {
             total += it.fileInfo().size();
             it.next();
         }

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -17,6 +17,7 @@
 #include <QString>
 #include <QDebug>
 #include <QSaveFile>
+#include <QDirIterator>
 #include "World.h"
 
 #include "GZip.h"
@@ -187,6 +188,25 @@ bool putLevelDatDataToFS(const QFileInfo &file, QByteArray & data)
     return f.commit();
 }
 
+int64_t calculateWorldSize(const QFileInfo &file)
+{
+    if (file.isFile() && file.suffix() == "zip")
+    {
+        return file.size();
+    }
+    else if(file.isDir())
+    {
+        QDirIterator it(file.absolutePath(), QDirIterator::Subdirectories);
+        int64_t total = 0;
+        while (it.hasNext()) {        
+            total += it.fileInfo().size();
+            it.next();
+        }
+        return total;
+    }
+    return -1;
+}
+
 World::World(const QFileInfo &file)
 {
     repath(file);
@@ -196,6 +216,7 @@ void World::repath(const QFileInfo &file)
 {
     m_containerFile = file;
     m_folderName = file.fileName();
+    m_size = calculateWorldSize(file);
     if(file.isFile() && file.suffix() == "zip")
     {
         m_iconFile = QString();
@@ -482,6 +503,7 @@ void World::loadFromLevelDat(QByteArray data)
     if(randomSeed) {
         qDebug() << "Seed:" << *randomSeed;
     }
+    qDebug() << "Size:" << m_size;
     qDebug() << "GameType:" << m_gameType.toLogString();
 }
 

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -17,6 +17,7 @@
 #include <QFileInfo>
 #include <QDateTime>
 #include <nonstd/optional>
+#include <qfileinfo.h>
 
 struct GameType {
     GameType() = default;
@@ -51,6 +52,10 @@ public:
     QString iconFile() const
     {
         return m_iconFile;
+    }
+    int64_t bytes() const
+    {
+        return m_size;
     }
     QDateTime lastPlayed() const
     {
@@ -105,6 +110,7 @@ protected:
     QString m_iconFile;
     QDateTime levelDatTime;
     QDateTime m_lastPlayed;
+    int64_t m_size;
     int64_t m_randomSeed = 0;
     GameType m_gameType;
     bool is_valid = false;

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -17,7 +17,6 @@
 #include <QFileInfo>
 #include <QDateTime>
 #include <nonstd/optional>
-#include <qfileinfo.h>
 
 struct GameType {
     GameType() = default;

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -14,6 +14,8 @@
  */
 
 #include "WorldList.h"
+
+#include "Application.h"
 #include <FileSystem.h>
 #include <QMimeData>
 #include <QUrl>
@@ -150,7 +152,7 @@ bool WorldList::resetIcon(int row)
 
 int WorldList::columnCount(const QModelIndex &parent) const
 {
-    return 3;
+    return 4;
 }
 
 QVariant WorldList::data(const QModelIndex &index, int role) const
@@ -163,6 +165,8 @@ QVariant WorldList::data(const QModelIndex &index, int role) const
 
     if (row < 0 || row >= worlds.size())
         return QVariant();
+
+    QLocale locale;
 
     auto & world = worlds[row];
     switch (role)
@@ -178,6 +182,9 @@ QVariant WorldList::data(const QModelIndex &index, int role) const
 
         case LastPlayedColumn:
             return world.lastPlayed();
+
+        case SizeColumn:
+            return locale.formattedDataSize(world.bytes());
 
         default:
             return QVariant();
@@ -207,6 +214,10 @@ QVariant WorldList::data(const QModelIndex &index, int role) const
     {
         return world.lastPlayed();
     }
+    case SizeRole:
+    {
+        return locale.formattedDataSize(world.bytes());
+    }
     case IconFileRole:
     {
         return world.iconFile();
@@ -229,6 +240,9 @@ QVariant WorldList::headerData(int section, Qt::Orientation orientation, int rol
             return tr("Game Mode");
         case LastPlayedColumn:
             return tr("Last Played");
+        case SizeColumn:
+            //: World size on disk
+            return tr("Size");
         default:
             return QVariant();
         }
@@ -242,6 +256,8 @@ QVariant WorldList::headerData(int section, Qt::Orientation orientation, int rol
             return tr("Game mode of the world.");
         case LastPlayedColumn:
             return tr("Date and time the world was last played.");
+        case SizeColumn:
+            return tr("Size of the world on disk.");
         default:
             return QVariant();
         }

--- a/launcher/minecraft/WorldList.h
+++ b/launcher/minecraft/WorldList.h
@@ -32,7 +32,8 @@ public:
     {
         NameColumn,
         GameModeColumn,
-        LastPlayedColumn
+        LastPlayedColumn,
+        SizeColumn
     };
 
     enum Roles
@@ -43,6 +44,7 @@ public:
         NameRole,
         GameModeRole,
         LastPlayedRole,
+        SizeRole,
         IconFileRole
     };
 


### PR DESCRIPTION
Closes #365

Needs some testing. I am not sure if there is a performance penalty for huge worlds. Someone please check this with a 2B2T world download or something.
(You can just check it by opening the Worlds tab for an instance)

![Screenshot of Worlds](https://scrumplex.rocks/img/1648745053.png)