### PR TITLE
Improve the progress dialog when there's multiple tasks

### DIFF
--- a/launcher/tasks/SequentialTask.cpp
+++ b/launcher/tasks/SequentialTask.cpp
@@ -1,7 +1,23 @@
 #include "SequentialTask.h"
 
-SequentialTask::SequentialTask(QObject *parent) : Task(parent), m_currentIndex(-1)
+SequentialTask::SequentialTask(QObject* parent, const QString& task_name) : Task(parent), m_name(task_name), m_currentIndex(-1) {}
+
+SequentialTask::~SequentialTask()
 {
+    for(auto task : m_queue){
+        if(task)
+            task->deleteLater();
+    }
+}
+
+auto SequentialTask::getStepProgress() const -> qint64
+{
+    return m_stepProgress;
+}
+
+auto SequentialTask::getStepTotalProgress() const -> qint64
+{
+    return m_stepTotalProgress;
 }
 
 void SequentialTask::addTask(Task::Ptr task)
@@ -15,16 +31,24 @@ void SequentialTask::executeTask()
     startNext();
 }
 
+bool SequentialTask::abort()
+{
+    bool succeeded = true;
+    for (auto& task : m_queue) {
+        if (!task->abort()) succeeded = false;
+    }
+
+    return succeeded;
+}
+
 void SequentialTask::startNext()
 {
-    if (m_currentIndex != -1)
-    {
+    if (m_currentIndex != -1) {
         Task::Ptr previous = m_queue[m_currentIndex];
         disconnect(previous.get(), 0, this, 0);
     }
     m_currentIndex++;
-    if (m_queue.isEmpty() || m_currentIndex >= m_queue.size())
-    {
+    if (m_queue.isEmpty() || m_currentIndex >= m_queue.size()) {
         emitSucceeded();
         return;
     }
@@ -33,23 +57,27 @@ void SequentialTask::startNext()
     connect(next.get(), SIGNAL(status(QString)), this, SLOT(subTaskStatus(QString)));
     connect(next.get(), SIGNAL(progress(qint64, qint64)), this, SLOT(subTaskProgress(qint64, qint64)));
     connect(next.get(), SIGNAL(succeeded()), this, SLOT(startNext()));
+
+    setStatus(tr("Executing task %1 out of %2").arg(m_currentIndex + 1).arg(m_queue.size()));
     next->start();
 }
 
-void SequentialTask::subTaskFailed(const QString &msg)
+void SequentialTask::subTaskFailed(const QString& msg)
 {
     emitFailed(msg);
 }
-void SequentialTask::subTaskStatus(const QString &msg)
+void SequentialTask::subTaskStatus(const QString& msg)
 {
-    setStatus(msg);
+    setStepStatus(m_queue[m_currentIndex]->getStatus());
 }
 void SequentialTask::subTaskProgress(qint64 current, qint64 total)
 {
-    if(total == 0)
-    {
+    if (total == 0) {
         setProgress(0, 100);
         return;
     }
-    setProgress(current, total);
+    setProgress(m_currentIndex, m_queue.count());
+
+    m_stepProgress = current;
+    m_stepTotalProgress = total;
 }

--- a/launcher/tasks/SequentialTask.h
+++ b/launcher/tasks/SequentialTask.h
@@ -9,13 +9,21 @@ class SequentialTask : public Task
 {
     Q_OBJECT
 public:
-    explicit SequentialTask(QObject *parent = 0);
-    virtual ~SequentialTask() {};
+    explicit SequentialTask(QObject *parent = nullptr, const QString& task_name = "");
+    virtual ~SequentialTask();
+
+    inline auto isMultiStep() const -> bool override { return m_queue.size() > 1; };
+    auto getStepProgress() const -> qint64 override;
+    auto getStepTotalProgress() const -> qint64 override;
+
+    inline auto getStepStatus() const -> QString override { return m_step_status; }
 
     void addTask(Task::Ptr task);
 
-protected:
-    void executeTask();
+protected slots:
+    void executeTask() override;
+public slots:
+    bool abort() override;
 
 private
 slots:
@@ -24,7 +32,19 @@ slots:
     void subTaskStatus(const QString &msg);
     void subTaskProgress(qint64 current, qint64 total);
 
+signals:
+    void stepStatus(QString status);
+
 private:
+    void setStepStatus(QString status) { m_step_status = status; };
+
+private:
+    QString m_name;
+    QString m_step_status;
+
     QQueue<Task::Ptr > m_queue;
     int m_currentIndex;
+
+    qint64 m_stepProgress = 0;
+    qint64 m_stepTotalProgress = 100;
 };

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -81,6 +81,12 @@ int ProgressDialog::execWithTask(Task *task)
     connect(task, SIGNAL(status(QString)), SLOT(changeStatus(const QString &)));
     connect(task, SIGNAL(progress(qint64, qint64)), SLOT(changeProgress(qint64, qint64)));
 
+    m_is_multi_step = task->isMultiStep();
+    if(!m_is_multi_step){
+        ui->globalStatusLabel->setHidden(true);
+        ui->globalProgressBar->setHidden(true);
+    }
+
     // if this didn't connect to an already running task, invoke start
     if(!task->isRunning())
     {
@@ -152,14 +158,24 @@ void ProgressDialog::onTaskSucceeded()
 
 void ProgressDialog::changeStatus(const QString &status)
 {
-    ui->statusLabel->setText(status);
+    ui->statusLabel->setText(task->getStepStatus());
+    ui->globalStatusLabel->setText(status);
     updateSize();
 }
 
 void ProgressDialog::changeProgress(qint64 current, qint64 total)
 {
-    ui->taskProgressBar->setMaximum(total);
-    ui->taskProgressBar->setValue(current);
+    ui->globalProgressBar->setMaximum(total);
+    ui->globalProgressBar->setValue(current);
+
+    if(!m_is_multi_step){
+        ui->taskProgressBar->setMaximum(total);
+        ui->taskProgressBar->setValue(current);
+    }
+    else{
+        ui->taskProgressBar->setMaximum(task->getStepProgress());
+        ui->taskProgressBar->setValue(task->getStepTotalProgress());
+    }
 }
 
 void ProgressDialog::keyPressEvent(QKeyEvent *e)

--- a/launcher/ui/dialogs/ProgressDialog.h
+++ b/launcher/ui/dialogs/ProgressDialog.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 class Task;
+class SequentialTask;
 
 namespace Ui
 {
@@ -35,7 +36,7 @@ public:
 
     void updateSize();
 
-    int execWithTask(Task *task);
+    int execWithTask(Task* task);
     int execWithTask(std::unique_ptr<Task> &&task);
     int execWithTask(std::unique_ptr<Task> &task);
 
@@ -68,4 +69,6 @@ private:
     Ui::ProgressDialog *ui;
 
     Task *task;
+
+    bool m_is_multi_step = false;
 };

--- a/launcher/ui/dialogs/ProgressDialog.ui
+++ b/launcher/ui/dialogs/ProgressDialog.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>ProgressDialog</class>
  <widget class="QDialog" name="ProgressDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>100</height>
-   </rect>
-  </property>
   <property name="minimumSize">
    <size>
     <width>400</width>
@@ -26,27 +18,7 @@
    <string>Please wait...</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="statusLabel">
-     <property name="text">
-      <string>Task Status...</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QProgressBar" name="taskProgressBar">
-     <property name="value">
-      <number>24</number>
-     </property>
-     <property name="textVisible">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
+   <item row="4" column="0">
     <widget class="QPushButton" name="skipButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -56,6 +28,43 @@
      </property>
      <property name="text">
       <string>Skip</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="globalStatusLabel">
+     <property name="text">
+      <string>Global Task Status...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="statusLabel">
+     <property name="text">
+      <string>Task Status...</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QProgressBar" name="taskProgressBar">
+     <property name="value">
+      <number>24</number>
+     </property>
+     <property name="textVisible">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QProgressBar" name="globalProgressBar">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="value">
+      <number>24</number>
      </property>
     </widget>
    </item>

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -58,6 +58,7 @@
 
 #include "Version.h"
 #include "ui/dialogs/ProgressDialog.h"
+#include "tasks/SequentialTask.h"
 
 namespace {
     // FIXME: wasteful
@@ -394,25 +395,25 @@ void ModFolderPage::on_actionInstall_mods_triggered()
         return;
     }
     ModDownloadDialog mdownload(m_mods, this, m_inst);
-    if(mdownload.exec()) {
-        for(auto task : mdownload.getTasks()){
-            connect(task, &Task::failed, [this, task](QString reason) {
-                task->deleteLater();
-                CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
-            });
-            connect(task, &Task::succeeded, [this, task]() {
-                QStringList warnings = task->warnings();
-                if (warnings.count()) {
-                    CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'),
-                                                 QMessageBox::Warning)->show();
-                }
-                task->deleteLater();
-            });
-            ProgressDialog loadDialog(this);
-            loadDialog.setSkipButton(true, tr("Abort"));
-            loadDialog.execWithTask(task);
-            m_mods->update();
+    if (mdownload.exec()) {
+        SequentialTask* tasks = new SequentialTask(this);
+        connect(tasks, &Task::failed, [this, tasks](QString reason) {
+            CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
+            tasks->deleteLater();
+        });
+        connect(tasks, &Task::succeeded, [this, tasks]() {
+            QStringList warnings = tasks->warnings();
+            if (warnings.count()) { CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show(); }
+            tasks->deleteLater();
+        });
+
+        for (auto task : mdownload.getTasks()) {
+            tasks->addTask(task);
         }
+        ProgressDialog loadDialog(this);
+        loadDialog.setSkipButton(true, tr("Abort"));
+        loadDialog.execWithTask(tasks);
+        m_mods->update();
     }
 }
 


### PR DESCRIPTION
Should close #376.

This puts all mod downloading tasks inside a SequentialTask, which is, for more than one task, a multi step task. This is handled by the ProgressDialog by showing both the global progress of tasks executed, and the individual progress of each of them.

I figured showing the percentage of total tasks done would be nice, and computing it based on done tasks rather than done + ongoing tasks would be better. If you disagree, tell me why!

Note: When there's only a single task (e.g. downloading a single mod), the previous progress dialog is shown.

Example of the new dialog:
![new dialog image](https://user-images.githubusercontent.com/9145768/161263736-f69d68d8-7007-4815-b4ea-f465a9ac00aa.png)
