### PR TITLE
Use empty string when version is null in the Technic pack manifest

### DIFF
--- a/launcher/modplatform/technic/SolderPackManifest.cpp
+++ b/launcher/modplatform/technic/SolderPackManifest.cpp
@@ -37,7 +37,7 @@ void loadPack(Pack& v, QJsonObject& obj)
 static void loadPackBuildMod(PackBuildMod& b, QJsonObject& obj)
 {
     b.name = Json::requireString(obj, "name");
-    b.version = Json::requireString(obj, "version");
+    b.version = Json::ensureString(obj, "version", "");
     b.md5 = Json::requireString(obj, "md5");
     b.url = Json::requireString(obj, "url");
 }


### PR DESCRIPTION
I hope this fixes #591 (Modpacks seem to download fine now, but I hope someone can test whether everything is in it's due place, since I don't really know much about the manifest to be able to tell :< )