### PR TITLE
Query for Fabric mods if Quilt is in use

### DIFF
--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -23,7 +23,7 @@ class FlameAPI : public NetworkModAPI {
             .arg(args.offset)
             .arg(args.search)
             .arg(args.sorting)
-            .arg(args.mod_loader)
+            .arg(getMappedModLoader(args.mod_loader))
             .arg(gameVersionStr);
     };
 
@@ -31,4 +31,13 @@ class FlameAPI : public NetworkModAPI {
     {
         return QString("https://addons-ecs.forgesvc.net/api/v2/addon/%1/files").arg(args.addonId);
     };
+
+   public:
+    static auto getMappedModLoader(const ModLoaderType type) -> const ModLoaderType
+    {
+        // TODO: remove this once Quilt drops official Fabric support
+        if (type == Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
+            return Fabric;
+        return type;
+    }
 };

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -3,6 +3,7 @@
 #include "Json.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
+#include "modplatform/flame/FlameAPI.h"
 #include "net/NetJob.h"
 
 void FlameMod::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
@@ -43,8 +44,9 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                                        BaseInstance* inst)
 {
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
-    bool hasFabric = !(dynamic_cast<MinecraftInstance*>(inst))->getPackProfile()->getComponentVersion("net.fabricmc.fabric-loader").isEmpty();
-    QString mcVersion = (dynamic_cast<MinecraftInstance*>(inst))->getPackProfile()->getComponentVersion("net.minecraft");
+    auto profile = (dynamic_cast<MinecraftInstance*>(inst))->getPackProfile();
+    bool hasFabric = FlameAPI::getMappedModLoader(profile->getModLoader()) == ModAPI::Fabric;
+    QString mcVersion = profile->getComponentVersion("net.minecraft");
 
     for (auto versionIter : arr) {
         auto obj = versionIter.toObject();

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -54,6 +54,9 @@ class ModrinthAPI : public NetworkModAPI {
     {
         if (type == Unspecified)
             return "fabric, forge, quilt";
+        // TODO: remove this once Quilt drops official Fabric support
+        if (type == Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
+            return "fabric, quilt";
         return ModAPI::getModLoaderString(type);
     }
 


### PR DESCRIPTION
Right now we want to include Fabric mods in our searches where possible.
Modrinth allows definining multiple loaders, while Flame only allows a
single value.

As a compromise we ask for Fabric mods only on Flame and for both Fabric
and Quilt mods on Modrinth.

