### PR TITLE
Increase Mod Downloader's initial size

### DIFF
--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -11,6 +11,7 @@
 #include <QPushButton>
 #include <QValidator>
 #include <QDialogButtonBox>
+#include <QDesktopWidget>
 
 #include "ui/widgets/PageContainer.h"
 #include "ui/pages/modplatform/modrinth/ModrinthPage.h"
@@ -22,7 +23,12 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods
     : QDialog(parent), mods(mods), m_instance(instance)
 {
     setObjectName(QStringLiteral("ModDownloadDialog"));
-    resize(400, 347);
+
+    QRect screenDimentions = QApplication::desktop()->screenGeometry();
+    int screenWidth = screenDimentions.width();
+    int screenHeight = screenDimentions.height();
+
+    resize(screenWidth / 2, screenHeight / 2);
     m_verticalLayout = new QVBoxLayout(this);
     m_verticalLayout->setObjectName(QStringLiteral("verticalLayout"));
 


### PR DESCRIPTION
This sets its width and height to 50% screen width and height.

Not sure if this is the best way to do it though. Suggestions welcome!

Closes #404 

EDIT: Looks like this
![2022-04-07_09-40](https://user-images.githubusercontent.com/768728/162118533-166fe344-f3c6-474b-8d42-0c080111a411.png)