### PR TITLE
Add option to install mod loader during instance creation

### DIFF
--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -9,6 +9,15 @@
 InstanceCreationTask::InstanceCreationTask(BaseVersionPtr version)
 {
     m_version = version;
+    m_usingLoader = false;
+}
+
+InstanceCreationTask::InstanceCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loaderVersion)
+{
+    m_version = version;
+    m_usingLoader = true;
+    m_loader = loader;
+    m_loaderVersion = loaderVersion;
 }
 
 void InstanceCreationTask::executeTask()
@@ -21,6 +30,8 @@ void InstanceCreationTask::executeTask()
         auto components = inst.getPackProfile();
         components->buildingFromScratch();
         components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
+        if(m_usingLoader)
+            components->setComponentVersion(m_loader, m_loaderVersion->descriptor(), true);
         inst.setName(m_instName);
         inst.setIconKey(m_instIcon);
         instanceSettings->resumeSave();

--- a/launcher/InstanceCreationTask.h
+++ b/launcher/InstanceCreationTask.h
@@ -12,6 +12,7 @@ class InstanceCreationTask : public InstanceTask
     Q_OBJECT
 public:
     explicit InstanceCreationTask(BaseVersionPtr version);
+    explicit InstanceCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loaderVersion);
 
 protected:
     //! Entry point for tasks.
@@ -19,4 +20,7 @@ protected:
 
 private: /* data */
     BaseVersionPtr m_version;
+    bool m_usingLoader;
+    QString m_loader;
+    BaseVersionPtr m_loaderVersion;
 };

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -61,7 +61,10 @@ VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     connect(ui->refreshBtn, &QPushButton::clicked, this, &VanillaPage::refresh);
 
     connect(ui->loaderVersionList, &VersionSelectWidget::selectedVersionChanged, this, &VanillaPage::setSelectedLoaderVersion);
-    connect(ui->loaderBtnGroup, &QButtonGroup::idToggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->noneFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->forgeFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->fabricFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->liteLoaderFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->loaderRefreshBtn, &QPushButton::clicked, this, &VanillaPage::loaderRefresh);
 
 }

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -121,6 +121,7 @@ void VanillaPage::loaderFilterChanged()
         ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // empty list
         // TODO: The below message does not show when the add instance window is first opened. This should be fixed.
         ui->loaderVersionList->setEmptyString(tr("No mod loader is selected."));
+        ui->loaderVersionList->setEmptyMode(VersionListView::String);
         return;
     }
     else if(ui->forgeFilter->isChecked())

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -59,6 +59,11 @@ VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     connect(ui->releaseFilter, &QCheckBox::stateChanged, this, &VanillaPage::filterChanged);
     connect(ui->experimentsFilter, &QCheckBox::stateChanged, this, &VanillaPage::filterChanged);
     connect(ui->refreshBtn, &QPushButton::clicked, this, &VanillaPage::refresh);
+
+    connect(ui->loaderVersionList, &VersionSelectWidget::selectedVersionChanged, this, &VanillaPage::setSelectedLoaderVersion);
+    connect(ui->loaderBtnGroup, &QButtonGroup::idToggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->loaderRefreshBtn, &QPushButton::clicked, this, &VanillaPage::loaderRefresh);
+
 }
 
 void VanillaPage::openedImpl()
@@ -80,6 +85,13 @@ void VanillaPage::refresh()
     ui->versionList->loadList();
 }
 
+void VanillaPage::loaderRefresh()
+{
+    if(ui->noneFilter->isChecked())
+        return;
+    ui->loaderVersionList->loadList();
+}
+
 void VanillaPage::filterChanged()
 {
     QStringList out;
@@ -97,6 +109,38 @@ void VanillaPage::filterChanged()
         out << "(experiment)";
     auto regexp = out.join('|');
     ui->versionList->setFilter(BaseVersionList::TypeRole, new RegexpFilter(regexp, false));
+}
+
+void VanillaPage::loaderFilterChanged()
+{
+    if(ui->noneFilter->isChecked())
+    {
+        ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // empty list
+        // TODO: The below message does not show when the add instance window is first opened. This should be fixed.
+        ui->loaderVersionList->setEmptyString(tr("No mod loader is selected."));
+        return;
+    }
+    else if(ui->forgeFilter->isChecked())
+    {
+        ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, m_selectedVersion->descriptor());
+        m_selectedLoader = "net.minecraftforge";
+    }
+    else if(ui->fabricFilter->isChecked())
+    {
+        ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "");
+        m_selectedLoader = "net.fabricmc.fabric-loader";
+    }
+    else if(ui->liteLoaderFilter->isChecked())
+    {
+        ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, m_selectedVersion->descriptor());
+        m_selectedLoader = "com.mumfrey.liteloader";
+    }
+
+    auto vlist = APPLICATION->metadataIndex()->get(m_selectedLoader);
+    ui->loaderVersionList->initialize(vlist.get());
+    ui->loaderVersionList->selectRecommended();
+    suggestCurrent();
+    ui->loaderVersionList->setEmptyString(tr("No versions are currently available for Minecraft %1").arg(m_selectedVersion->descriptor()));
 }
 
 VanillaPage::~VanillaPage()
