### PR TITLE
Update `BundleUtilities` to fix macOS Qt framework bundle structure

### DIFF
--- a/cmake/BundleUtilities.cmake
+++ b/cmake/BundleUtilities.cmake
@@ -1,165 +1,259 @@
-# - Functions to help assemble a standalone bundle application.
-# A collection of CMake utility functions useful for dealing with .app
-# bundles on the Mac and bundle-like directories on any OS.
-#
-# The following functions are provided by this module:
-#   fixup_bundle
-#   copy_and_fixup_bundle
-#   verify_app
-#   get_bundle_main_executable
-#   get_dotapp_dir
-#   get_bundle_and_executable
-#   get_bundle_all_executables
-#   get_item_key
-#   clear_bundle_keys
-#   set_bundle_key_values
-#   get_bundle_keys
-#   copy_resolved_item_into_bundle
-#   copy_resolved_framework_into_bundle
-#   fixup_bundle_item
-#   verify_bundle_prerequisites
-#   verify_bundle_symlinks
-# Requires CMake 2.6 or greater because it uses function, break and
-# PARENT_SCOPE. Also depends on GetPrerequisites.cmake.
-#
-#  FIXUP_BUNDLE(<app> <libs> <dirs>)
-# Fix up a bundle in-place and make it standalone, such that it can be
-# drag-n-drop copied to another machine and run on that machine as long as all
-# of the system libraries are compatible.
-#
-# If you pass plugins to fixup_bundle as the libs parameter, you should install
-# them or copy them into the bundle before calling fixup_bundle. The "libs"
-# parameter is a list of libraries that must be fixed up, but that cannot be
-# determined by otool output analysis. (i.e., plugins)
-#
-# Gather all the keys for all the executables and libraries in a bundle, and
-# then, for each key, copy each prerequisite into the bundle. Then fix each one
-# up according to its own list of prerequisites.
-#
-# Then clear all the keys and call verify_app on the final bundle to ensure
-# that it is truly standalone.
-#
-#  COPY_AND_FIXUP_BUNDLE(<src> <dst> <libs> <dirs>)
-# Makes a copy of the bundle <src> at location <dst> and then fixes up the
-# new copied bundle in-place at <dst>...
-#
-#  VERIFY_APP(<app>)
-# Verifies that an application <app> appears valid based on running analysis
-# tools on it. Calls "message(FATAL_ERROR" if the application is not verified.
-#
-#  GET_BUNDLE_MAIN_EXECUTABLE(<bundle> <result_var>)
-# The result will be the full path name of the bundle's main executable file
-# or an "error:" prefixed string if it could not be determined.
-#
-#  GET_DOTAPP_DIR(<exe> <dotapp_dir_var>)
-# Returns the nearest parent dir whose name ends with ".app" given the full
-# path to an executable. If there is no such parent dir, then simply return
-# the dir containing the executable.
-#
-# The returned directory may or may not exist.
-#
-#  GET_BUNDLE_AND_EXECUTABLE(<app> <bundle_var> <executable_var> <valid_var>)
-# Takes either a ".app" directory name or the name of an executable
-# nested inside a ".app" directory and returns the path to the ".app"
-# directory in <bundle_var> and the path to its main executable in
-# <executable_var>
-#
-#  GET_BUNDLE_ALL_EXECUTABLES(<bundle> <exes_var>)
-# Scans the given bundle recursively for all executable files and accumulates
-# them into a variable.
-#
-#  GET_ITEM_KEY(<item> <key_var>)
-# Given a file (item) name, generate a key that should be unique considering
-# the set of libraries that need copying or fixing up to make a bundle
-# standalone. This is essentially the file name including extension with "."
-# replaced by "_"
-#
-# This key is used as a prefix for CMake variables so that we can associate a
-# set of variables with a given item based on its key.
-#
-#  CLEAR_BUNDLE_KEYS(<keys_var>)
-# Loop over the list of keys, clearing all the variables associated with each
-# key. After the loop, clear the list of keys itself.
-#
-# Caller of get_bundle_keys should call clear_bundle_keys when done with list
-# of keys.
-#
-#  SET_BUNDLE_KEY_VALUES(<keys_var> <context> <item> <exepath> <dirs>
-#                        <copyflag>)
-# Add a key to the list (if necessary) for the given item. If added,
-# also set all the variables associated with that key.
-#
-#  GET_BUNDLE_KEYS(<app> <libs> <dirs> <keys_var>)
-# Loop over all the executable and library files within the bundle (and given
-# as extra <libs>) and accumulate a list of keys representing them. Set
-# values associated with each key such that we can loop over all of them and
-# copy prerequisite libs into the bundle and then do appropriate
-# install_name_tool fixups.
-#
-#  COPY_RESOLVED_ITEM_INTO_BUNDLE(<resolved_item> <resolved_embedded_item>)
-# Copy a resolved item into the bundle if necessary. Copy is not necessary if
-# the resolved_item is "the same as" the resolved_embedded_item.
-#
-#  COPY_RESOLVED_FRAMEWORK_INTO_BUNDLE(<resolved_item> <resolved_embedded_item>)
-# Copy a resolved framework into the bundle if necessary. Copy is not necessary
-# if the resolved_item is "the same as" the resolved_embedded_item.
-#
-# By default, BU_COPY_FULL_FRAMEWORK_CONTENTS is not set. If you want full
-# frameworks embedded in your bundles, set BU_COPY_FULL_FRAMEWORK_CONTENTS to
-# ON before calling fixup_bundle. By default,
-# COPY_RESOLVED_FRAMEWORK_INTO_BUNDLE copies the framework dylib itself plus
-# the framework Resources directory.
-#
-#  FIXUP_BUNDLE_ITEM(<resolved_embedded_item> <exepath> <dirs>)
-# Get the direct/non-system prerequisites of the resolved embedded item. For
-# each prerequisite, change the way it is referenced to the value of the
-# _EMBEDDED_ITEM keyed variable for that prerequisite. (Most likely changing to
-# an "@executable_path" style reference.)
-#
-# This function requires that the resolved_embedded_item be "inside" the bundle
-# already. In other words, if you pass plugins to fixup_bundle as the libs
-# parameter, you should install them or copy them into the bundle before
-# calling fixup_bundle. The "libs" parameter is a list of libraries that must
-# be fixed up, but that cannot be determined by otool output analysis. (i.e.,
-# plugins)
-#
-# Also, change the id of the item being fixed up to its own _EMBEDDED_ITEM
-# value.
-#
-# Accumulate changes in a local variable and make *one* call to
-# install_name_tool at the end of the function with all the changes at once.
-#
-# If the BU_CHMOD_BUNDLE_ITEMS variable is set then bundle items will be
-# marked writable before install_name_tool tries to change them.
-#
-#  VERIFY_BUNDLE_PREREQUISITES(<bundle> <result_var> <info_var>)
-# Verifies that the sum of all prerequisites of all files inside the bundle
-# are contained within the bundle or are "system" libraries, presumed to exist
-# everywhere.
-#
-#  VERIFY_BUNDLE_SYMLINKS(<bundle> <result_var> <info_var>)
-# Verifies that any symlinks found in the bundle point to other files that are
-# already also in the bundle... Anything that points to an external file causes
-# this function to fail the verification.
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
-#=============================================================================
-# Copyright 2008-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+BundleUtilities
+---------------
+
+Functions to help assemble a standalone bundle application.
+
+A collection of CMake utility functions useful for dealing with ``.app``
+bundles on the Mac and bundle-like directories on any OS.
+
+The following functions are provided by this module:
+
+.. code-block:: cmake
+
+   fixup_bundle
+   copy_and_fixup_bundle
+   verify_app
+   get_bundle_main_executable
+   get_dotapp_dir
+   get_bundle_and_executable
+   get_bundle_all_executables
+   get_item_key
+   get_item_rpaths
+   clear_bundle_keys
+   set_bundle_key_values
+   get_bundle_keys
+   copy_resolved_item_into_bundle
+   copy_resolved_framework_into_bundle
+   fixup_bundle_item
+   verify_bundle_prerequisites
+   verify_bundle_symlinks
+
+Requires CMake 2.6 or greater because it uses function, break and
+``PARENT_SCOPE``.  Also depends on ``GetPrerequisites.cmake``.
+
+DO NOT USE THESE FUNCTIONS AT CONFIGURE TIME (from ``CMakeLists.txt``)!
+Instead, invoke them from an :command:`install(CODE)` or
+:command:`install(SCRIPT)` rule.
+
+.. code-block:: cmake
+
+  fixup_bundle(<app> <libs> <dirs>)
+
+Fix up ``<app>`` bundle in-place and make it standalone, such that it can be
+drag-n-drop copied to another machine and run on that machine as long
+as all of the system libraries are compatible.
+
+If you pass plugins to ``fixup_bundle`` as the libs parameter, you should
+install them or copy them into the bundle before calling ``fixup_bundle``.
+The ``<libs>`` parameter is a list of libraries that must be fixed up, but
+that cannot be determined by ``otool`` output analysis  (i.e. ``plugins``).
+
+Gather all the keys for all the executables and libraries in a bundle,
+and then, for each key, copy each prerequisite into the bundle.  Then
+fix each one up according to its own list of prerequisites.
+
+Then clear all the keys and call ``verify_app`` on the final bundle to
+ensure that it is truly standalone.
+
+.. versionadded:: 3.6
+  As an optional parameter (``IGNORE_ITEM``) a list of file names can be passed,
+  which are then ignored
+  (e.g. ``IGNORE_ITEM "vcredist_x86.exe;vcredist_x64.exe"``).
+
+.. code-block:: cmake
+
+  copy_and_fixup_bundle(<src> <dst> <libs> <dirs>)
+
+Makes a copy of the bundle ``<src>`` at location ``<dst>`` and then fixes up
+the new copied bundle in-place at ``<dst>``.
+
+.. code-block:: cmake
+
+  verify_app(<app>)
+
+Verifies that an application ``<app>`` appears valid based on running
+analysis tools on it.  Calls :command:`message(FATAL_ERROR)` if the application
+is not verified.
+
+.. versionadded:: 3.6
+  As an optional parameter (``IGNORE_ITEM``) a list of file names can be passed,
+  which are then ignored
+  (e.g. ``IGNORE_ITEM "vcredist_x86.exe;vcredist_x64.exe"``)
+
+.. code-block:: cmake
+
+  get_bundle_main_executable(<bundle> <result_var>)
+
+The result will be the full path name of the bundle's main executable
+file or an ``error:`` prefixed string if it could not be determined.
+
+.. code-block:: cmake
+
+  get_dotapp_dir(<exe> <dotapp_dir_var>)
+
+Returns the nearest parent dir whose name ends with ``.app`` given the
+full path to an executable.  If there is no such parent dir, then
+simply return the dir containing the executable.
+
+The returned directory may or may not exist.
+
+.. code-block:: cmake
+
+  get_bundle_and_executable(<app> <bundle_var> <executable_var> <valid_var>)
+
+Takes either a ``.app`` directory name or the name of an executable
+nested inside a ``.app`` directory and returns the path to the ``.app``
+directory in ``<bundle_var>`` and the path to its main executable in
+``<executable_var>``.
+
+.. code-block:: cmake
+
+  get_bundle_all_executables(<bundle> <exes_var>)
+
+Scans ``<bundle>`` bundle recursively for all ``<exes_var>`` executable
+files and accumulates them into a variable.
+
+.. code-block:: cmake
+
+  get_item_key(<item> <key_var>)
+
+Given ``<item>`` file name, generate ``<key_var>`` key that should be unique
+considering the set of libraries that need copying or fixing up to
+make a bundle standalone.  This is essentially the file name including
+extension with ``.`` replaced by ``_``
+
+This key is used as a prefix for CMake variables so that we can
+associate a set of variables with a given item based on its key.
+
+.. code-block:: cmake
+
+  clear_bundle_keys(<keys_var>)
+
+Loop over the ``<keys_var>`` list of keys, clearing all the variables
+associated with each key.  After the loop, clear the list of keys itself.
+
+Caller of ``get_bundle_keys`` should call ``clear_bundle_keys`` when done with
+list of keys.
+
+.. code-block:: cmake
+
+  set_bundle_key_values(<keys_var> <context> <item> <exepath> <dirs>
+                        <copyflag> [<rpaths>])
+
+Add ``<keys_var>`` key to the list (if necessary) for the given item.
+If added, also set all the variables associated with that key.
+
+.. code-block:: cmake
+
+  get_bundle_keys(<app> <libs> <dirs> <keys_var>)
+
+Loop over all the executable and library files within ``<app>`` bundle (and
+given as extra ``<libs>``) and accumulate a list of keys representing
+them.  Set values associated with each key such that we can loop over
+all of them and copy prerequisite libs into the bundle and then do
+appropriate ``install_name_tool`` fixups.
+
+.. versionadded:: 3.6
+  As an optional parameter (``IGNORE_ITEM``) a list of file names can be passed,
+  which are then ignored
+  (e.g. ``IGNORE_ITEM "vcredist_x86.exe;vcredist_x64.exe"``)
+
+.. code-block:: cmake
+
+  copy_resolved_item_into_bundle(<resolved_item> <resolved_embedded_item>)
+
+Copy a resolved item into the bundle if necessary.
+Copy is not necessary, if the ``<resolved_item>`` is "the same as" the
+``<resolved_embedded_item>``.
+
+.. code-block:: cmake
+
+  copy_resolved_framework_into_bundle(<resolved_item> <resolved_embedded_item>)
+
+Copy a resolved framework into the bundle if necessary.
+Copy is not necessary, if the ``<resolved_item>`` is "the same as" the
+``<resolved_embedded_item>``.
+
+By default, ``BU_COPY_FULL_FRAMEWORK_CONTENTS`` is not set.  If you want
+full frameworks embedded in your bundles, set
+``BU_COPY_FULL_FRAMEWORK_CONTENTS`` to ``ON`` before calling fixup_bundle.  By
+default, ``COPY_RESOLVED_FRAMEWORK_INTO_BUNDLE`` copies the framework
+dylib itself plus the framework ``Resources`` directory.
+
+.. code-block:: cmake
+
+  fixup_bundle_item(<resolved_embedded_item> <exepath> <dirs>)
+
+Get the direct/non-system prerequisites of the ``<resolved_embedded_item>``.
+For each prerequisite, change the way it is referenced to the value of
+the ``_EMBEDDED_ITEM`` keyed variable for that prerequisite.  (Most likely
+changing to an ``@executable_path`` style reference.)
+
+This function requires that the ``<resolved_embedded_item>`` be ``inside``
+the bundle already.  In other words, if you pass plugins to ``fixup_bundle``
+as the libs parameter, you should install them or copy them into the
+bundle before calling ``fixup_bundle``.  The ``libs`` parameter is a list of
+libraries that must be fixed up, but that cannot be determined by
+otool output analysis.  (i.e., ``plugins``)
+
+Also, change the id of the item being fixed up to its own
+``_EMBEDDED_ITEM`` value.
+
+Accumulate changes in a local variable and make *one* call to
+``install_name_tool`` at the end of the function with all the changes at
+once.
+
+If the ``BU_CHMOD_BUNDLE_ITEMS`` variable is set then bundle items will be
+marked writable before ``install_name_tool`` tries to change them.
+
+.. code-block:: cmake
+
+  verify_bundle_prerequisites(<bundle> <result_var> <info_var>)
+
+Verifies that the sum of all prerequisites of all files inside the
+bundle are contained within the bundle or are ``system`` libraries,
+presumed to exist everywhere.
+
+.. versionadded:: 3.6
+  As an optional parameter (``IGNORE_ITEM``) a list of file names can be passed,
+  which are then ignored
+  (e.g. ``IGNORE_ITEM "vcredist_x86.exe;vcredist_x64.exe"``)
+
+.. code-block:: cmake
+
+  verify_bundle_symlinks(<bundle> <result_var> <info_var>)
+
+Verifies that any symlinks found in the ``<bundle>`` bundle point to other files
+that are already also in the bundle...  Anything that points to an
+external file causes this function to fail the verification.
+#]=======================================================================]
+
+function(_warn_cmp0080)
+  cmake_policy(GET_WARNING CMP0080 _cmp0080_warning)
+  message(AUTHOR_WARNING "${_cmp0080_warning}\n")
+endfunction()
+
+# Do not include this module at configure time!
+if(DEFINED CMAKE_GENERATOR)
+  cmake_policy(GET CMP0080 _BundleUtilities_CMP0080)
+  if(_BundleUtilities_CMP0080 STREQUAL "NEW")
+    message(FATAL_ERROR "BundleUtilities cannot be included at configure time!")
+  elseif(NOT _BundleUtilities_CMP0080 STREQUAL "OLD" AND NOT _CMP0080_SUPPRESS_WARNING)
+    _warn_cmp0080()
+  endif()
+endif()
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
 # The functions defined in this file depend on the get_prerequisites function
 # (and possibly others) found in:
 #
