### PR TITLE
Hide temporary directory in instances folder

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -38,6 +38,10 @@
 #include "ExponentialSeries.h"
 #include "WatchLock.h"
 
+#ifdef Q_OS_WIN32
+#include <Windows.h>
+#endif
+
 const static int GROUP_FILE_FORMAT_VERSION = 1;
 
 InstanceList::InstanceList(SettingsObjectPtr settings, const QString & instDir, QObject *parent)
@@ -851,13 +855,18 @@ Task * InstanceList::wrapInstanceTask(InstanceTask * task)
 QString InstanceList::getStagedInstancePath()
 {
     QString key = QUuid::createUuid().toString();
-    QString relPath = FS::PathCombine("_LAUNCHER_TEMP/" , key);
+    QString tempDir = ".LAUNCHER_TEMP/";
+    QString relPath = FS::PathCombine(tempDir, key);
     QDir rootPath(m_instDir);
     auto path = FS::PathCombine(m_instDir, relPath);
     if(!rootPath.mkpath(relPath))
     {
         return QString();
     }
+#ifdef Q_OS_WIN32
+    auto tempPath = FS::PathCombine(m_instDir, tempDir);
+    SetFileAttributesA(tempPath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+#endif
     return path;
 }
 


### PR DESCRIPTION
Closes #524.

Unfortunately, Qt doesn't have any helper functions to hide files/directories (unless I missed it). The name starts with a `.` to hide it on Linux/Mac, and the Windows API is used to hide it on Windows. (https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-setfileattributesa). 