### PR TITLE
Improve security by enabling hardened runtime for macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Configure CMake (Linux)
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -G Ninja 
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -G Ninja
 
       ##
       # BUILD
@@ -143,6 +143,7 @@ jobs:
 
           cd ${{ env.INSTALL_DIR }}
           chmod +x "PolyMC.app/Contents/MacOS/polymc"
+          sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "PolyMC.app/Contents/MacOS/polymc"
           tar -czf ../PolyMC.tar.gz *
 
       - name: Package (Windows)

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>A Minecraft mod wants to access your camera.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>A Minecraft mod wants to access your microphone.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/program_info/App.entitlements
+++ b/program_info/App.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Enable the [hardened runtime](https://developer.apple.com/documentation/security/hardened_runtime?language=objc) for PolyMC on macOS. This protects against certain types of exploits. Other platforms are unaffected.

Also fixes a bug where Minecraft mods that request access to the microphone or camera would silently fail on recent versions of macOS. Add a string that explains that a Minecraft mod, not PolyMC, wants to access these resources.

---

To enable the hardened runtime, the app is now code-signed. A simple ad-hoc signature is enough (`--sign -`), and does not cost anything. This does not get past Gatekeeper (users will still get warnings when they open the app, as if it was not signed at all).

---

Some entitlements (exceptions to the hardened runtime protections) are present:

* [Disable Library Validation Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-library-validation?language=objc): Without this, PolyMC crashes on startup. Since we don't really have a true signature, macOS doesn't see that the Qt frameworks and the app were signed by the same team, and thus blocks the app from loading Qt without this entitlement.
* [Audio Input](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_device_audio-input?language=objc) and [Camera](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_device_camera?language=objc): not used by PolyMC, but Minecraft mods could plausibly use these. User approval is still required.

The `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` are shown by the OS when a mod requests access. Even for people on older versions of macOS where these prompts already work, the prompt used to just say PolyMC was requesting access with no explanation, which could confuse and scare players. (One notable example of this was the Mekanism mod, which would request access to the microphone when players entered a world if the voice server was enabled, even if they did not have a Walkie-Talkie item.)

There's a [few other entitlements](https://developer.apple.com/documentation/security/hardened_runtime?language=objc#topics) available, but I don't think PolyMC, Minecraft, or any mod would (or should) ever really use them (see note below). (Maybe something like OpenComputers or ComputerCraft? I tested ComputerCraft and was able to run the `lua` command and then `exit()`, but I don't know much other than that. I'm assuming if it was an issue, that wouldn't work, so I think it's fine.) I tested Enigmatica 2: Expert, and I was able to run it and enter a world.

---

Possible (future) conflict:

One protection (Executable Memory Protection) may interfere with the [current updater system](https://github.com/PolyMC/PolyMC/tree/develop/launcher/updater) (or not, I'm just speculating). There is [an entitlement to disable this](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-executable-page-protection?language=objc) if we really want to use that updater, but it disables a lot of the protection that hardened runtime gives. This won't cause any problems now, as the updater isn't used, but it's worth considering, especially when working on #60.

> The system causes an app that attempts to directly modify sections of its own executable files on disk to forcefully exit. Use the Disable Executable Memory Protection Entitlement to enable this kind of unsafe software update. Even with this entitlement, however, updates that modify some files but not others may cause unexpected app state. Ensure that you perform updates atomically, with the final app bundle swapped out after app exit.

A bit off-topic, but when an updater is implemented, using something like the [Sparkle framework](https://sparkle-project.org/), used by most macOS developers, should work and give a more native feel. It would require quite a bit of macOS specific code, though, and probably a little bit of bridging to Objective-C. There's also a version of Sparkle for Windows, but I'm not sure about Linux.