-get_filename_component(BundleUtilities_cmake_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
-include("${BundleUtilities_cmake_dir}/GetPrerequisites.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/GetPrerequisites.cmake")
 
 
 function(get_bundle_main_executable bundle result_var)
@@ -174,8 +268,9 @@ function(get_bundle_main_executable bundle result_var)
     #
     set(eol_char "E")
     file(READ "${bundle}/Contents/Info.plist" info_plist)
-    string(REGEX REPLACE ";" "\\\\;" info_plist "${info_plist}")
-    string(REGEX REPLACE "\n" "${eol_char};" info_plist "${info_plist}")
+    string(REPLACE ";" "\\;" info_plist "${info_plist}")
+    string(REPLACE "\n" "${eol_char};" info_plist "${info_plist}")
+    string(REPLACE "\r" "${eol_char};" info_plist "${info_plist}")
 
     # Scan the lines for "<key>CFBundleExecutable</key>" - the line after that
     # is the name of the main executable.
@@ -186,12 +281,12 @@ function(get_bundle_main_executable bundle result_var)
         break()
       endif()
 
-      if(line MATCHES "^.*<key>CFBundleExecutable</key>.*$")
+      if(line MATCHES "<key>CFBundleExecutable</key>")
         set(line_is_main_executable 1)
       endif()
     endforeach()
 
-    if(NOT "${bundle_executable}" STREQUAL "")
+    if(NOT bundle_executable STREQUAL "")
       if(EXISTS "${bundle}/Contents/MacOS/${bundle_executable}")
         set(result "${bundle}/Contents/MacOS/${bundle_executable}")
       else()
@@ -226,7 +321,7 @@ endfunction()
 function(get_dotapp_dir exe dotapp_dir_var)
   set(s "${exe}")
 
-  if(s MATCHES "^.*/.*\\.app/.*$")
+  if(s MATCHES "/.*\\.app/")
     # If there is a ".app" parent directory,
     # ascend until we hit it:
     #   (typical of a Mac bundle executable)
@@ -301,7 +396,7 @@ function(get_bundle_and_executable app bundle_var executable_var valid_var)
       endif()
     endif()
   else()
-    message(STATUS "warning: *NOT* handled - directory/file ${app} does not exist...")
+    message(STATUS "warning: *NOT* handled - directory/file does not exist...")
   endif()
 
   if(NOT valid)
@@ -316,7 +411,25 @@ endfunction()
 function(get_bundle_all_executables bundle exes_var)
   set(exes "")
 
-  file(GLOB_RECURSE file_list "${bundle}/*")
+  if(UNIX)
+    find_program(find_cmd "find")
+    mark_as_advanced(find_cmd)
+  endif()
+
+  # find command is much quicker than checking every file one by one on Unix
+  # which can take long time for large bundles, and since anyway we expect
+  # executable to have execute flag set we can narrow the list much quicker.
+  if(find_cmd)
+    execute_process(COMMAND "${find_cmd}" "${bundle}"
+        -type f \( -perm -0100 -o -perm -0010 -o -perm -0001 \)
+        OUTPUT_VARIABLE file_list
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    string(REPLACE "\n" ";" file_list "${file_list}")
+  else()
+    file(GLOB_RECURSE file_list "${bundle}/*")
+  endif()
+
   foreach(f ${file_list})
     is_file_executable("${f}" is_executable)
     if(is_executable)
@@ -328,12 +441,52 @@ function(get_bundle_all_executables bundle exes_var)
 endfunction()
 
 
+function(get_item_rpaths item rpaths_var)
+  if(APPLE)
+    find_program(otool_cmd "otool")
+    mark_as_advanced(otool_cmd)
+  endif()
+
+  if(otool_cmd)
+    execute_process(
+        COMMAND "${otool_cmd}" -l "${item}"
+        OUTPUT_VARIABLE load_cmds_ov
+        RESULT_VARIABLE otool_rv
+        ERROR_VARIABLE otool_ev
+    )
+    if(NOT otool_rv STREQUAL "0")
+      message(FATAL_ERROR "otool -l failed: ${otool_rv}\n${otool_ev}")
+    endif()
+    string(REGEX REPLACE "[^\n]+cmd LC_RPATH\n[^\n]+\n[^\n]+path ([^\n]+) \\(offset[^\n]+\n" "rpath \\1\n" load_cmds_ov "${load_cmds_ov}")
+    string(REGEX MATCHALL "rpath [^\n]+" load_cmds_ov "${load_cmds_ov}")
+    string(REGEX REPLACE "rpath " "" load_cmds_ov "${load_cmds_ov}")
+    if(load_cmds_ov)
+      foreach(rpath ${load_cmds_ov})
+        gp_append_unique(${rpaths_var} "${rpath}")
+      endforeach()
+    endif()
+  endif()
+
+  if(UNIX AND NOT APPLE)
+    file(READ_ELF ${item} RPATH rpath_var RUNPATH runpath_var CAPTURE_ERROR error_var)
+    get_filename_component(item_dir ${item} DIRECTORY)
+    foreach(rpath ${rpath_var} ${runpath_var})
+      # Substitute $ORIGIN with the exepath and add to the found rpaths
+      string(REPLACE "$ORIGIN" "${item_dir}" rpath "${rpath}")
+      gp_append_unique(${rpaths_var} "${rpath}")
+    endforeach()
+  endif()
+
+  set(${rpaths_var} ${${rpaths_var}} PARENT_SCOPE)
+endfunction()
+
+
 function(get_item_key item key_var)
   get_filename_component(item_name "${item}" NAME)
   if(WIN32)
     string(TOLOWER "${item_name}" item_name)
   endif()
-  string(REGEX REPLACE "\\." "_" ${key_var} "${item_name}")
+  string(REPLACE "." "_" ${key_var} "${item_name}")
   set(${key_var} ${${key_var}} PARENT_SCOPE)
 endfunction()
 
@@ -346,12 +499,18 @@ function(clear_bundle_keys keys_var)
     set(${key}_EMBEDDED_ITEM PARENT_SCOPE)
     set(${key}_RESOLVED_EMBEDDED_ITEM PARENT_SCOPE)
     set(${key}_COPYFLAG PARENT_SCOPE)
+    set(${key}_RPATHS PARENT_SCOPE)
   endforeach()
   set(${keys_var} PARENT_SCOPE)
 endfunction()
 
 
 function(set_bundle_key_values keys_var context item exepath dirs copyflag)
+  if(ARGC GREATER 6)
+    set(rpaths "${ARGV6}")
+  else()
+    set(rpaths "")
+  endif()
   get_filename_component(item_name "${item}" NAME)
 
   get_item_key("${item}" key)
@@ -361,11 +520,13 @@ function(set_bundle_key_values keys_var context item exepath dirs copyflag)
   list(LENGTH ${keys_var} length_after)
 
   if(NOT length_before EQUAL length_after)
-    gp_resolve_item("${context}" "${item}" "${exepath}" "${dirs}" resolved_item)
+    gp_resolve_item("${context}" "${item}" "${exepath}" "${dirs}" resolved_item "${rpaths}")
 
     gp_item_default_embedded_path("${item}" default_embedded_path)
 
-    if(item MATCHES "[^/]+\\.framework/")
+    get_item_rpaths("${resolved_item}" item_rpaths)
+
+    if((NOT item MATCHES "\\.dylib$") AND (item MATCHES "[^/]+\\.framework/"))
       # For frameworks, construct the name under the embedded path from the
       # opening "${item_name}.framework/" to the closing "/${item_name}":
       #
@@ -400,6 +561,8 @@ function(set_bundle_key_values keys_var context item exepath dirs copyflag)
     set(${key}_EMBEDDED_ITEM "${embedded_item}" PARENT_SCOPE)
     set(${key}_RESOLVED_EMBEDDED_ITEM "${resolved_embedded_item}" PARENT_SCOPE)
     set(${key}_COPYFLAG "${copyflag}" PARENT_SCOPE)
+    set(${key}_RPATHS "${item_rpaths}" PARENT_SCOPE)
+    set(${key}_RDEP_RPATHS "${rpaths}" PARENT_SCOPE)
   else()
     #message("warning: item key '${key}' already in the list, subsequent references assumed identical to first")
   endif()
@@ -408,6 +571,11 @@ endfunction()
 
 function(get_bundle_keys app libs dirs keys_var)
   set(${keys_var} PARENT_SCOPE)
+
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs IGNORE_ITEM)
+  cmake_parse_arguments(CFG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   get_bundle_and_executable("${app}" bundle executable valid)
   if(valid)
@@ -420,19 +588,34 @@ function(get_bundle_keys app libs dirs keys_var)
     #
     get_bundle_all_executables("${bundle}" exes)
 
+    # Set keys for main executable first:
+    #
+    set_bundle_key_values(${keys_var} "${executable}" "${executable}" "${exepath}" "${dirs}" 0)
+
+    # Get rpaths specified by main executable:
+    #
+    get_item_key("${executable}" executable_key)
+    set(main_rpaths "${${executable_key}_RPATHS}")
+
     # For each extra lib, accumulate a key as well and then also accumulate
     # any of its prerequisites. (Extra libs are typically dynamically loaded
     # plugins: libraries that are prerequisites for full runtime functionality
     # but that do not show up in otool -L output...)
     #
     foreach(lib ${libs})
-      set_bundle_key_values(${keys_var} "${lib}" "${lib}" "${exepath}" "${dirs}" 0)
+      set_bundle_key_values(${keys_var} "${lib}" "${lib}" "${exepath}" "${dirs}" 0 "${main_rpaths}")
 
       set(prereqs "")
-      get_prerequisites("${lib}" prereqs 1 1 "${exepath}" "${dirs}")
-      foreach(pr ${prereqs})
-        set_bundle_key_values(${keys_var} "${lib}" "${pr}" "${exepath}" "${dirs}" 1)
-      endforeach()
+      get_filename_component(prereq_filename ${lib} NAME)
+
+      if(NOT prereq_filename IN_LIST CFG_IGNORE_ITEM)
+        get_prerequisites("${lib}" prereqs 1 1 "${exepath}" "${dirs}" "${main_rpaths}")
+        foreach(pr ${prereqs})
+          set_bundle_key_values(${keys_var} "${lib}" "${pr}" "${exepath}" "${dirs}" 1 "${main_rpaths}")
+        endforeach()
+      else()
+        message(STATUS "Ignoring file: ${prereq_filename}")
+      endif()
     endforeach()
 
     # For each executable found in the bundle, accumulate keys as we go.
@@ -440,19 +623,63 @@ function(get_bundle_keys app libs dirs keys_var)
     # binaries in the bundle have been analyzed.
     #
     foreach(exe ${exes})
-      # Add the exe itself to the keys:
+      # Main executable is scanned first above:
       #
-      set_bundle_key_values(${keys_var} "${exe}" "${exe}" "${exepath}" "${dirs}" 0)
+      if(NOT exe STREQUAL executable)
+        # Add the exe itself to the keys:
+        #
+        set_bundle_key_values(${keys_var} "${exe}" "${exe}" "${exepath}" "${dirs}" 0 "${main_rpaths}")
+
+        # Get rpaths specified by executable:
+        #
+        get_item_key("${exe}" exe_key)
+        set(exe_rpaths "${main_rpaths}" "${${exe_key}_RPATHS}")
+      else()
+        set(exe_rpaths "${main_rpaths}")
+      endif()
 
       # Add each prerequisite to the keys:
       #
       set(prereqs "")
-      get_prerequisites("${exe}" prereqs 1 1 "${exepath}" "${dirs}")
-      foreach(pr ${prereqs})
-        set_bundle_key_values(${keys_var} "${exe}" "${pr}" "${exepath}" "${dirs}" 1)
-      endforeach()
+      get_filename_component(prereq_filename ${exe} NAME)
+
+      if(NOT prereq_filename IN_LIST CFG_IGNORE_ITEM)
+        get_prerequisites("${exe}" prereqs 1 1 "${exepath}" "${dirs}" "${exe_rpaths}")
+        foreach(pr ${prereqs})
+          set_bundle_key_values(${keys_var} "${exe}" "${pr}" "${exepath}" "${dirs}" 1 "${exe_rpaths}")
+        endforeach()
+      else()
+        message(STATUS "Ignoring file: ${prereq_filename}")
+      endif()
     endforeach()
 
+    # preserve library symlink structure
+    foreach(key ${${keys_var}})
+      if("${${key}_COPYFLAG}" STREQUAL "1")
+        if(IS_SYMLINK "${${key}_RESOLVED_ITEM}")
+          get_filename_component(target "${${key}_RESOLVED_ITEM}" REALPATH)
+          set_bundle_key_values(${keys_var} "${exe}" "${target}" "${exepath}" "${dirs}" 1 "${exe_rpaths}")
+          get_item_key("${target}" targetkey)
+
+          if(WIN32)
+            # ignore case on Windows
+            string(TOLOWER "${${key}_RESOLVED_ITEM}" resolved_item_compare)
+            string(TOLOWER "${${targetkey}_RESOLVED_EMBEDDED_ITEM}" resolved_embedded_item_compare)
+          else()
+            set(resolved_item_compare "${${key}_RESOLVED_ITEM}")
+            set(resolved_embedded_item_compare "${${targetkey}_RESOLVED_EMBEDDED_ITEM}")
+          endif()
+          get_filename_component(resolved_item_compare "${resolved_item_compare}" NAME)
+          get_filename_component(resolved_embedded_item_compare "${resolved_embedded_item_compare}" NAME)
+
+          if(NOT resolved_item_compare STREQUAL resolved_embedded_item_compare)
+            set(${key}_COPYFLAG "2")
+            set(${key}_RESOLVED_ITEM "${${targetkey}_RESOLVED_EMBEDDED_ITEM}")
+          endif()
+
+        endif()
+      endif()
+    endforeach()
     # Propagate values to caller's scope:
     #
     set(${keys_var} ${${keys_var}} PARENT_SCOPE)
@@ -463,10 +690,33 @@ function(get_bundle_keys app libs dirs keys_var)
       set(${key}_EMBEDDED_ITEM "${${key}_EMBEDDED_ITEM}" PARENT_SCOPE)
       set(${key}_RESOLVED_EMBEDDED_ITEM "${${key}_RESOLVED_EMBEDDED_ITEM}" PARENT_SCOPE)
       set(${key}_COPYFLAG "${${key}_COPYFLAG}" PARENT_SCOPE)
+      set(${key}_RPATHS "${${key}_RPATHS}" PARENT_SCOPE)
+      set(${key}_RDEP_RPATHS "${${key}_RDEP_RPATHS}" PARENT_SCOPE)
     endforeach()
   endif()
 endfunction()
 
+function(link_resolved_item_into_bundle resolved_item resolved_embedded_item)
+  if(WIN32)
+    # ignore case on Windows
+    string(TOLOWER "${resolved_item}" resolved_item_compare)
+    string(TOLOWER "${resolved_embedded_item}" resolved_embedded_item_compare)
+  else()
+    set(resolved_item_compare "${resolved_item}")
+    set(resolved_embedded_item_compare "${resolved_embedded_item}")
+  endif()
+
+  if(resolved_item_compare STREQUAL resolved_embedded_item_compare)
+    message(STATUS "warning: resolved_item == resolved_embedded_item - not linking...")
+  else()
+    get_filename_component(target_dir "${resolved_embedded_item}" DIRECTORY)
+    file(RELATIVE_PATH symlink_target "${target_dir}" "${resolved_item}")
+    if (NOT EXISTS "${target_dir}")
+      file(MAKE_DIRECTORY "${target_dir}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${symlink_target}" "${resolved_embedded_item}")
+  endif()
+endfunction()
 
 function(copy_resolved_item_into_bundle resolved_item resolved_embedded_item)
   if(WIN32)
@@ -478,7 +728,7 @@ function(copy_resolved_item_into_bundle resolved_item resolved_embedded_item)
     set(resolved_embedded_item_compare "${resolved_embedded_item}")
   endif()
 
-  if("${resolved_item_compare}" STREQUAL "${resolved_embedded_item_compare}")
+  if(resolved_item_compare STREQUAL resolved_embedded_item_compare)
     message(STATUS "warning: resolved_item == resolved_embedded_item - not copying...")
   else()
     #message(STATUS "copying COMMAND ${CMAKE_COMMAND} -E copy ${resolved_item} ${resolved_embedded_item}")
@@ -501,7 +751,7 @@ function(copy_resolved_framework_into_bundle resolved_item resolved_embedded_ite
     set(resolved_embedded_item_compare "${resolved_embedded_item}")
   endif()
 
-  if("${resolved_item_compare}" STREQUAL "${resolved_embedded_item_compare}")
+  if(resolved_item_compare STREQUAL resolved_embedded_item_compare)
     message(STATUS "warning: resolved_item == resolved_embedded_item - not copying...")
   else()
     if(BU_COPY_FULL_FRAMEWORK_CONTENTS)
@@ -518,11 +768,44 @@ function(copy_resolved_framework_into_bundle resolved_item resolved_embedded_ite
       execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${resolved_item}" "${resolved_embedded_item}")
 
       # Plus Resources, if they exist:
-      string(REGEX REPLACE "^(.*)/[^/]+/[^/]+/[^/]+$" "\\1/Resources" resolved_resources "${resolved_item}")
-      string(REGEX REPLACE "^(.*)/[^/]+/[^/]+/[^/]+$" "\\1/Resources" resolved_embedded_resources "${resolved_embedded_item}")
+      string(REGEX REPLACE "^(.*)/[^/]+$" "\\1/Resources" resolved_resources "${resolved_item}")
+      string(REGEX REPLACE "^(.*)/[^/]+$" "\\1/Resources" resolved_embedded_resources "${resolved_embedded_item}")
       if(EXISTS "${resolved_resources}")
         #message(STATUS "copying COMMAND ${CMAKE_COMMAND} -E copy_directory '${resolved_resources}' '${resolved_embedded_resources}'")
         execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory "${resolved_resources}" "${resolved_embedded_resources}")
+      endif()
+
+      # Some frameworks e.g. Qt put Info.plist in wrong place, so when it is
+      # missing in resources, copy it from other well known incorrect locations:
+      if(NOT EXISTS "${resolved_resources}/Info.plist")
+        # Check for Contents/Info.plist in framework root (older Qt SDK):
+        string(REGEX REPLACE "^(.*)/[^/]+/[^/]+/[^/]+$" "\\1/Contents/Info.plist" resolved_info_plist "${resolved_item}")
+        string(REGEX REPLACE "^(.*)/[^/]+$" "\\1/Resources/Info.plist" resolved_embedded_info_plist "${resolved_embedded_item}")
+        if(EXISTS "${resolved_info_plist}")
+          #message(STATUS "copying COMMAND ${CMAKE_COMMAND} -E copy_directory '${resolved_info_plist}' '${resolved_embedded_info_plist}'")
+          execute_process(COMMAND ${CMAKE_COMMAND} -E copy "${resolved_info_plist}" "${resolved_embedded_info_plist}")
+        endif()
+      endif()
+
+      # Check if framework is versioned and fix it layout
+      string(REGEX REPLACE "^.*/([^/]+)/[^/]+$" "\\1" resolved_embedded_version "${resolved_embedded_item}")
+      string(REGEX REPLACE "^(.*)/[^/]+/[^/]+$" "\\1" resolved_embedded_versions "${resolved_embedded_item}")
+      string(REGEX REPLACE "^.*/([^/]+)/[^/]+/[^/]+$" "\\1" resolved_embedded_versions_basename "${resolved_embedded_item}")
+      if(resolved_embedded_versions_basename STREQUAL "Versions")
+        # Ensure Current symlink points to the framework version
+        if(NOT EXISTS "${resolved_embedded_versions}/Current")
+          execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${resolved_embedded_version}" "${resolved_embedded_versions}/Current")
+        endif()
+        # Restore symlinks in framework root pointing to current framework
+        # binary and resources:
+        string(REGEX REPLACE "^(.*)/[^/]+/[^/]+/[^/]+$" "\\1" resolved_embedded_root "${resolved_embedded_item}")
+        string(REGEX REPLACE "^.*/([^/]+)$" "\\1" resolved_embedded_item_basename "${resolved_embedded_item}")
+        if(NOT EXISTS "${resolved_embedded_root}/${resolved_embedded_item_basename}")
+          execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "Versions/Current/${resolved_embedded_item_basename}" "${resolved_embedded_root}/${resolved_embedded_item_basename}")
+        endif()
+        if(NOT EXISTS "${resolved_embedded_root}/Resources")
+          execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "Versions/Current/Resources" "${resolved_embedded_root}/Resources")
+        endif()
       endif()
     endif()
     if(UNIX AND NOT APPLE)
@@ -548,12 +831,12 @@ function(fixup_bundle_item resolved_embedded_item exepath dirs)
   string(LENGTH "${resolved_embedded_item}" resolved_embedded_item_length)
   set(path_too_short 0)
   set(is_embedded 0)
-  if(${resolved_embedded_item_length} LESS ${exe_dotapp_dir_length})
+  if(resolved_embedded_item_length LESS exe_dotapp_dir_length)
     set(path_too_short 1)
   endif()
   if(NOT path_too_short)
     string(SUBSTRING "${resolved_embedded_item}" 0 ${exe_dotapp_dir_length} item_substring)
-    if("${exe_dotapp_dir}/" STREQUAL "${item_substring}")
+    if("${exe_dotapp_dir}/" STREQUAL item_substring)
       set(is_embedded 1)
     endif()
   endif()
@@ -568,8 +851,10 @@ function(fixup_bundle_item resolved_embedded_item exepath dirs)
     message(FATAL_ERROR "cannot fixup an item that is not in the bundle...")
   endif()
 
+  set(rpaths "${${ikey}_RPATHS}" "${${ikey}_RDEP_RPATHS}")
+
   set(prereqs "")
-  get_prerequisites("${resolved_embedded_item}" prereqs 1 0 "${exepath}" "${dirs}")
+  get_prerequisites("${resolved_embedded_item}" prereqs 1 0 "${exepath}" "${dirs}" "${rpaths}")
 
   set(changes "")
 
@@ -589,12 +874,42 @@ function(fixup_bundle_item resolved_embedded_item exepath dirs)
     execute_process(COMMAND chmod u+w "${resolved_embedded_item}")
   endif()
 
+  # CMAKE_INSTALL_NAME_TOOL may not be set if executed in script mode
+  # Duplicated from CMakeFindBinUtils.cmake
+  find_program(CMAKE_INSTALL_NAME_TOOL NAMES install_name_tool HINTS ${_CMAKE_TOOLCHAIN_LOCATION})
+
+  # Only if install_name_tool supports -delete_rpath:
+  #
+  execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL}
+      OUTPUT_VARIABLE install_name_tool_usage
+      ERROR_VARIABLE  install_name_tool_usage
+      )
+  if(install_name_tool_usage MATCHES ".*-delete_rpath.*")
+    foreach(rpath ${${ikey}_RPATHS})
+      set(changes ${changes} -delete_rpath "${rpath}")
+    endforeach()
+  endif()
+
+  if(${ikey}_EMBEDDED_ITEM)
+    set(changes ${changes} -id "${${ikey}_EMBEDDED_ITEM}")
+  endif()
+
   # Change this item's id and all of its references in one call
   # to install_name_tool:
   #