@@ -119,6 +163,16 @@ BaseVersionPtr VanillaPage::selectedVersion() const
     return m_selectedVersion;
 }
 
+BaseVersionPtr VanillaPage::selectedLoaderVersion() const
+{
+    return m_selectedLoaderVersion;
+}
+
+QString VanillaPage::selectedLoader() const
+{
+    return m_selectedLoader;
+}
+
 void VanillaPage::suggestCurrent()
 {
     if (!isOpened)
@@ -132,12 +186,27 @@ void VanillaPage::suggestCurrent()
         return;
     }
 
-    dialog->setSuggestedPack(m_selectedVersion->descriptor(), new InstanceCreationTask(m_selectedVersion));
+    // List is empty if either no mod loader is selected, or no versions are available
+    if(!ui->loaderVersionList->hasVersions())
+        dialog->setSuggestedPack(m_selectedVersion->descriptor(), new InstanceCreationTask(m_selectedVersion));
+    else
+    {
+        dialog->setSuggestedPack(m_selectedVersion->descriptor(),
+                                 new InstanceCreationTask(m_selectedVersion, m_selectedLoader,
+                                                          m_selectedLoaderVersion));
+    }
     dialog->setSuggestedIcon("default");
 }
 
 void VanillaPage::setSelectedVersion(BaseVersionPtr version)
 {
     m_selectedVersion = version;
+    suggestCurrent();
+    loaderFilterChanged();
+}
+
+void VanillaPage::setSelectedLoaderVersion(BaseVersionPtr version)
+{
+    m_selectedLoaderVersion = version;
     suggestCurrent();
 }

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -65,6 +65,7 @@ VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     connect(ui->noneFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->forgeFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->fabricFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
+    connect(ui->quiltFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->liteLoaderFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->loaderRefreshBtn, &QPushButton::clicked, this, &VanillaPage::loaderRefresh);
 
@@ -133,11 +134,20 @@ void VanillaPage::loaderFilterChanged()
     else if(ui->fabricFilter->isChecked())
     {
         // FIXME: dirty hack because the launcher is unaware of Fabric's dependencies
-        if (Version(minecraftVersion) >= Version("1.14")) // Fabric supported
+        if (Version(minecraftVersion) >= Version("1.14")) // Fabric/Quilt supported
             ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "");
-        else // Fabric unsupported
+        else // Fabric/Quilt unsupported
             ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // clear list
         m_selectedLoader = "net.fabricmc.fabric-loader";
+    }
+    else if(ui->quiltFilter->isChecked())
+    {
+        // FIXME: dirty hack because the launcher is unaware of Quilt's dependencies (same as Fabric)
+        if (Version(minecraftVersion) >= Version("1.14")) // Fabric/Quilt supported
+            ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "");
+        else // Fabric/Quilt unsupported
+            ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // clear list
+        m_selectedLoader = "org.quiltmc.quilt-loader";
     }
     else if(ui->liteLoaderFilter->isChecked())
     {

--- a/launcher/ui/pages/modplatform/VanillaPage.h
+++ b/launcher/ui/pages/modplatform/VanillaPage.h
@@ -77,15 +77,20 @@ public:
     void openedImpl() override;
 
     BaseVersionPtr selectedVersion() const;
+    BaseVersionPtr selectedLoaderVersion() const;
+    QString selectedLoader() const;
 
 public slots:
     void setSelectedVersion(BaseVersionPtr version);
+    void setSelectedLoaderVersion(BaseVersionPtr version);
 
 private slots:
     void filterChanged();
+    void loaderFilterChanged();
 
 private:
     void refresh();
+    void loaderRefresh();
     void suggestCurrent();
 
 private:
@@ -94,4 +99,6 @@ private:
     Ui::VanillaPage *ui = nullptr;
     bool m_versionSetByUser = false;
     BaseVersionPtr m_selectedVersion;
+    BaseVersionPtr m_selectedLoaderVersion;
+    QString m_selectedLoader;
 };

--- a/launcher/ui/pages/modplatform/VanillaPage.ui
+++ b/launcher/ui/pages/modplatform/VanillaPage.ui
@@ -215,6 +215,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QRadioButton" name="quiltFilter">
+             <property name="text">
+              <string>Quilt</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loaderBtnGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
             <widget class="QRadioButton" name="liteLoaderFilter">
              <property name="text">
               <string>LiteLoader</string>

--- a/launcher/ui/pages/modplatform/VanillaPage.ui
+++ b/launcher/ui/pages/modplatform/VanillaPage.ui
@@ -33,112 +33,220 @@
        <string notr="true"/>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="1">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Filter</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="releaseFilter">
