### PR TITLE
Remove old macOS data migration code

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -409,69 +409,6 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         return;
     }
 
-#if defined(Q_OS_MAC)
-    // move user data to new location if on macOS and it still exists in Contents/MacOS
-    QDir fi(applicationDirPath());
-    QString originalData = fi.absolutePath();
-    // if the config file exists in Contents/MacOS, then user data is still there and needs to moved
-    if (QFileInfo::exists(FS::PathCombine(originalData, BuildConfig.LAUNCHER_CONFIGFILE)))
-    {
-        if (!QFileInfo::exists(FS::PathCombine(originalData, "dontmovemacdata")))
-        {
-            QMessageBox::StandardButton askMoveDialogue;
-            askMoveDialogue = QMessageBox::question(
-                nullptr,
-                BuildConfig.LAUNCHER_DISPLAYNAME,
-                "Would you like to move application data to a new data location? It will improve the launcher's performance, but if you switch to older versions it will look like instances have disappeared. If you select no, you can migrate later in settings. You should select yes unless you're commonly switching between different versions (eg. develop and stable).",
-                QMessageBox::Yes | QMessageBox::No,
-                QMessageBox::Yes
-            );
-            if (askMoveDialogue == QMessageBox::Yes)
-            {
-                qDebug() << "On macOS and found config file in old location, moving user data...";
-                QDir dir;
-                QStringList dataFiles {
-                    "*.log", // Launcher log files: ${Launcher_Name}-@.log
-                    "accounts.json",
-                    "accounts",
-                    "assets",
-                    "cache",
-                    "icons",
-                    "instances",
-                    "libraries",
-                    "meta",
-                    "metacache",
-                    "mods",
-                    BuildConfig.LAUNCHER_CONFIGFILE,
-                    "themes",
-                    "translations"
-                };
-                QDirIterator files(originalData, dataFiles);
-                while (files.hasNext()) {
-                    QString filePath(files.next());
-                    QString fileName(files.fileName());
-                    if (!dir.rename(filePath, FS::PathCombine(dataPath, fileName)))
-                    {
-                        qWarning() << "Failed to move " << fileName;
-                    }
-                }
-            }
-            else
-            {
-                dataPath = originalData;
-                QDir::setCurrent(dataPath);
-                QFile file(originalData + "/dontmovemacdata");
-                file.open(QIODevice::WriteOnly);
-            }
-        }
-        else
-        {
-            dataPath = originalData;
-            QDir::setCurrent(dataPath);
-        }
-    }
-#endif
-
     /*
      * Establish the mechanism for communication with an already running PolyMC that uses the same data path.
      * If there is one, tell it what the user actually wanted to do and exit.

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -97,13 +97,6 @@ LauncherPage::LauncherPage(QWidget *parent) : QWidget(parent), ui(new Ui::Launch
     }
     connect(ui->fontSizeBox, SIGNAL(valueChanged(int)), SLOT(refreshFontPreview()));
     connect(ui->consoleFont, SIGNAL(currentFontChanged(QFont)), SLOT(refreshFontPreview()));
-
-    //move mac data button
-    QFile file(QDir::current().absolutePath() + "/dontmovemacdata");
-    if (!file.exists())
-    {
-        ui->migrateDataFolderMacBtn->setVisible(false);
-    }
 }
 
 LauncherPage::~LauncherPage()
@@ -189,13 +182,6 @@ void LauncherPage::on_modsDirBrowseBtn_clicked()
         QString cooked_dir = FS::NormalizePath(raw_dir);
         ui->modsDirTextBox->setText(cooked_dir);
     }
-}
-void LauncherPage::on_migrateDataFolderMacBtn_clicked()
-{
-    QFile file(QDir::current().absolutePath() + "/dontmovemacdata");
-    file.remove();
-    QProcess::startDetached(qApp->arguments()[0]);
-    qApp->quit();
 }
 
 void LauncherPage::refreshUpdateChannelList()

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -88,7 +88,6 @@ slots:
     void on_instDirBrowseBtn_clicked();
     void on_modsDirBrowseBtn_clicked();
     void on_iconsDirBrowseBtn_clicked();
-    void on_migrateDataFolderMacBtn_clicked();
 
     /*!
      * Updates the list of update channels in the combo box.

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -158,13 +158,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="migrateDataFolderMacBtn">
-         <property name="text">
-          <string>Move the data to new location (will restart the launcher)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
A bunch of code was inherited from MultiMC to migrate old users' data to a new location. Since PolyMC does not have any old users with data in this old location (this code existed before PolyMC), nor does it even store data in the app bundle to begin with, this code should be safe to remove.