-  execute_process(COMMAND install_name_tool
-    ${changes} -id "${${ikey}_EMBEDDED_ITEM}" "${resolved_embedded_item}"
-  )
+  if(changes)
+    # Check for a script by extension (.bat,.sh,...) or if the file starts with "#!" (shebang)
+    file(READ ${resolved_embedded_item} file_contents LIMIT 5)
+    if(NOT "${resolved_embedded_item}" MATCHES "\\.(bat|c?sh|bash|ksh|cmd)$" AND
+        NOT file_contents MATCHES "^#!")
+      set(cmd ${CMAKE_INSTALL_NAME_TOOL} ${changes} "${resolved_embedded_item}")
+      execute_process(COMMAND ${cmd} RESULT_VARIABLE install_name_tool_result)
+      if(NOT install_name_tool_result EQUAL 0)
+        string(REPLACE ";" "' '" msg "'${cmd}'")
+        message(FATAL_ERROR "Command failed:\n ${msg}")
+      endif()
+    endif()
+  endif()
 endfunction()
 
 
@@ -604,12 +919,19 @@ function(fixup_bundle app libs dirs)
   message(STATUS "  libs='${libs}'")
   message(STATUS "  dirs='${dirs}'")
 
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs IGNORE_ITEM)
+  cmake_parse_arguments(CFG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  message(STATUS "  ignoreItems='${CFG_IGNORE_ITEM}'")
+
   get_bundle_and_executable("${app}" bundle executable valid)
   if(valid)
     get_filename_component(exepath "${executable}" PATH)
 
     message(STATUS "fixup_bundle: preparing...")
-    get_bundle_keys("${app}" "${libs}" "${dirs}" keys)
+    get_bundle_keys("${app}" "${libs}" "${dirs}" keys IGNORE_ITEM "${CFG_IGNORE_ITEM}")
 
     message(STATUS "fixup_bundle: copying...")
     list(LENGTH keys n)
@@ -618,7 +940,9 @@ function(fixup_bundle app libs dirs)
     set(i 0)
     foreach(key ${keys})
       math(EXPR i ${i}+1)
-      if(${${key}_COPYFLAG})
+      if("${${key}_COPYFLAG}" STREQUAL "2")
+        message(STATUS "${i}/${n}: linking '${${key}_RESOLVED_ITEM}' -> '${${key}_RESOLVED_EMBEDDED_ITEM}'")
+      elseif(${${key}_COPYFLAG})
         message(STATUS "${i}/${n}: copying '${${key}_RESOLVED_ITEM}'")
       else()
         message(STATUS "${i}/${n}: *NOT* copying '${${key}_RESOLVED_ITEM}'")
@@ -636,14 +960,17 @@ function(fixup_bundle app libs dirs)
         message(STATUS "")
       endif()
 
-      if(${${key}_COPYFLAG})
+      if("${${key}_COPYFLAG}" STREQUAL "2")
+        link_resolved_item_into_bundle("${${key}_RESOLVED_ITEM}"
+            "${${key}_RESOLVED_EMBEDDED_ITEM}")
+      elseif(${${key}_COPYFLAG})
         set(item "${${key}_ITEM}")
         if(item MATCHES "[^/]+\\.framework/")
           copy_resolved_framework_into_bundle("${${key}_RESOLVED_ITEM}"
-            "${${key}_RESOLVED_EMBEDDED_ITEM}")
+              "${${key}_RESOLVED_EMBEDDED_ITEM}")
         else()
           copy_resolved_item_into_bundle("${${key}_RESOLVED_ITEM}"
-            "${${key}_RESOLVED_EMBEDDED_ITEM}")
+              "${${key}_RESOLVED_EMBEDDED_ITEM}")
         endif()
       endif()
     endforeach()
