### PR TITLE
Fix mnemonics that didn't parse

### DIFF
--- a/launcher/ui/pages/global/ExternalToolsPage.ui
+++ b/launcher/ui/pages/global/ExternalToolsPage.ui
@@ -158,6 +158,9 @@
             <property name="text">
              <string>&amp;Text Editor:</string>
             </property>
+            <property name="buddy">
+             <cstring>jsonEditorTextBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="2">

--- a/launcher/ui/pages/global/JavaPage.ui
+++ b/launcher/ui/pages/global/JavaPage.ui
@@ -72,12 +72,18 @@
             <property name="text">
              <string>&amp;Minimum memory allocation:</string>
             </property>
+            <property name="buddy">
+             <cstring>minMemSpinBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="labelMaxMem">
             <property name="text">
              <string>Ma&amp;ximum memory allocation:</string>
+            </property>
+            <property name="buddy">
+             <cstring>maxMemSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -107,6 +113,9 @@
            <widget class="QLabel" name="labelPermGen">
             <property name="text">
              <string notr="true">&amp;PermGen:</string>
+            </property>
+            <property name="buddy">
+             <cstring>permGenSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -152,6 +161,9 @@
             <property name="text">
              <string>&amp;Java path:</string>
             </property>
+            <property name="buddy">
+             <cstring>javaPathTextBox</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1" colspan="2">
@@ -193,6 +205,9 @@
             </property>
             <property name="text">
              <string>J&amp;VM arguments:</string>
+            </property>
+            <property name="buddy">
+             <cstring>jvmArgsTextBox</cstring>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/ProxyPage.ui
+++ b/launcher/ui/pages/global/ProxyPage.ui
@@ -147,12 +147,18 @@
             <property name="text">
              <string>&amp;Username:</string>
             </property>
+            <property name="buddy">
+             <cstring>proxyUserEdit</cstring>
+            </property>
            </widget>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="proxyPasswordLabel">
             <property name="text">
              <string>&amp;Password:</string>
+            </property>
+            <property name="buddy">
+             <cstring>proxyPassEdit</cstring>
             </property>
            </widget>
           </item>

--- a/launcher/ui/widgets/CustomCommands.ui
+++ b/launcher/ui/widgets/CustomCommands.ui
@@ -43,6 +43,9 @@
         <property name="text">
          <string>P&amp;ost-exit command:</string>
         </property>
+        <property name="buddy">
+         <cstring>postExitCmdTextBox</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="1">
@@ -53,6 +56,9 @@
         <property name="text">
          <string>&amp;Pre-launch command:</string>
         </property>
+        <property name="buddy">
+         <cstring>preLaunchCmdTextBox</cstring>
+        </property>
        </widget>
       </item>
       <item row="2" column="1">
@@ -62,6 +68,9 @@
        <widget class="QLabel" name="labelWrapperCmd">
         <property name="text">
          <string>&amp;Wrapper command:</string>
+        </property>
+        <property name="buddy">
+         <cstring>wrapperCmdTextBox</cstring>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Some mnemonics show up with the `&` and don't trigger navigation.

Examples:
![image](https://user-images.githubusercontent.com/768728/165819212-e23ad025-5248-4326-b296-d97bda8cc765.png)
![image](https://user-images.githubusercontent.com/768728/165819241-bc54c0c3-866d-4905-b0fa-71a4290797fb.png)

Introduced in #480