### PR TITLE
fix(quilt) always prefer qmj over fmj

### DIFF
--- a/launcher/minecraft/mod/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/LocalModParseTask.cpp
@@ -430,19 +430,6 @@ void LocalModParseTask::processAsZip()
         zip.close();
         return;
     }
-    else if (zip.setCurrentFile("fabric.mod.json"))
-    {
-        if (!file.open(QIODevice::ReadOnly))
-        {
-            zip.close();
-            return;
-        }
-
-        m_result->details = ReadFabricModInfo(file.readAll());
-        file.close();
-        zip.close();
-        return;
-    }
     else if (zip.setCurrentFile("quilt.mod.json"))
     {
         if (!file.open(QIODevice::ReadOnly))
@@ -452,6 +439,19 @@ void LocalModParseTask::processAsZip()
         }
 
         m_result->details = ReadQuiltModInfo(file.readAll());
+        file.close();
+        zip.close();
+        return;
+    }
+    else if (zip.setCurrentFile("fabric.mod.json"))
+    {
+        if (!file.open(QIODevice::ReadOnly))
+        {
+            zip.close();
+            return;
+        }
+
+        m_result->details = ReadFabricModInfo(file.readAll());
         file.close();
         zip.close();
         return;


### PR DESCRIPTION
this fixes Quilt-only mods like ok zoomer showing wrong metadata

before:
<img width="1196" alt="before" src="https://user-images.githubusercontent.com/83089242/169041330-c2fcbc27-7e04-4069-bfae-3f715b90fb29.png">

after: 
<img width="1196" alt="after" src="https://user-images.githubusercontent.com/83089242/169041374-a2de7df8-d9ea-47e9-bcc4-6efb5c9ba3af.png">
 