@@ -653,7 +980,9 @@ function(fixup_bundle app libs dirs)
       math(EXPR i ${i}+1)
       if(APPLE)
         message(STATUS "${i}/${n}: fixing up '${${key}_RESOLVED_EMBEDDED_ITEM}'")
-        fixup_bundle_item("${${key}_RESOLVED_EMBEDDED_ITEM}" "${exepath}" "${dirs}")
+        if(NOT "${${key}_COPYFLAG}" STREQUAL "2")
+          fixup_bundle_item("${${key}_RESOLVED_EMBEDDED_ITEM}" "${exepath}" "${dirs}")
+        endif()
       else()
         message(STATUS "${i}/${n}: fix-up not required on this platform '${${key}_RESOLVED_EMBEDDED_ITEM}'")
       endif()
@@ -663,7 +992,7 @@ function(fixup_bundle app libs dirs)
     clear_bundle_keys(keys)
 
     message(STATUS "fixup_bundle: verifying...")
-    verify_app("${app}")
+    verify_app("${app}" IGNORE_ITEM "${CFG_IGNORE_ITEM}")
   else()
     message(SEND_ERROR "error: fixup_bundle: not a valid bundle")
   endif()
@@ -683,19 +1012,26 @@ function(verify_bundle_prerequisites bundle result_var info_var)
   set(info "")
   set(count 0)
 
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs IGNORE_ITEM)
+  cmake_parse_arguments(CFG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
   get_bundle_main_executable("${bundle}" main_bundle_exe)
 
-  file(GLOB_RECURSE file_list "${bundle}/*")
+  get_bundle_all_executables("${bundle}" file_list)
   foreach(f ${file_list})
-    is_file_executable("${f}" is_executable)
-    if(is_executable)
-      get_filename_component(exepath "${f}" PATH)
-      math(EXPR count "${count} + 1")
+    get_filename_component(exepath "${f}" PATH)
+    math(EXPR count "${count} + 1")
 
-      message(STATUS "executable file ${count}: ${f}")
+    message(STATUS "executable file ${count}: ${f}")
 
-      set(prereqs "")
-      get_prerequisites("${f}" prereqs 1 1 "${exepath}" "")
+    set(prereqs "")
+    get_filename_component(prereq_filename ${f} NAME)
+
+    if(NOT prereq_filename IN_LIST CFG_IGNORE_ITEM)
+      get_item_rpaths(${f} _main_exe_rpaths)
+      get_prerequisites("${f}" prereqs 1 1 "${exepath}" "${_main_exe_rpaths}")
 
       # On the Mac,
       # "embedded" and "system" prerequisites are fine... anything else means
@@ -705,6 +1041,7 @@ function(verify_bundle_prerequisites bundle result_var info_var)
       # On Windows (and others? Linux/Unix/...?)
       # "local" and "system" prereqs are fine...
       #
+
       set(external_prereqs "")
 
       foreach(p ${prereqs})
@@ -712,11 +1049,11 @@ function(verify_bundle_prerequisites bundle result_var info_var)
         gp_file_type("${f}" "${p}" p_type)
 
         if(APPLE)
-          if(NOT "${p_type}" STREQUAL "embedded" AND NOT "${p_type}" STREQUAL "system")
+          if(NOT p_type STREQUAL "embedded" AND NOT p_type STREQUAL "system")
             set(external_prereqs ${external_prereqs} "${p}")
           endif()
         else()
-          if(NOT "${p_type}" STREQUAL "local" AND NOT "${p_type}" STREQUAL "system")
+          if(NOT p_type STREQUAL "local" AND NOT p_type STREQUAL "system")
             set(external_prereqs ${external_prereqs} "${p}")
           endif()
         endif()
@@ -727,6 +1064,8 @@ function(verify_bundle_prerequisites bundle result_var info_var)
         set(result 0)
         set(info ${info} "external prerequisites found:\nf='${f}'\nexternal_prereqs='${external_prereqs}'\n")
       endif()
+    else()
+      message(STATUS "Ignoring file: ${prereq_filename}")
     endif()
   endforeach()
 
@@ -756,6 +1095,11 @@ function(verify_app app)
   set(verified 0)
   set(info "")
 
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs IGNORE_ITEM)
+  cmake_parse_arguments(CFG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
   get_bundle_and_executable("${app}" bundle executable valid)
 
   message(STATUS "===========================================================================")
@@ -766,7 +1110,7 @@ function(verify_app app)
 
   # Verify that the bundle does not have any "external" prerequisites:
   #
-  verify_bundle_prerequisites("${bundle}" verified info)
+  verify_bundle_prerequisites("${bundle}" verified info IGNORE_ITEM "${CFG_IGNORE_ITEM}")
   message(STATUS "verified='${verified}'")
   message(STATUS "info='${info}'")
   message(STATUS "")
@@ -784,3 +1128,5 @@ function(verify_app app)
     message(FATAL_ERROR "error: verify_app failed")
   endif()
 endfunction()
+
+cmake_policy(POP)

--- a/cmake/GetPrerequisites.cmake
+++ b/cmake/GetPrerequisites.cmake
@@ -1,136 +1,184 @@
-# - Functions to analyze and list executable file prerequisites.
-# This module provides functions to list the .dll, .dylib or .so
-# files that an executable or shared library file depends on. (Its
-# prerequisites.)
-#
-# It uses various tools to obtain the list of required shared library files:
-#   dumpbin (Windows)
-#   objdump (MinGW on Windows)
-#   ldd (Linux/Unix)
-#   otool (Mac OSX)
-# The following functions are provided by this module:
-#   get_prerequisites
-#   list_prerequisites
-#   list_prerequisites_by_glob
-#   gp_append_unique
-#   is_file_executable
-#   gp_item_default_embedded_path
-#     (projects can override with gp_item_default_embedded_path_override)
-#   gp_resolve_item
-#     (projects can override with gp_resolve_item_override)
-#   gp_resolved_file_type
-#     (projects can override with gp_resolved_file_type_override)
-#   gp_file_type
-# Requires CMake 2.6 or greater because it uses function, break, return and
-# PARENT_SCOPE.
-#
-#  GET_PREREQUISITES(<target> <prerequisites_var> <exclude_system> <recurse>
-#                    <exepath> <dirs>)
-# Get the list of shared library files required by <target>. The list in
-# the variable named <prerequisites_var> should be empty on first entry to
-# this function. On exit, <prerequisites_var> will contain the list of
-# required shared library files.
-#
-# <target> is the full path to an executable file. <prerequisites_var> is the
-# name of a CMake variable to contain the results. <exclude_system> must be 0
-# or 1 indicating whether to include or exclude "system" prerequisites. If
-# <recurse> is set to 1 all prerequisites will be found recursively, if set to
-# 0 only direct prerequisites are listed. <exepath> is the path to the top
-# level executable used for @executable_path replacment on the Mac. <dirs> is
-# a list of paths where libraries might be found: these paths are searched
-# first when a target without any path info is given. Then standard system
-# locations are also searched: PATH, Framework locations, /usr/lib...
-#
-#  LIST_PREREQUISITES(<target> [<recurse> [<exclude_system> [<verbose>]]])
-# Print a message listing the prerequisites of <target>.
-#
-# <target> is the name of a shared library or executable target or the full
-# path to a shared library or executable file. If <recurse> is set to 1 all
-# prerequisites will be found recursively, if set to 0 only direct
-# prerequisites are listed. <exclude_system> must be 0 or 1 indicating whether
-# to include or exclude "system" prerequisites. With <verbose> set to 0 only
-# the full path names of the prerequisites are printed, set to 1 extra
-# informatin will be displayed.
-#
-#  LIST_PREREQUISITES_BY_GLOB(<glob_arg> <glob_exp>)
-# Print the prerequisites of shared library and executable files matching a
-# globbing pattern. <glob_arg> is GLOB or GLOB_RECURSE and <glob_exp> is a
-# globbing expression used with "file(GLOB" or "file(GLOB_RECURSE" to retrieve
-# a list of matching files. If a matching file is executable, its prerequisites
-# are listed.
-#
-# Any additional (optional) arguments provided are passed along as the
-# optional arguments to the list_prerequisites calls.
-#
-#  GP_APPEND_UNIQUE(<list_var> <value>)
-# Append <value> to the list variable <list_var> only if the value is not
-# already in the list.
-#
-#  IS_FILE_EXECUTABLE(<file> <result_var>)
-# Return 1 in <result_var> if <file> is a binary executable, 0 otherwise.
-#
-#  GP_ITEM_DEFAULT_EMBEDDED_PATH(<item> <default_embedded_path_var>)
-# Return the path that others should refer to the item by when the item
-# is embedded inside a bundle.
-#
-# Override on a per-project basis by providing a project-specific
-# gp_item_default_embedded_path_override function.
-#
-#  GP_RESOLVE_ITEM(<context> <item> <exepath> <dirs> <resolved_item_var>)
-# Resolve an item into an existing full path file.
-#
-# Override on a per-project basis by providing a project-specific
-# gp_resolve_item_override function.
-#
-#  GP_RESOLVED_FILE_TYPE(<original_file> <file> <exepath> <dirs> <type_var>)
-# Return the type of <file> with respect to <original_file>. String
-# describing type of prerequisite is returned in variable named <type_var>.
-#
-# Use <exepath> and <dirs> if necessary to resolve non-absolute <file>
-# values -- but only for non-embedded items.
-#
-# Possible types are:
-#   system
-#   local
-#   embedded
-#   other
-# Override on a per-project basis by providing a project-specific
-# gp_resolved_file_type_override function.
-#
-#  GP_FILE_TYPE(<original_file> <file> <type_var>)
-# Return the type of <file> with respect to <original_file>. String
-# describing type of prerequisite is returned in variable named <type_var>.
-#
-# Possible types are:
-#   system
-#   local
-#   embedded
-#   other
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
-#=============================================================================
-# Copyright 2008-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+GetPrerequisites
+----------------
+
+.. deprecated:: 3.16
+
+  Use :command:`file(GET_RUNTIME_DEPENDENCIES)` instead.
+
+Functions to analyze and list executable file prerequisites.
+
+This module provides functions to list the .dll, .dylib or .so files
+that an executable or shared library file depends on.  (Its
+prerequisites.)
+
+It uses various tools to obtain the list of required shared library
+files:
+
+::
+
+   dumpbin (Windows)
+   objdump (MinGW on Windows)
+   ldd (Linux/Unix)
+   otool (Mac OSX)
+
+.. versionchanged:: 3.16
+  The tool specified by ``CMAKE_OBJDUMP`` will be used, if set.
+
+The following functions are provided by this module:
+
+::
+
+   get_prerequisites
+   list_prerequisites
+   list_prerequisites_by_glob
+   gp_append_unique
+   is_file_executable
+   gp_item_default_embedded_path
+     (projects can override with gp_item_default_embedded_path_override)
+   gp_resolve_item
+     (projects can override with gp_resolve_item_override)
+   gp_resolved_file_type
+     (projects can override with gp_resolved_file_type_override)
+   gp_file_type
+
+::
+
+  GET_PREREQUISITES(<target> <prerequisites_var> <exclude_system> <recurse>
+                    <exepath> <dirs> [<rpaths>])
+
+Get the list of shared library files required by <target>.  The list
+in the variable named <prerequisites_var> should be empty on first
+entry to this function.  On exit, <prerequisites_var> will contain the
+list of required shared library files.
+
+<target> is the full path to an executable file.  <prerequisites_var>
+is the name of a CMake variable to contain the results.
+<exclude_system> must be 0 or 1 indicating whether to include or
+exclude "system" prerequisites.  If <recurse> is set to 1 all
+prerequisites will be found recursively, if set to 0 only direct
+prerequisites are listed.  <exepath> is the path to the top level
+executable used for @executable_path replacement on the Mac.  <dirs> is
+a list of paths where libraries might be found: these paths are
+searched first when a target without any path info is given.  Then
+standard system locations are also searched: PATH, Framework
+locations, /usr/lib...
+
+.. versionadded:: 3.14
+  The variable GET_PREREQUISITES_VERBOSE can be set to true to enable verbose
+  output.
+
+::
+
+  LIST_PREREQUISITES(<target> [<recurse> [<exclude_system> [<verbose>]]])
+
+Print a message listing the prerequisites of <target>.
+
+<target> is the name of a shared library or executable target or the
+full path to a shared library or executable file.  If <recurse> is set
+to 1 all prerequisites will be found recursively, if set to 0 only
+direct prerequisites are listed.  <exclude_system> must be 0 or 1
+indicating whether to include or exclude "system" prerequisites.  With
+<verbose> set to 0 only the full path names of the prerequisites are
+printed, set to 1 extra information will be displayed.
+
+::
+
+  LIST_PREREQUISITES_BY_GLOB(<glob_arg> <glob_exp>)
+
+Print the prerequisites of shared library and executable files
+matching a globbing pattern.  <glob_arg> is GLOB or GLOB_RECURSE and
+<glob_exp> is a globbing expression used with "file(GLOB" or
+"file(GLOB_RECURSE" to retrieve a list of matching files.  If a
+matching file is executable, its prerequisites are listed.
+
+Any additional (optional) arguments provided are passed along as the
+optional arguments to the list_prerequisites calls.
+
+::
+
+  GP_APPEND_UNIQUE(<list_var> <value>)
+
+Append <value> to the list variable <list_var> only if the value is
+not already in the list.
+
+::
+
+  IS_FILE_EXECUTABLE(<file> <result_var>)
+
+Return 1 in <result_var> if <file> is a binary executable, 0
+otherwise.
+
+::
+
+  GP_ITEM_DEFAULT_EMBEDDED_PATH(<item> <default_embedded_path_var>)
+
+Return the path that others should refer to the item by when the item
+is embedded inside a bundle.
+
+Override on a per-project basis by providing a project-specific
+gp_item_default_embedded_path_override function.
+
+::
+
+  GP_RESOLVE_ITEM(<context> <item> <exepath> <dirs> <resolved_item_var>
+                  [<rpaths>])
+
+Resolve an item into an existing full path file.
+
+Override on a per-project basis by providing a project-specific
+gp_resolve_item_override function.
+
+::
+
+  GP_RESOLVED_FILE_TYPE(<original_file> <file> <exepath> <dirs> <type_var>
+                        [<rpaths>])
+
+Return the type of <file> with respect to <original_file>.  String
+describing type of prerequisite is returned in variable named
+<type_var>.
+
+Use <exepath> and <dirs> if necessary to resolve non-absolute <file>
+values -- but only for non-embedded items.
+
+Possible types are:
+
+::
+
+   system
+   local
+   embedded
+   other
+
+Override on a per-project basis by providing a project-specific
+gp_resolved_file_type_override function.
+
+::
+
+  GP_FILE_TYPE(<original_file> <file> <type_var>)
+
+Return the type of <file> with respect to <original_file>.  String
+describing type of prerequisite is returned in variable named
+<type_var>.
+
+Possible types are:
+
+::
+
+   system
+   local
+   embedded
+   other
+#]=======================================================================]
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
 function(gp_append_unique list_var value)
-  set(contains 0)
-
-  foreach(item ${${list_var}})
-    if("${item}" STREQUAL "${value}")
-      set(contains 1)
-      break()
-    endif()
-  endforeach()
-
-  if(NOT contains)
+  if(NOT value IN_LIST ${list_var})
     set(${list_var} ${${list_var}} "${value}" PARENT_SCOPE)
   endif()
 endfunction()
@@ -174,9 +222,14 @@ function(is_file_executable file result_var)
 
     if(file_cmd)
       execute_process(COMMAND "${file_cmd}" "${file_full}"
+        RESULT_VARIABLE file_rv
         OUTPUT_VARIABLE file_ov
+        ERROR_VARIABLE file_ev
         OUTPUT_STRIP_TRAILING_WHITESPACE
         )
+      if(NOT file_rv STREQUAL "0")
+        message(FATAL_ERROR "${file_cmd} failed: ${file_rv}\n${file_ev}")
+      endif()
 
       # Replace the name of the file in the output with a placeholder token
       # (the string " _file_full_ ") so that just in case the path name of
@@ -225,7 +278,6 @@ function(gp_item_default_embedded_path item default_embedded_path_var)
   # as the executable by default:
   #
   set(path "@executable_path")
-  set(overridden 0)
 
   # On the Mac, relative to the executable depending on the type
   # of the thing we are embedding:
@@ -244,20 +296,11 @@ function(gp_item_default_embedded_path item default_embedded_path_var)
     #
     set(path "@executable_path/../../Contents/MacOS")
 
-    # Embed .dylibs right next to the main bundle executable:
+    # Embed frameworks and .dylibs in the embedded "Frameworks" directory
+    # (sibling of MacOS):
     #
-    if(item MATCHES "\\.dylib$")
-      set(path "@executable_path/../MacOS")
-      set(overridden 1)
-    endif()
-
-    # Embed frameworks in the embedded "Frameworks" directory (sibling of MacOS):
-    #
-    if(NOT overridden)
-      if(item MATCHES "[^/]+\\.framework/")
-        set(path "@executable_path/../Frameworks")
-        set(overridden 1)
-      endif()
+    if(item MATCHES "[^/]+\\.framework/" OR item MATCHES "\\.dylib$")
+      set(path "@executable_path/../Frameworks")
     endif()
   endif()
 
@@ -275,6 +318,11 @@ endfunction()
 function(gp_resolve_item context item exepath dirs resolved_item_var)
   set(resolved 0)
   set(resolved_item "${item}")
+  if(ARGC GREATER 5)
+    set(rpaths "${ARGV5}")
+  else()
+    set(rpaths "")
+  endif()
 
   # Is it already resolved?
   #
@@ -283,7 +331,7 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
   endif()
 
   if(NOT resolved)
-    if(item MATCHES "@executable_path")
+    if(item MATCHES "^@executable_path")
       #
       # @executable_path references are assumed relative to exepath
       #
@@ -301,7 +349,7 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
   endif()
 
   if(NOT resolved)
-    if(item MATCHES "@loader_path")
+    if(item MATCHES "^@loader_path")
       #
       # @loader_path references are assumed relative to the
       # PATH of the given "context" (presumably another library)
@@ -321,7 +369,7 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
   endif()
 
   if(NOT resolved)
-    if(item MATCHES "@rpath")
+    if(item MATCHES "^@rpath")
       #
       # @rpath references are relative to the paths built into the binaries with -rpath
       # We handle this case like we do for other Unixes
@@ -329,9 +377,9 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
       string(REPLACE "@rpath/" "" norpath_item "${item}")
 
       set(ri "ri-NOTFOUND")
-      find_file(ri "${norpath_item}" ${exepath} ${dirs} NO_DEFAULT_PATH)
+      find_file(ri "${norpath_item}" ${exepath} ${dirs} ${rpaths} NO_DEFAULT_PATH)
       if(ri)
-        #message(STATUS "info: 'find_file' in exepath/dirs (${ri})")
+        #message(STATUS "info: 'find_file' in exepath/dirs/rpaths (${ri})")
         set(resolved 1)
         set(resolved_item "${ri}")
         set(ri "ri-NOTFOUND")
@@ -344,6 +392,11 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
     set(ri "ri-NOTFOUND")
     find_file(ri "${item}" ${exepath} ${dirs} NO_DEFAULT_PATH)
     find_file(ri "${item}" ${exepath} ${dirs} /usr/lib)
+
+    get_filename_component(basename_item "${item}" NAME)
+    find_file(ri "${basename_item}" PATHS ${exepath} ${dirs} NO_DEFAULT_PATH)
+    find_file(ri "${basename_item}" PATHS /usr/lib)
+
     if(ri)
       #message(STATUS "info: 'find_file' in exepath/dirs (${ri})")
       set(resolved 1)
@@ -375,8 +428,8 @@ function(gp_resolve_item context item exepath dirs resolved_item_var)
   if(WIN32 AND NOT UNIX)
   if(NOT resolved)
     set(ri "ri-NOTFOUND")
-    find_program(ri "${item}" PATHS "${exepath};${dirs}" NO_DEFAULT_PATH)
-    find_program(ri "${item}" PATHS "${exepath};${dirs}")
+    find_program(ri "${item}" PATHS ${exepath} ${dirs} NO_DEFAULT_PATH)
+    find_program(ri "${item}" PATHS ${exepath} ${dirs})
     if(ri)
       #message(STATUS "info: 'find_program' in exepath/dirs (${ri})")
       set(resolved 1)
@@ -425,10 +478,18 @@ endfunction()
 
 
 function(gp_resolved_file_type original_file file exepath dirs type_var)
+  if(ARGC GREATER 5)
+    set(rpaths "${ARGV5}")
+  else()
+    set(rpaths "")
+  endif()
   #message(STATUS "**")
 
   if(NOT IS_ABSOLUTE "${original_file}")
     message(STATUS "warning: gp_resolved_file_type expects absolute full path for first arg original_file")
+  endif()
+  if(IS_ABSOLUTE "${original_file}")
+    get_filename_component(original_file "${original_file}" ABSOLUTE) # canonicalize path
   endif()
 
   set(is_embedded 0)
@@ -443,14 +504,17 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
 
   if(NOT is_embedded)
     if(NOT IS_ABSOLUTE "${file}")
-      gp_resolve_item("${original_file}" "${file}" "${exepath}" "${dirs}" resolved_file)
+      gp_resolve_item("${original_file}" "${file}" "${exepath}" "${dirs}" resolved_file "${rpaths}")
+    endif()
+    if(IS_ABSOLUTE "${resolved_file}")
+      get_filename_component(resolved_file "${resolved_file}" ABSOLUTE) # canonicalize path
     endif()
 
     string(TOLOWER "${original_file}" original_lower)
     string(TOLOWER "${resolved_file}" lower)
 
     if(UNIX)
-      if(resolved_file MATCHES "^(/lib/|/lib32/|/lib64/|/usr/lib/|/usr/lib32/|/usr/lib64/|/usr/X11R6/|/usr/bin/)")
+      if(resolved_file MATCHES "^(/lib/|/lib32/|/libx32/|/lib64/|/usr/lib/|/usr/lib32/|/usr/libx32/|/usr/lib64/|/usr/X11R6/|/usr/bin/)")
         set(is_system 1)
       endif()
     endif()
@@ -463,12 +527,12 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
 
     if(WIN32)
       string(TOLOWER "$ENV{SystemRoot}" sysroot)
-      string(REGEX REPLACE "\\\\" "/" sysroot "${sysroot}")
+      file(TO_CMAKE_PATH "${sysroot}" sysroot)
 
       string(TOLOWER "$ENV{windir}" windir)
-      string(REGEX REPLACE "\\\\" "/" windir "${windir}")
+      file(TO_CMAKE_PATH "${windir}" windir)
 
-      if(lower MATCHES "^(${sysroot}/sys(tem|wow)|${windir}/sys(tem|wow)|(.*/)*msvc[^/]+dll)")
+      if(lower MATCHES "^(${sysroot}/sys(tem|wow)|${windir}/sys(tem|wow)|(.*/)*(msvc|api-ms-win-|vcruntime)[^/]+dll)")
         set(is_system 1)
       endif()
 
@@ -478,15 +542,25 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
 
         if(CYGPATH_EXECUTABLE)
           execute_process(COMMAND ${CYGPATH_EXECUTABLE} -W
+                          RESULT_VARIABLE env_rv
                           OUTPUT_VARIABLE env_windir
+                          ERROR_VARIABLE env_ev
                           OUTPUT_STRIP_TRAILING_WHITESPACE)
+          if(NOT env_rv STREQUAL "0")
+            message(FATAL_ERROR "${CYGPATH_EXECUTABLE} -W failed: ${env_rv}\n${env_ev}")
+          endif()
           execute_process(COMMAND ${CYGPATH_EXECUTABLE} -S
+                          RESULT_VARIABLE env_rv
                           OUTPUT_VARIABLE env_sysdir
+                          ERROR_VARIABLE env_ev
                           OUTPUT_STRIP_TRAILING_WHITESPACE)
+          if(NOT env_rv STREQUAL "0")
+            message(FATAL_ERROR "${CYGPATH_EXECUTABLE} -S failed: ${env_rv}\n${env_ev}")
+          endif()
           string(TOLOWER "${env_windir}" windir)
           string(TOLOWER "${env_sysdir}" sysroot)
 
-          if(lower MATCHES "^(${sysroot}/sys(tem|wow)|${windir}/sys(tem|wow)|(.*/)*msvc[^/]+dll)")
+          if(lower MATCHES "^(${sysroot}/sys(tem|wow)|${windir}/sys(tem|wow)|(.*/)*(msvc|api-ms-win-|vcruntime)[^/]+dll)")
             set(is_system 1)
           endif()
         endif()
@@ -496,14 +570,14 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
     if(NOT is_system)
       get_filename_component(original_path "${original_lower}" PATH)
       get_filename_component(path "${lower}" PATH)
-      if("${original_path}" STREQUAL "${path}")
+      if(original_path STREQUAL path)
         set(is_local 1)
       else()
         string(LENGTH "${original_path}/" original_length)
         string(LENGTH "${lower}" path_length)
         if(${path_length} GREATER ${original_length})
           string(SUBSTRING "${lower}" 0 ${original_length} path)
-          if("${original_path}/" STREQUAL "${path}")
+          if("${original_path}/" STREQUAL path)
             set(is_embedded 1)
           endif()
         endif()
@@ -528,7 +602,7 @@ function(gp_resolved_file_type original_file file exepath dirs type_var)
 
   if(NOT is_embedded)
     if(NOT IS_ABSOLUTE "${resolved_file}")
-      if(lower MATCHES "^msvc[^/]+dll" AND is_system)
+      if(lower MATCHES "^(msvc|api-ms-win-|vcruntime)[^/]+dll" AND is_system)
         message(STATUS "info: non-absolute msvc file '${file}' returning type '${type}'")
       else()
         message(STATUS "warning: gp_resolved_file_type non-absolute file '${file}' returning type '${type}' -- possibly incorrect")
@@ -566,6 +640,15 @@ endfunction()
 function(get_prerequisites target prerequisites_var exclude_system recurse exepath dirs)
   set(verbose 0)
   set(eol_char "E")
+  if(ARGC GREATER 6)
+    set(rpaths "${ARGV6}")
+  else()
+    set(rpaths "")
+  endif()
+
+  if(GET_PREREQUISITES_VERBOSE)
+    set(verbose 1)
+  endif()
 
   if(NOT IS_ABSOLUTE "${target}")
     message("warning: target '${target}' is not absolute...")
@@ -573,17 +656,43 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
 
   if(NOT EXISTS "${target}")
     message("warning: target '${target}' does not exist...")
+    return()
+  endif()
+
+  # Check for a script by extension (.bat,.sh,...) or if the file starts with "#!" (shebang)
+  file(READ ${target} file_contents LIMIT 5)
+  if(target MATCHES "\\.(bat|c?sh|bash|ksh|cmd)$" OR file_contents MATCHES "^#!")
+    message(STATUS "GetPrequisites(${target}) : ignoring script file")
+    # Clear var
+    set(${prerequisites_var} "" PARENT_SCOPE)
+    return()
   endif()
 
   set(gp_cmd_paths ${gp_cmd_paths}
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\14.0;InstallDir]/../../VC/bin"
+    "$ENV{VS140COMNTOOLS}/../../VC/bin"
+    "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\12.0;InstallDir]/../../VC/bin"
+    "$ENV{VS120COMNTOOLS}/../../VC/bin"
+    "C:/Program Files (x86)/Microsoft Visual Studio 12.0/VC/bin"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\11.0;InstallDir]/../../VC/bin"
+    "$ENV{VS110COMNTOOLS}/../../VC/bin"
+    "C:/Program Files (x86)/Microsoft Visual Studio 11.0/VC/bin"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\10.0;InstallDir]/../../VC/bin"
+    "$ENV{VS100COMNTOOLS}/../../VC/bin"
+    "C:/Program Files (x86)/Microsoft Visual Studio 10.0/VC/bin"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\9.0;InstallDir]/../../VC/bin"
+    "$ENV{VS90COMNTOOLS}/../../VC/bin"
     "C:/Program Files/Microsoft Visual Studio 9.0/VC/bin"
     "C:/Program Files (x86)/Microsoft Visual Studio 9.0/VC/bin"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\8.0;InstallDir]/../../VC/bin"
