### PR TITLE
Fix Steam overlay on macOS

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>A Minecraft mod wants to access your camera.</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>A Minecraft mod wants to access your microphone.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>A Minecraft mod wants to access your camera.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>A Minecraft mod wants to access your microphone.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/program_info/App.entitlements
+++ b/program_info/App.entitlements
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>

--- a/program_info/App.entitlements
+++ b/program_info/App.entitlements
@@ -2,11 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
-	<true/>
-	<key>com.apple.security.device.camera</key>
-	<true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This adds the `com.apple.security.cs.allow-dyld-environment-variables` entitlement, which is required for the Steam overlay to be injected into Minecraft on macOS. See Steam documentation (https://partner.steamgames.com/doc/store/application/platforms). This is a regression originating from #454. I tested this on my Mac, and Steam overlay appears in-game (tested MC 1.8.9) with this fix.

This does **not** affect #302 – the reporter experienced that issue on Linux, but this PR only affects the macOS build.