### PR TITLE
Show "executable" screenshots in the screenshot manager

### DIFF
--- a/launcher/ui/pages/instance/ScreenshotsPage.h
+++ b/launcher/ui/pages/instance/ScreenshotsPage.h
@@ -100,6 +100,7 @@ private slots:
     void on_actionRename_triggered();
     void on_actionView_Folder_triggered();
     void onItemActivated(QModelIndex);
+    void onCurrentSelectionChanged(const QItemSelection &selected);
     void ShowContextMenu(const QPoint &pos);
 
 private:


### PR DESCRIPTION
Closes #517.

`QDir::Filters` is weird. You'd probably expect `setFilter(QDir::Files | QDir::Writable | QDir::Readable)` to show files that are readable and writable. Instead, when used with a `QFileSystemModel`, it shows the following (as tested on macOS, Qt 5.15.2):

* Files that are readable-only
* Files that are writable-only; and
* Files that are both readable and writable

It does **not** show the following:

* Files that are neither readable nor writable; or
* Files that are executable, even if they meet the above criteria (Qt bug? Seems like this behavior is different depending on the circumstance: https://forum.qt.io/topic/92081/want-a-qfiledialog-that-displays-only-executable-files-but-qdir-filter-values-are-used-differently-by-qfiledialog-than-by-qdir-entryinfolist)

Hence, #517.

To fix this, I just filtered for files only, and removed the part about readable and writable. Instead, I enabled/disabled appropriate buttons (i.e. upload, copy image, copy files, rename, delete) depending on whether the selected screenshot(s) were readable or writable. (Before, actions would silently fail if you didn't have the appropriate permission. For example, pressing rename on a readable-only screenshot would do nothing.)