### PR TITLE
Fix Qt framework bundle structure in macOS package

### DIFF
--- a/.github/scripts/macos_fix_qt_structure.sh
+++ b/.github/scripts/macos_fix_qt_structure.sh
@@ -3,8 +3,14 @@
 # A script that fixes macOS Qt framework weirdness.
 # See https://stackoverflow.com/questions/27952111/unable-to-sign-app-bundle-using-qt-frameworks-on-os-x-10-10/28097138#28097138
 
+# Usage: ./macos_fix_qt_structure.sh path_to_app [major_qt_version]
+
 # retrieve bundle name from first parameter
 BUNDLE_NAME=$1
+
+# retrieve Qt major version from second parameter (5 by default)
+QT_MAJOR_VERSION=$2
+QT_MAJOR_VERSION="${QT_MAJOR_VERSION:-5}"
 
 # if can't change directory, then quit immediately
 cd "${BUNDLE_NAME}/Contents/Frameworks/" || return 1
@@ -14,11 +20,11 @@ for CURRENT_FRAMEWORK in Qt*; do
 
     CURRENT_FRAMEWORK_NAME="${CURRENT_FRAMEWORK%.*}"
 
-    mkdir -p "${CURRENT_FRAMEWORK}/Versions/5"
+    mkdir -p "${CURRENT_FRAMEWORK}/Versions/${QT_MAJOR_VERSION}"
 
-    mv "${CURRENT_FRAMEWORK}/Resources" "${CURRENT_FRAMEWORK}/Versions/5/Resources"
+    mv "${CURRENT_FRAMEWORK}/Resources" "${CURRENT_FRAMEWORK}/Versions/${QT_MAJOR_VERSION}/Resources"
 
-    ln -nfs "5"                                          "${CURRENT_FRAMEWORK}/Versions/Current"
+    ln -nfs "${QT_MAJOR_VERSION}"                        "${CURRENT_FRAMEWORK}/Versions/Current"
     ln -nfs "Versions/Current/${CURRENT_FRAMEWORK_NAME}" "${CURRENT_FRAMEWORK}/${CURRENT_FRAMEWORK_NAME}"
     ln -nfs "Versions/Current/Resources"                 "${CURRENT_FRAMEWORK}/Resources"
 done

--- a/.github/scripts/macos_fix_qt_structure.sh
+++ b/.github/scripts/macos_fix_qt_structure.sh
@@ -20,7 +20,10 @@ for CURRENT_FRAMEWORK in Qt*; do
 
     CURRENT_FRAMEWORK_NAME="${CURRENT_FRAMEWORK%.*}"
 
-    mkdir -p "${CURRENT_FRAMEWORK}/Versions/${QT_MAJOR_VERSION}"
+    if [ ! -d "${CURRENT_FRAMEWORK}/Versions/${QT_MAJOR_VERSION}" ]; then
+        echo "The Qt framework does not seem to contain version ${QT_MAJOR_VERSION}. Are you sure the version is correct?"
+        exit 1
+    fi
 
     mv "${CURRENT_FRAMEWORK}/Resources" "${CURRENT_FRAMEWORK}/Versions/${QT_MAJOR_VERSION}/Resources"
 

--- a/.github/scripts/macos_fix_qt_structure.sh
+++ b/.github/scripts/macos_fix_qt_structure.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# A script that fixes macOS Qt framework weirdness.
+# See https://stackoverflow.com/questions/27952111/unable-to-sign-app-bundle-using-qt-frameworks-on-os-x-10-10/28097138#28097138
+
+# retrieve bundle name from first parameter
+BUNDLE_NAME=$1
+
+# if can't change directory, then quit immediately
+cd "${BUNDLE_NAME}/Contents/Frameworks/" || return 1
+
+for CURRENT_FRAMEWORK in Qt*; do
+    echo "Processing framework: ${CURRENT_FRAMEWORK}"
+
+    CURRENT_FRAMEWORK_NAME="${CURRENT_FRAMEWORK%.*}"
+
+    mkdir -p "${CURRENT_FRAMEWORK}/Versions/5"
+
+    mv "${CURRENT_FRAMEWORK}/Resources" "${CURRENT_FRAMEWORK}/Versions/5/Resources"
+
+    ln -nfs "5"                                          "${CURRENT_FRAMEWORK}/Versions/Current"
+    ln -nfs "Versions/Current/${CURRENT_FRAMEWORK_NAME}" "${CURRENT_FRAMEWORK}/${CURRENT_FRAMEWORK_NAME}"
+    ln -nfs "Versions/Current/Resources"                 "${CURRENT_FRAMEWORK}/Resources"
+done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
 
           cd ${{ env.INSTALL_DIR }}
           chmod +x "PolyMC.app/Contents/MacOS/polymc"
+          ${{ github.workspace }}/.github/scripts/macos_fix_qt_structure.sh PolyMC.app
           sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "PolyMC.app/Contents/MacOS/polymc"
           tar -czf ../PolyMC.tar.gz *
 


### PR DESCRIPTION
### Problem

A deep verification of the current ad-hoc code signature fails:

> $ codesign -v  /Applications/PolyMC.app
> /Applications/PolyMC.app: embedded framework contains modified or invalid version
> In subcomponent: /Applications/PolyMC.app/Contents/Frameworks/QtGui.framework

For some reason, the structure of the Qt frameworks embedded in the PolyMC.app bundle are not correct. The correct general structure of a framework on macOS is described [here](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html). This causes the code signature for the embedded framework to be invalid.

Current:
```
QtCore.framework/
       Resources/
       Versions/
           5/
               QtCore
```

Expected:
```
QtCore.framework/
       QtCore    -> Versions/Current/QtCore
       Resources -> Versions/Current/Resources
       Versions/
           Current -> 5
           5/
               QtCore
               Resources/
                   Info.plist
```

This is not a very important problem at the moment. This doesn't matter on Macs using any of the official builds, because regardless of a broken signature, the ad-hoc signature won't get through Gatekeeper, so it all looks the same to the user with the same "unverified" warnings (in fact, the only difference I saw was that output in the Terminal). However, on Apple Silicon, Apple enforces a signature requirement for native ARM apps. All ARM apps must be signed (an ad-hoc signature like what was added in #454 is enough, barring this issue).

This requirement doesn't apply to Intel-based Macs nor Intel apps running on Apple Silicon. As a result, this really only matters if PolyMC decides to support Apple Silicon natively in the future. 

---

### Solution

I added a shell script for the CI to run whenever it packages for macOS before codesigning. This is kind of a hack, and it would probably be better to figure out why the format of the Qt framework is incorrect in the first place. I'm pretty sure that would involve looking at the cmake files, but I don't have much experience with that, so I'm not really sure how to look for the problem.

> PolyMC.app: valid on disk
> PolyMC.app: satisfies its Designated Requirement

---

### References

* https://stackoverflow.com/questions/27952111/unable-to-sign-app-bundle-using-qt-frameworks-on-os-x-10-10 (the script is derived from the one in this answer)
* https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes (codesign required on Apple Silicon)

