### PR TITLE
Fix crash if no Minecraft version is selected in the new instance screen

### DIFF
--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -118,7 +118,18 @@ void VanillaPage::filterChanged()
 
 void VanillaPage::loaderFilterChanged()
 {
-    auto minecraftVersion = m_selectedVersion->descriptor();
+    QString minecraftVersion;
+    if (m_selectedVersion)
+    {
+        minecraftVersion = m_selectedVersion->descriptor();
+    }
+    else
+    {
+        ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // empty list
+        ui->loaderVersionList->setEmptyString(tr("No Minecraft version is selected."));
+        ui->loaderVersionList->setEmptyMode(VersionListView::String);
+        return;
+    }
     if(ui->noneFilter->isChecked())
     {
         ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // empty list


### PR DESCRIPTION
Closes #468 

Fix the root cause of the crash described in #468. `m_selectedVersion` should not be assumed to be non-null.