+    "$ENV{VS80COMNTOOLS}/../../VC/bin"
     "C:/Program Files/Microsoft Visual Studio 8/VC/BIN"
     "C:/Program Files (x86)/Microsoft Visual Studio 8/VC/BIN"
+    "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\7.1;InstallDir]/../../VC7/bin"
+    "$ENV{VS71COMNTOOLS}/../../VC7/bin"
     "C:/Program Files/Microsoft Visual Studio .NET 2003/VC7/BIN"
     "C:/Program Files (x86)/Microsoft Visual Studio .NET 2003/VC7/BIN"
-    "/usr/local/bin"
-    "/usr/bin"
     )
 
   # <setup-gp_tool-vars>
@@ -591,7 +700,7 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   # Try to choose the right tool by default. Caller can set gp_tool prior to
   # calling this function to force using a different tool.
   #
-  if("${gp_tool}" STREQUAL "")
+  if(NOT gp_tool)
     set(gp_tool "ldd")
 
     if(APPLE)
@@ -602,7 +711,9 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
       find_program(gp_dumpbin "dumpbin" PATHS ${gp_cmd_paths})
       if(gp_dumpbin)
         set(gp_tool "dumpbin")
-      else() # Try harder. Maybe we're on MinGW
+      elseif(CMAKE_OBJDUMP) # Try harder. Maybe we're on MinGW
+        set(gp_tool "${CMAKE_OBJDUMP}")
+      else()
         set(gp_tool "objdump")
       endif()
     endif()
