### PR TITLE
Check for empty slug before setting pack url

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -12,7 +12,13 @@ void Modrinth::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 {
     pack.addonId = Json::requireString(obj, "project_id");
     pack.name = Json::requireString(obj, "title");
-    pack.websiteUrl = "https://modrinth.com/mod/" + Json::ensureString(obj, "slug", "");
+    
+    QString slug = Json::ensureString(obj, "slug", "");
+    if (!slug.isEmpty())
+        pack.websiteUrl = "https://modrinth.com/mod/" + Json::ensureString(obj, "slug", "");
+    else
+        pack.websiteUrl = "";
+
     pack.description = Json::ensureString(obj, "description", "");
 
     pack.logoUrl = Json::requireString(obj, "icon_url");


### PR DESCRIPTION
Check if a slug exists (is not returned empty) before composing a url (which will be invalid if the slug is blank)