### PR TITLE
better FreeBSD support

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -213,7 +213,7 @@ QString MinecraftInstance::binRoot() const
 
 QString MinecraftInstance::getNativePath() const
 {
-#if defined(Q_OS_FREEBSD)
+#if defined(Os_FreeBSD)
     QDir natives_dir("/usr/local/lib/lwjgl/");
 #else
     QDir natives_dir(FS::PathCombine(instanceRoot(), "natives/"));

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -213,7 +213,7 @@ QString MinecraftInstance::binRoot() const
 
 QString MinecraftInstance::getNativePath() const
 {
-#if defined(Os_FreeBSD)
+#ifdef Q_OS_FREEBSD
     QDir natives_dir("/usr/local/lib/lwjgl/");
 #else
     QDir natives_dir(FS::PathCombine(instanceRoot(), "natives/"));

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -213,8 +213,12 @@ QString MinecraftInstance::binRoot() const
 
 QString MinecraftInstance::getNativePath() const
 {
+#if defined(Q_OS_FREEBSD)
+    QDir natives_dir("/usr/local/lib/lwjgl/");
+#else
     QDir natives_dir(FS::PathCombine(instanceRoot(), "natives/"));
     return natives_dir.absolutePath();
+#endif
 }
 
 QString MinecraftInstance::getLocalLibraryPath() const


### PR DESCRIPTION
Due to Microsoft not shipping LWJGL libraries and natives for FreeBSD, the user needs to install LWJGL himself over the ports on FreeBSD, this PR makes if FreeBSD is found to use the native system libraries to make it possible playing MC under FreeBSD, it's not the cleanest fix but enough for now.