@@ -611,49 +722,48 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   find_program(gp_cmd ${gp_tool} PATHS ${gp_cmd_paths})
 
   if(NOT gp_cmd)
-    message(FATAL_ERROR "FATAL ERROR: could not find '${gp_tool}' - cannot analyze prerequisites!")
+    message(STATUS "warning: could not find '${gp_tool}' - cannot analyze prerequisites...")
     return()
   endif()
 
-  set(gp_tool_known 0)
+  set(gp_cmd_maybe_filter)      # optional command to pre-filter gp_tool results
 
-  if("${gp_tool}" STREQUAL "ldd")
+  if(gp_tool MATCHES "ldd$")
     set(gp_cmd_args "")
-    set(gp_regex "^[\t ]*[^\t ]+ => ([^\t\(]+) .*${eol_char}$")
+    set(gp_regex "^[\t ]*[^\t ]+ =>[\t ]+([^\t\(]+)( \(.+\))?${eol_char}$")
     set(gp_regex_error "not found${eol_char}$")
     set(gp_regex_fallback "^[\t ]*([^\t ]+) => ([^\t ]+).*${eol_char}$")
     set(gp_regex_cmp_count 1)
-    set(gp_tool_known 1)
-  endif()
-
-  if("${gp_tool}" STREQUAL "otool")
+  elseif(gp_tool MATCHES "otool$")
     set(gp_cmd_args "-L")
