### PR TITLE
Hide all tokens for non-Debug builds for log and logfiles

### DIFF
--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -50,7 +50,9 @@ void LauncherLoginStep::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
+#ifndef NDEBUG
     qDebug() << data;
+#endif
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
 #ifndef NDEBUG


### PR DESCRIPTION
Now there won't be any tokens in logs.