### PR TITLE
Install manpage on Linux system builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ elseif(UNIX)
         set(LAUNCHER_DESKTOP_DEST_DIR "share/applications" CACHE STRING "Path to the desktop file directory")
         set(LAUNCHER_METAINFO_DEST_DIR "share/metainfo" CACHE STRING "Path to the metainfo directory")
         set(LAUNCHER_ICON_DEST_DIR "share/icons/hicolor/scalable/apps" CACHE STRING "Path to the scalable icon directory")
+        set(LAUNCHER_MAN_DEST_DIR "share/man/man6" CACHE STRING "Path to the man page directory")
 
         # jars path is determined on runtime, relative to "Application root path", generally /usr for Launcher_PORTABLE=0
         set(Launcher_APP_BINARY_DEFS "-DLAUNCHER_JARS_LOCATION=${JARS_DEST_DIR}")
@@ -211,6 +212,7 @@ elseif(UNIX)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_Desktop} DESTINATION ${LAUNCHER_DESKTOP_DEST_DIR})
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${LAUNCHER_METAINFO_DEST_DIR})
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_SVG} DESTINATION ${LAUNCHER_ICON_DEST_DIR})
+        install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_ManPage} DESTINATION ${LAUNCHER_MAN_DEST_DIR} RENAME "${Launcher_APP_BINARY_NAME}.6")
     endif()
 
     # install as bundle with no dependencies included

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -11,6 +11,7 @@ set(Launcher_DesktopFileName "org.polymc.PolyMC.desktop" PARENT_SCOPE)
 
 set(Launcher_Desktop "program_info/org.polymc.PolyMC.desktop" PARENT_SCOPE)
 set(Launcher_MetaInfo "program_info/org.polymc.PolyMC.metainfo.xml" PARENT_SCOPE)
+set(Launcher_ManPage "program_info/polymc.6.txt" PARENT_SCOPE)
 set(Launcher_SVG "program_info/org.polymc.PolyMC.svg" PARENT_SCOPE)
 set(Launcher_Branding_ICNS "program_info/polymc.icns" PARENT_SCOPE)
 set(Launcher_Branding_WindowsRC "program_info/polymc.rc" PARENT_SCOPE)

--- a/program_info/polymc.6.txt
+++ b/program_info/polymc.6.txt
@@ -59,8 +59,6 @@ Main website: <https://polymc.org>
 
 AUTHORS
 -------
-peterix <peterix@gmail.com>
-
-swurl <swurl@swurl.xyz>
+PolyMC Contributors
 
 // vim: syntax=asciidoc


### PR DESCRIPTION
Closes #415 

Install our manpage to `<prefix>/share/man/man1/<launcher-name>.1`. This should be `/usr/share/man/man1/polymc.1` for most installations.