-    set(gp_regex "^\t([^\t]+) \\(compatibility version ([0-9]+.[0-9]+.[0-9]+), current version ([0-9]+.[0-9]+.[0-9]+)\\)${eol_char}$")
+    set(gp_regex "^\t([^\t]+) \\(compatibility version ([0-9]+.[0-9]+.[0-9]+), current version ([0-9]+.[0-9]+.[0-9]+)(, weak)?\\)${eol_char}$")
     set(gp_regex_error "")
     set(gp_regex_fallback "")
     set(gp_regex_cmp_count 3)
-    set(gp_tool_known 1)
-  endif()
-
-  if("${gp_tool}" STREQUAL "dumpbin")
+  elseif(gp_tool MATCHES "dumpbin$")
     set(gp_cmd_args "/dependents")
     set(gp_regex "^    ([^ ].*[Dd][Ll][Ll])${eol_char}$")
     set(gp_regex_error "")
     set(gp_regex_fallback "")
     set(gp_regex_cmp_count 1)
-    set(gp_tool_known 1)
-  endif()
-
-  if("${gp_tool}" STREQUAL "objdump")
+  elseif(gp_tool MATCHES "objdump(\\.exe)?$")
     set(gp_cmd_args "-p")
     set(gp_regex "^\t*DLL Name: (.*\\.[Dd][Ll][Ll])${eol_char}$")
     set(gp_regex_error "")
     set(gp_regex_fallback "")
     set(gp_regex_cmp_count 1)
