### PR TITLE
Support Mojang's new split natives

### DIFF
--- a/launcher/minecraft/GradleSpecifier.h
+++ b/launcher/minecraft/GradleSpecifier.h
@@ -124,7 +124,7 @@ struct GradleSpecifier
     }
     bool matchName(const GradleSpecifier & other) const
     {
-        return other.artifactId() == artifactId() && other.groupId() == groupId();
+        return other.artifactId() == artifactId() && other.groupId() == groupId() && other.classifier() == classifier();
     }
     bool operator==(const GradleSpecifier & other) const
     {


### PR DESCRIPTION
Mojang introduced a new structure for natives, notably for LWJGL.
Now instead of using the `natives` structure of the version format, Mojang
chose to create a seperate library entry for each platform, which uses
the `rules` structure to specify the platform. These new split natives
carry the same groupId and artifactId, as the main library, but have an
additional classifier, like `natives-linux`.

When comparing GradleSpecifiers we don't look at the classifier, so when
the launcher sees an artifact called `org.lwjgl:lwjgl:3.3.1` and right
after that an artifact called `org.lwjgl:lwjgl:3.3.1:natives-linux`, it
will treat it as "already added" and forget it.

This change will include the classifier in that comparison.