### PR TITLE
Disable old snapshot filter check box

### DIFF
--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -69,6 +69,8 @@ VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     connect(ui->liteLoaderFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->loaderRefreshBtn, &QPushButton::clicked, this, &VanillaPage::loaderRefresh);
 
+    // FIXME: hotfix for issue #468
+    ui->oldSnapshotFilter->setEnabled(false);
 }
 
 void VanillaPage::openedImpl()


### PR DESCRIPTION
Hotfix for #468

Should probably figure out whether the launcher can get old snapshots from somewhere else, ~but this temporarily prevents the crash bug in case you want to include it in the next bugfix release~