-    set(gp_tool_known 1)
-  endif()
-
-  if(NOT gp_tool_known)
+    # objdump generates copious output so we create a grep filter to pre-filter results
+    if(WIN32)
+      find_program(gp_grep_cmd findstr)
+      set(gp_grep_cmd_arg "")
+    else()
+      find_program(gp_grep_cmd grep)
+      set(gp_grep_cmd_arg "-a")
+    endif()
+    if(gp_grep_cmd)
+      set(gp_cmd_maybe_filter COMMAND ${gp_grep_cmd} "${gp_grep_cmd_arg}" "^[[:blank:]]*DLL Name: ")
+    endif()
+  else()
     message(STATUS "warning: gp_tool='${gp_tool}' is an unknown tool...")
     message(STATUS "CMake function get_prerequisites needs more code to handle '${gp_tool}'")
     message(STATUS "Valid gp_tool values are dumpbin, ldd, objdump and otool.")
@@ -661,7 +771,7 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   endif()
 
 
-  if("${gp_tool}" STREQUAL "dumpbin")
+  if(gp_tool MATCHES "dumpbin$")
     # When running dumpbin, it also needs the "Common7/IDE" directory in the
     # PATH. It will already be in the PATH if being run from a Visual Studio
     # command prompt. Add it to the PATH here in case we are running from a
@@ -676,7 +786,7 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
       set(gp_found_cmd_dlls_dir 0)
       file(TO_CMAKE_PATH "$ENV{PATH}" env_path)
       foreach(gp_env_path_element ${env_path})
-        if("${gp_env_path_element}" STREQUAL "${gp_cmd_dlls_dir}")
+        if(gp_env_path_element STREQUAL gp_cmd_dlls_dir)
           set(gp_found_cmd_dlls_dir 1)
         endif()
       endforeach()
@@ -690,11 +800,13 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   #
   # </setup-gp_tool-vars>
 
-  if("${gp_tool}" STREQUAL "ldd")
+  if(gp_tool MATCHES "ldd$")
     set(old_ld_env "$ENV{LD_LIBRARY_PATH}")
-    foreach(dir ${exepath} ${dirs})
-      set(ENV{LD_LIBRARY_PATH} "${dir}:$ENV{LD_LIBRARY_PATH}")
+    set(new_ld_env "${exepath}")
+    foreach(dir ${dirs})
+      string(APPEND new_ld_env ":${dir}")
     endforeach()
+    set(ENV{LD_LIBRARY_PATH} "${new_ld_env}:$ENV{LD_LIBRARY_PATH}")
   endif()
 
 
@@ -707,10 +819,35 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   #
   execute_process(
     COMMAND ${gp_cmd} ${gp_cmd_args} ${target}
+    ${gp_cmd_maybe_filter}
+    RESULT_VARIABLE gp_rv
     OUTPUT_VARIABLE gp_cmd_ov
+    ERROR_VARIABLE gp_ev
     )
 
-  if("${gp_tool}" STREQUAL "ldd")
+  if(gp_tool MATCHES "dumpbin$")
+    # Exclude delay load dependencies under windows (they are listed in dumpbin output after the message below)
+    string(FIND "${gp_cmd_ov}" "Image has the following delay load dependencies" gp_delayload_pos)
+    if (${gp_delayload_pos} GREATER -1)
+      string(SUBSTRING "${gp_cmd_ov}" 0 ${gp_delayload_pos} gp_cmd_ov_no_delayload_deps)
+      string(SUBSTRING "${gp_cmd_ov}" ${gp_delayload_pos} -1 gp_cmd_ov_delayload_deps)
+      if (verbose)
+        message(STATUS "GetPrequisites(${target}) : ignoring the following delay load dependencies :\n ${gp_cmd_ov_delayload_deps}")
+      endif()
+      set(gp_cmd_ov ${gp_cmd_ov_no_delayload_deps})
+    endif()
+  endif()
+
+  if(NOT gp_rv STREQUAL "0")
+    if(gp_tool MATCHES "dumpbin$")
+      # dumpbin error messages seem to go to stdout
+      message(FATAL_ERROR "${gp_cmd} failed: ${gp_rv}\n${gp_ev}\n${gp_cmd_ov}")
+    else()
+      message(FATAL_ERROR "${gp_cmd} failed: ${gp_rv}\n${gp_ev}")
+    endif()
+  endif()
+
+  if(gp_tool MATCHES "ldd$")
     set(ENV{LD_LIBRARY_PATH} "${old_ld_env}")
   endif()
 
@@ -724,17 +861,22 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
 
   # Convert to a list of lines:
   #
-  string(REGEX REPLACE ";" "\\\\;" candidates "${gp_cmd_ov}")
-  string(REGEX REPLACE "\n" "${eol_char};" candidates "${candidates}")
+  string(REPLACE ";" "\\;" candidates "${gp_cmd_ov}")
+  string(REPLACE "\n" "${eol_char};" candidates "${candidates}")
 
   # check for install id and remove it from list, since otool -L can include a
   # reference to itself
   set(gp_install_id)
-  if("${gp_tool}" STREQUAL "otool")
+  if(gp_tool MATCHES "otool$")
     execute_process(
-      COMMAND otool -D ${target}
+      COMMAND ${gp_cmd} -D ${target}
+      RESULT_VARIABLE otool_rv
       OUTPUT_VARIABLE gp_install_id_ov
+      ERROR_VARIABLE otool_ev
       )
+    if(NOT otool_rv STREQUAL "0")
+      message(FATAL_ERROR "otool -D failed: ${otool_rv}\n${otool_ev}")
+    endif()
     # second line is install name
     string(REGEX REPLACE ".*:\n" "" gp_install_id "${gp_install_id_ov}")
     if(gp_install_id)
@@ -780,15 +922,15 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
     #
     set(add_item 1)
 
-    if("${item}" STREQUAL "${gp_install_id}")
+    if(item STREQUAL gp_install_id)
       set(add_item 0)
     endif()
 
     if(add_item AND ${exclude_system})
       set(type "")
-      gp_resolved_file_type("${target}" "${item}" "${exepath}" "${dirs}" type)
+      gp_resolved_file_type("${target}" "${item}" "${exepath}" "${dirs}" type "${rpaths}")
 
-      if("${type}" STREQUAL "system")
+      if(type STREQUAL "system")
         set(add_item 0)
       endif()
     endif()
@@ -807,8 +949,12 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
         # that the analysis tools can simply accept it as input.
         #
         if(NOT list_length_before_append EQUAL list_length_after_append)
-          gp_resolve_item("${target}" "${item}" "${exepath}" "${dirs}" resolved_item)
-          set(unseen_prereqs ${unseen_prereqs} "${resolved_item}")
+          gp_resolve_item("${target}" "${item}" "${exepath}" "${dirs}" resolved_item "${rpaths}")
+          if(EXISTS "${resolved_item}")
+            # Recurse only if we could resolve the item.
+            # Otherwise the prerequisites_var list will be cleared
+            set(unseen_prereqs ${unseen_prereqs} "${resolved_item}")
+          endif()
         endif()
       endif()
     endif()
@@ -826,7 +972,7 @@ function(get_prerequisites target prerequisites_var exclude_system recurse exepa
   if(${recurse})
     set(more_inputs ${unseen_prereqs})
     foreach(input ${more_inputs})
-      get_prerequisites("${input}" ${prerequisites_var} ${exclude_system} ${recurse} "${exepath}" "${dirs}")
+      get_prerequisites("${input}" ${prerequisites_var} ${exclude_system} ${recurse} "${exepath}" "${dirs}" "${rpaths}")
     endforeach()
   endif()
 
@@ -835,22 +981,22 @@ endfunction()
 
 
 function(list_prerequisites target)
-  if("${ARGV1}" STREQUAL "")
-    set(all 1)
-  else()
+  if(ARGC GREATER 1 AND NOT "${ARGV1}" STREQUAL "")
     set(all "${ARGV1}")
+  else()
+    set(all 1)
   endif()
 
-  if("${ARGV2}" STREQUAL "")
-    set(exclude_system 0)
-  else()
+  if(ARGC GREATER 2 AND NOT "${ARGV2}" STREQUAL "")
     set(exclude_system "${ARGV2}")
+  else()
+    set(exclude_system 0)
   endif()
 
-  if("${ARGV3}" STREQUAL "")
-    set(verbose 0)
-  else()
+  if(ARGC GREATER 3 AND NOT "${ARGV3}" STREQUAL "")
     set(verbose "${ARGV3}")
+  else()
+    set(verbose 0)
   endif()
 
   set(count 0)
@@ -900,3 +1046,5 @@ function(list_prerequisites_by_glob glob_arg glob_exp)
     endif()
   endforeach()
 endfunction()
+
+cmake_policy(POP)


### PR DESCRIPTION
Updates `BundleUtilities.cmake` to the version available at https://github.com/Kitware/CMake/blob/master/Modules/BundleUtilities.cmake. Fixes the issue described in #488. Apparently a script from 2009 won't create a bundle structure that's up-to-date.

Alternatively, would it be possible to just remove `BundleUtilities.cmake` (and maybe some other stuff from `cmake/`, like `GetPrerequisites.cmake`) from the repo? It seems to build properly on my machine when they are deleted (I presume it just uses the latest version bundled with cmake or some other developer tools). According to Git history, it seems that they were added for people building on Windows who don't have `dumpbin.exe`. Is this an issue today for people building the program on Windows following the official build instructions?

Edit: Also updated `GetPrerequisites`: `BundleUtilities` depends on `GetPrerequisites`, which made some changes to `get_prerequisites` in an update. It's probably best to update them together.