### PR TITLE
fix: use size in bytes to sort by world size

### DIFF
--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -17,6 +17,7 @@
 
 #include "Application.h"
 #include <FileSystem.h>
+#include <Qt>
 #include <QMimeData>
 #include <QUrl>
 #include <QUuid>
@@ -190,6 +191,16 @@ QVariant WorldList::data(const QModelIndex &index, int role) const
             return QVariant();
         }
 
+    case Qt::UserRole:
+        switch (column)
+        {
+            case SizeColumn:
+                return qVariantFromValue<qlonglong>(world.bytes());
+
+            default:
+                return data(index, Qt::DisplayRole);
+        }
+
     case Qt::ToolTipRole:
     {
         return world.folderName();
@@ -216,7 +227,7 @@ QVariant WorldList::data(const QModelIndex &index, int role) const
     }
     case SizeRole:
     {
-        return locale.formattedDataSize(world.bytes());
+        return qVariantFromValue<qlonglong>(world.bytes());
     }
     case IconFileRole:
     {

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -45,6 +45,7 @@
 #include <QTreeView>
 #include <QInputDialog>
 #include <QProcess>
+#include <Qt>
 
 #include "tools/MCEditTool.h"
 #include "FileSystem.h"
@@ -92,6 +93,7 @@ WorldListPage::WorldListPage(BaseInstance *inst, std::shared_ptr<WorldList> worl
     WorldListProxyModel * proxy = new WorldListProxyModel(this);
     proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
     proxy->setSourceModel(m_worlds.get());
+    proxy->setSortRole(Qt::UserRole);
     ui->worldTreeView->setSortingEnabled(true);
     ui->worldTreeView->setModel(proxy);
     ui->worldTreeView->installEventFilter(this);


### PR DESCRIPTION
Closes #391

Based off this recommendation: https://forum.qt.io/topic/67529/how-can-i-sort-an-alphanumeric-string-in-abstract-table-view/3