### PR TITLE
Always build iconfix as static library

### DIFF
--- a/libraries/iconfix/CMakeLists.txt
+++ b/libraries/iconfix/CMakeLists.txt
@@ -12,7 +12,7 @@ internal/qiconloader.cpp
 internal/qiconloader_p.h
 )
 
-add_library(Launcher_iconfix ${ICONFIX_SOURCES})
+add_library(Launcher_iconfix STATIC ${ICONFIX_SOURCES})
 target_include_directories(Launcher_iconfix PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_BINARY_DIR}" )
 
 target_link_libraries(Launcher_iconfix Qt5::Core Qt5::Widgets)


### PR DESCRIPTION
On CI we build using the bundled Quazip, and automatically set `-DBUILD_STATIC_LIBS` to true, so it build iconfix statically as well.

However, since we recently added support for using the system quazip, this flag is not set anymore, and PolyMC fails to run because iconfix neither is statically linked, nor it correctly installs an .so file for dynamic linking.

Since most other libs are built statically, we should make this one static as well. Maybe we should consider allowing for dynamic linking of libs now that quazip is not much of an issue anymore. :^)