### PR TITLE
Fix some issues with Tasks and add unit test

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -413,6 +413,11 @@ set(TASKS_SOURCES
     tasks/SequentialTask.cpp
 )
 
+add_unit_test(Task
+    SOURCES tasks/Task_test.cpp
+    LIBS Launcher_logic
+    )
+
 set(SETTINGS_SOURCES
     # Settings
     settings/INIFile.cpp

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -40,6 +40,14 @@ InstanceImportTask::InstanceImportTask(const QUrl sourceUrl)
     m_sourceUrl = sourceUrl;
 }
 
+bool InstanceImportTask::abort()
+{
+    m_filesNetJob->abort();
+    m_extractFuture.cancel();
+
+    return false;
+}
+
 void InstanceImportTask::executeTask()
 {
     if (m_sourceUrl.isLocalFile())

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -37,6 +37,9 @@ class InstanceImportTask : public InstanceTask
 public:
     explicit InstanceImportTask(const QUrl sourceUrl);
 
+    bool canAbort() const override { return true; }
+    bool abort() override;
+
 protected:
     //! Entry point for tasks.
     virtual void executeTask() override;

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -53,7 +53,7 @@ class Task : public QObject {
     virtual bool canAbort() const { return false; }
 
     QString getStatus() { return m_status; }
-    virtual auto getStepStatus() const -> QString { return {}; }
+    virtual auto getStepStatus() const -> QString { return m_status; }
 
     qint64 getProgress() { return m_progress; }
     qint64 getTotalProgress() { return m_progressTotal; }

--- a/launcher/tasks/Task_test.cpp
+++ b/launcher/tasks/Task_test.cpp
@@ -6,9 +6,22 @@
 /* Does nothing. Only used for testing. */
 class BasicTask : public Task {
     Q_OBJECT
-   public:
-    explicit BasicTask() : Task() {};
+
+    friend class TaskTest;
+
    private:
+    void executeTask() override {};   
+};
+
+/* Does nothing. Only used for testing. */
+class BasicTask_MultiStep : public Task {
+    Q_OBJECT
+
+    friend class TaskTest;
+
+   private:
+    auto isMultiStep() const -> bool override { return true; }
+
     void executeTask() override {};   
 };
 
@@ -16,13 +29,26 @@ class TaskTest : public QObject {
     Q_OBJECT
 
    private slots:
-    void test_SetStatus(){
+    void test_SetStatus_NoMultiStep(){
         BasicTask t;
         QString status {"test status"};
 
         t.setStatus(status);
 
         QCOMPARE(t.getStatus(), status);
+        QCOMPARE(t.getStepStatus(), status);
+    }
+
+    void test_SetStatus_MultiStep(){
+        BasicTask_MultiStep t;
+        QString status {"test status"};
+
+        t.setStatus(status);
+
+        QCOMPARE(t.getStatus(), status);
+        // Even though it is multi step, it does not override the getStepStatus method,
+        // so it should remain the same.
+        QCOMPARE(t.getStepStatus(), status);
     }
 
     void test_SetProgress(){

--- a/launcher/tasks/Task_test.cpp
+++ b/launcher/tasks/Task_test.cpp
@@ -1,0 +1,42 @@
+#include <QTest>
+#include "TestUtil.h"
+
+#include "Task.h"
+
+/* Does nothing. Only used for testing. */
+class BasicTask : public Task {
+    Q_OBJECT
+   public:
+    explicit BasicTask() : Task() {};
+   private:
+    void executeTask() override {};   
+};
+
+class TaskTest : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void test_SetStatus(){
+        BasicTask t;
+        QString status {"test status"};
+
+        t.setStatus(status);
+
+        QCOMPARE(t.getStatus(), status);
+    }
+
+    void test_SetProgress(){
+        BasicTask t;
+        int current = 42;
+        int total = 207;
+
+        t.setProgress(current, total);
+
+        QCOMPARE(t.getProgress(), current);
+        QCOMPARE(t.getTotalProgress(), total);
+    }
+};
+
+QTEST_GUILESS_MAIN(TaskTest)
+
+#include "Task_test.moc"


### PR DESCRIPTION
This fixes two issues related to Tasks:
1. Non-sequential tasks did not have their status shown after #380 (sorry ;----;)
2. CurseForge modpacks could not be aborted because they didn't override the methods for that. That's not directly related to Tasks itself, but I found it while fixing the first issue, so I just did this as well. 

This also adds two basic unit tests for Task, so that it's harder for the first mistake to occur again!