### PR TITLE
CI Speedup [1/3]: Use ccache to speed up CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,13 +65,13 @@ jobs:
             ccache:p
 
       - name: Setup ccache
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && inputs.build_type == 'Debug'
         uses: hendrikmuhs/ccache-action@v1.2.1
         with:
-          key: ${{ matrix.os }}-${{ matrix.appimage }}-${{ inputs.build_type }}
+          key: ${{ matrix.os }}-${{ matrix.appimage }}
 
       - name: Setup ccache (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.build_type == 'Debug'
         shell: msys2 {0}
         run: |
           ccache --set-config=cache_dir='${{ github.workspace }}\.ccache'
@@ -81,13 +81,13 @@ jobs:
           ccache -z  # Zero stats
 
       - name: Retrieve ccache cache (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.build_type == 'Debug'
         uses: actions/cache@v3.0.2
         with:
           path: '${{ github.workspace }}\.ccache'
-          key: ${{ matrix.os }}-${{ matrix.msystem }}-${{ inputs.build_type }}
+          key: ${{ matrix.os }}-${{ matrix.msystem }}
           restore-keys: |
-              ${{ matrix.os }}-${{ matrix.msystem }}-${{ inputs.build_type }}
+              ${{ matrix.os }}-${{ matrix.msystem }}
 
       - name: Set short version
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,32 @@ jobs:
             cmake:p
             ninja:p
             qt5:p
+            ccache:p
+
+      - name: Setup ccache
+        if: runner.os != 'Windows'
+        uses: hendrikmuhs/ccache-action@v1.2.1
+        with:
+          key: ${{ matrix.os }}-${{ matrix.appimage }}-${{ inputs.build_type }}
+
+      - name: Setup ccache (Windows)
+        if: runner.os == 'Windows'
+        shell: msys2 {0}
+        run: |
+          ccache --set-config=cache_dir='${{ github.workspace }}\.ccache'
+          ccache --set-config=max_size='500M'
+          ccache --set-config=compression=true
+          ccache -p  # Show config
+          ccache -z  # Zero stats
+
+      - name: Retrieve ccache cache (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v3.0.2
+        with:
+          path: '${{ github.workspace }}\.ccache'
+          key: ${{ matrix.os }}-${{ matrix.msystem }}-${{ inputs.build_type }}
+          restore-keys: |
+              ${{ matrix.os }}-${{ matrix.msystem }}-${{ inputs.build_type }}
 
       - name: Set short version
         shell: bash
@@ -102,18 +128,18 @@ jobs:
       - name: Configure CMake (macOS)
         if: runner.os == 'macOS'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DQt5_DIR=/usr/local/opt/qt@5 -DCMAKE_PREFIX_PATH=/usr/local/opt/qt@5 -DLauncher_BUILD_PLATFORM=macOS -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DQt5_DIR=/usr/local/opt/qt@5 -DCMAKE_PREFIX_PATH=/usr/local/opt/qt@5 -DLauncher_BUILD_PLATFORM=macOS -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja
 
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
         shell: msys2 {0}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja
 
       - name: Configure CMake (Linux)
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja
 
       ##
       # BUILD


### PR DESCRIPTION
Linux and macOS build very fast with this (<5mins)
Windows i686 build is down from ~40mins to ~25mins
Windows x86_64 builds in ~15mins

First build in this repo will be slow as usual. Once the ccache is uploaded, subsequent builds will be fast.

Closes #501