### PR TITLE
CHANGE: switch the help pages to their own dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
 ######## Set URLs ########
 set(Launcher_NEWS_RSS_URL "https://polymc.org/feed/feed.xml" CACHE STRING "URL to fetch PolyMC's news RSS feed from.")
 set(Launcher_NEWS_OPEN_URL "https://polymc.org/news" CACHE STRING "URL that gets opened when the user clicks 'More News'")
-set(Launcher_HELP_URL "https://polymc.org/wiki/%1" CACHE STRING "URL (with arg %1 to be substituted with page-id) that gets opened when the user requests help")
+set(Launcher_HELP_URL "https://polymc.org/wiki/help-pages/%1" CACHE STRING "URL (with arg %1 to be substituted with page-id) that gets opened when the user requests help")
 
 ######## Set version numbers ########
 set(Launcher_VERSION_MAJOR    1)

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -49,7 +49,7 @@ class FlameModPage : public ModPage {
     inline auto displayName() const -> QString override { return "CurseForge"; }
     inline auto icon() const -> QIcon override { return APPLICATION->getThemedIcon("flame"); }
     inline auto id() const -> QString override { return "curseforge"; }
-    inline auto helpPage() const -> QString override { return "Flame-platform"; }
+    inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     inline auto debugName() const -> QString override { return "Flame"; }
     inline auto metaEntryBase() const -> QString override { return "FlameMods"; };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -49,7 +49,7 @@ class ModrinthPage : public ModPage {
     inline auto displayName() const -> QString override { return "Modrinth"; }
     inline auto icon() const -> QIcon override { return APPLICATION->getThemedIcon("modrinth"); }
     inline auto id() const -> QString override { return "modrinth"; }
-    inline auto helpPage() const -> QString override { return "Modrinth-platform"; }
+    inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     inline auto debugName() const -> QString override { return "Modrinth"; }
     inline auto metaEntryBase() const -> QString override { return "ModrinthPacks"; };


### PR DESCRIPTION
also renames modrinth-platform/curseforge-platform to just Mod-platform since they have the pages are basically the same.

CC: @ZekeSmith this was made to avoid the fact that the wiki with the help pages in the current way is confusing, when this get merged you need to move them to a help-pages dir in the wiki