-           <property name="text">
-            <string>Releases</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="snapshotFilter">
-           <property name="text">
-            <string>Snapshots</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="oldSnapshotFilter">
-           <property name="text">
-            <string>Old Snapshots</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="betaFilter">
-           <property name="text">
-            <string>Betas</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="alphaFilter">
-           <property name="text">
-            <string>Alphas</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="experimentsFilter">
-           <property name="text">
-            <string>Experiments</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="refreshBtn">
-           <property name="text">
-            <string>Refresh</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="0" column="0">
-        <widget class="VersionSelectWidget" name="versionList" native="true">
+       <item row="2" column="0">
+        <widget class="Line" name="line">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
         </widget>
+       </item>
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="minecraftLayout">
+         <item>
+          <widget class="VersionSelectWidget" name="versionList" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Filter</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="releaseFilter">
+             <property name="text">
+              <string>Releases</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="snapshotFilter">
+             <property name="text">
+              <string>Snapshots</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="oldSnapshotFilter">
+             <property name="text">
+              <string>Old Snapshots</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="betaFilter">
+             <property name="text">
+              <string>Betas</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="alphaFilter">
+             <property name="text">
+              <string>Alphas</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="experimentsFilter">
+             <property name="text">
+              <string>Experiments</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="refreshBtn">
+             <property name="text">
+              <string>Refresh</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item row="4" column="0">
+        <layout class="QHBoxLayout" name="loaderLayout">
+         <item>
+          <widget class="VersionSelectWidget" name="loaderVersionList" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QLabel" name="loaderLabel">
+             <property name="text">
+              <string>Mod Loader</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="noneFilter">
+             <property name="text">
+              <string>None</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loaderBtnGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="forgeFilter">
+             <property name="text">
+              <string>Forge</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loaderBtnGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="fabricFilter">
+             <property name="text">
+              <string>Fabric</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loaderBtnGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="liteLoaderFilter">
+             <property name="text">
+              <string>LiteLoader</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loaderBtnGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="loaderRefreshBtn">
+             <property name="text">
+              <string>Refresh</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -166,4 +274,7 @@
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="loaderBtnGroup"/>
+ </buttongroups>
 </ui>

--- a/launcher/ui/widgets/VersionSelectWidget.cpp
+++ b/launcher/ui/widgets/VersionSelectWidget.cpp
@@ -4,7 +4,6 @@
 #include <QVBoxLayout>
 #include <QHeaderView>
 
-#include "VersionListView.h"
 #include "VersionProxyModel.h"
 
 #include "ui/dialogs/CustomMessageBox.h"
@@ -55,6 +54,11 @@ void VersionSelectWidget::setEmptyString(QString emptyString)
 void VersionSelectWidget::setEmptyErrorString(QString emptyErrorString)
 {
     listView->setEmptyErrorString(emptyErrorString);
+}
+
+void VersionSelectWidget::setEmptyMode(VersionListView::EmptyMode mode)
+{
+    listView->setEmptyMode(mode);
 }
 
 VersionSelectWidget::~VersionSelectWidget()

--- a/launcher/ui/widgets/VersionSelectWidget.h
+++ b/launcher/ui/widgets/VersionSelectWidget.h
@@ -18,6 +18,7 @@
 #include <QWidget>
 #include <QSortFilterProxyModel>
 #include "BaseVersionList.h"
+#include "VersionListView.h"
 
 class VersionProxyModel;
 class VersionListView;
@@ -49,6 +50,7 @@ public:
     void setFilter(BaseVersionList::ModelRoles role, Filter *filter);
     void setEmptyString(QString emptyString);
     void setEmptyErrorString(QString emptyErrorString);
+    void setEmptyMode(VersionListView::EmptyMode mode);
     void setResizeOn(int column);
 
 signals:


### PR DESCRIPTION
This adds an option to install Forge, Fabric, or LiteLoader while creating a new instance. Closes #137.

What I currently have is below:

https://user-images.githubusercontent.com/79120643/161649230-25a5d72b-a86b-434c-a3e7-c461544edc25.mov

The UI may need a second look.

- Should the mod loader selection UI be visible in the "Vanilla" tab, or should a new tab be made for this?
- If this functionality stays in the "Vanilla" tab, should the tab's name be changed?
- Should the mod loader list be more like the experience while installing a mod loader on a preexisting instance? In that case, [a new dialog opens over the window](https://user-images.githubusercontent.com/79120643/161650317-170000ab-617e-4219-a73d-98f24d63e044.png), showing a list of mod loader versions. In comparison, my solution shows them side-by-side in the same window.
- ~I tried to get a message to show at the bottom when the new instance window first opens to tell the user that no mod loader is selected, but wasn't able to get it to work. The message only shows when selecting a mod loader and then selecting "None" again. I'm not sure why.~ Fixed in 44bdd7f