### PR TITLE
Revert "better FreeBSD support"

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -213,12 +213,8 @@ QString MinecraftInstance::binRoot() const
 
 QString MinecraftInstance::getNativePath() const
 {
-#ifdef Q_OS_FREEBSD
-    QDir natives_dir("/usr/local/lib/lwjgl/");
-#else
     QDir natives_dir(FS::PathCombine(instanceRoot(), "natives/"));
     return natives_dir.absolutePath();
-#endif
 }
 
 QString MinecraftInstance::getLocalLibraryPath() const


### PR DESCRIPTION
Reverts PolyMC/PolyMC#429

This path needs to be writable by PolyMC. It is used to extract downloaded natives. If you want FreeBSD support, then this needs to be dealt with using Meta.

See https://github.com/PolyMC/PolyMC/blob/develop/launcher/minecraft/launch/ExtractNatives.cpp