### PR TITLE
Refactor ModLoaderType

### DIFF
--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -978,8 +978,10 @@ void PackProfile::disableInteraction(bool disable)
     }
 }
 
-ModAPI::ModLoaderType PackProfile::getModLoader()
+ModAPI::ModLoaderTypes PackProfile::getModLoaders()
 {
+    ModAPI::ModLoaderTypes result = ModAPI::Unspecified;
+
     QMapIterator<QString, ModAPI::ModLoaderType> i(modloaderMapping);
 
     while (i.hasNext())
@@ -987,8 +989,8 @@ ModAPI::ModLoaderType PackProfile::getModLoader()
         i.next();
         Component* c = getComponent(i.key());
         if (c != nullptr && c->isEnabled()) {
-            return i.value();
+            result |= i.value();
         }
     }
-    return ModAPI::Unspecified;
+    return result;
 }

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -36,6 +36,13 @@
 #include "ComponentUpdateTask.h"
 
 #include "Application.h"
+#include "modplatform/ModAPI.h"
+
+static const QMap<QString, ModAPI::ModLoaderType> modloaderMapping{
+    {"net.minecraftforge", ModAPI::Forge},
+    {"net.fabricmc.fabric-loader", ModAPI::Fabric},
+    {"org.quiltmc.quilt-loader", ModAPI::Quilt}
+};
 
 PackProfile::PackProfile(MinecraftInstance * instance)
     : QAbstractListModel()
@@ -973,17 +980,15 @@ void PackProfile::disableInteraction(bool disable)
 
 ModAPI::ModLoaderType PackProfile::getModLoader()
 {
-    if (!getComponentVersion("net.minecraftforge").isEmpty())
+    QMapIterator<QString, ModAPI::ModLoaderType> i(modloaderMapping);
+
+    while (i.hasNext())
     {
-        return ModAPI::Forge;
-    }
-    else if (!getComponentVersion("net.fabricmc.fabric-loader").isEmpty())
-    {
-        return ModAPI::Fabric;
-    }
-    else if (!getComponentVersion("org.quiltmc.quilt-loader").isEmpty())
-    {
-        return ModAPI::Quilt;
+        i.next();
+        Component* c = getComponent(i.key());
+        if (c != nullptr && c->isEnabled()) {
+            return i.value();
+        }
     }
     return ModAPI::Unspecified;
 }

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -118,7 +118,7 @@ public:
     // todo(merged): is this the best approach
     void appendComponent(ComponentPtr component);
 
-    ModAPI::ModLoaderType getModLoader();
+    ModAPI::ModLoaderTypes getModLoaders();
 
 private:
     void scheduleSave();

--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -16,14 +16,21 @@ class ModAPI {
    public:
     virtual ~ModAPI() = default;
 
-    // https://docs.curseforge.com/?http#tocS_ModLoaderType
-    enum ModLoaderType { Unspecified = 0, Forge = 1, Cauldron = 2, LiteLoader = 3, Fabric = 4, Quilt = 5 };
+    enum ModLoaderType {
+        Unspecified = 0,
+        Forge = 1 << 0,
+        Cauldron = 1 << 1,
+        LiteLoader = 1 << 2,
+        Fabric = 1 << 3,
+        Quilt = 1 << 4
+    };
+    Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
 
     struct SearchArgs {
         int offset;
         QString search;
         QString sorting;
-        ModLoaderType mod_loader;
+        ModLoaderTypes loaders;
         std::list<Version> versions;
     };
 
@@ -33,7 +40,7 @@ class ModAPI {
     struct VersionSearchArgs {
         QString addonId;
         std::list<Version> mcVersions;
-        ModLoaderType loader;
+        ModLoaderTypes loaders;
     };
 
     virtual void getVersions(CallerType* caller, VersionSearchArgs&& args) const = 0;

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -37,14 +37,14 @@ class FlameAPI : public NetworkModAPI {
             .arg(args.offset)
             .arg(args.search)
             .arg(getSortFieldInt(args.sorting))
-            .arg(getMappedModLoader(args.mod_loader))
+            .arg(getMappedModLoader(args.loaders))
             .arg(gameVersionStr);
     };
 
     inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {
         QString gameVersionQuery = args.mcVersions.size() == 1 ? QString("gameVersion=%1&").arg(args.mcVersions.front().toString()) : "";
-        QString modLoaderQuery = QString("modLoaderType=%1&").arg(getMappedModLoader(args.loader));
+        QString modLoaderQuery = QString("modLoaderType=%1&").arg(getMappedModLoader(args.loaders));
 
         return QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&%2%3")
             .arg(args.addonId)
@@ -53,11 +53,16 @@ class FlameAPI : public NetworkModAPI {
     };
 
    public:
-    static auto getMappedModLoader(const ModLoaderType type) -> const ModLoaderType
+    static auto getMappedModLoader(const ModLoaderTypes loaders) -> const int
     {
+        // https://docs.curseforge.com/?http#tocS_ModLoaderType
+        if (loaders & Forge)
+            return 1;
+        if (loaders & Fabric)
+            return 4;
         // TODO: remove this once Quilt drops official Fabric support
-        if (type == Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
-            return Fabric;
-        return type;
+        if (loaders & Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
+            return 4;  // Quilt would probably be 5
+        return 0;
     }
 };

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -33,12 +33,12 @@ class ModrinthAPI : public NetworkModAPI {
         QStringList l;
         for (auto loader : {Forge, Fabric, Quilt})
         {
-            if (types & loader || types == Unspecified)
+            if ((types & loader) || types == Unspecified)
             {
                 l << ModAPI::getModLoaderString(loader);
             }
         }
-        if (types & Quilt && ~types & Fabric)  // Add Fabric if Quilt is in use, if Fabric isn't already there
+        if ((types & Quilt) && (~types & Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
             l << ModAPI::getModLoaderString(Fabric);
         return l;
     }
@@ -98,7 +98,7 @@ class ModrinthAPI : public NetworkModAPI {
 
     inline auto validateModLoaders(ModLoaderTypes loaders) const -> bool
     {
-        return loaders == Unspecified || loaders & (Forge | Fabric | Quilt);
+        return (loaders == Unspecified) || (loaders & (Forge | Fabric | Quilt));
     }
 
 };

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -391,7 +391,7 @@ void ModFolderPage::on_actionInstall_mods_triggered()
         return; //this is a null instance or a legacy instance
     }
     auto profile = ((MinecraftInstance *)m_inst)->getPackProfile();
-    if (profile->getModLoader() == ModAPI::Unspecified) {
+    if (profile->getModLoaders() == ModAPI::Unspecified) {
         QMessageBox::critical(this,tr("Error"),tr("Please install a mod loader first!"));
         return;
     }

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -68,7 +68,7 @@ void ListModel::requestModVersions(ModPlatform::IndexedPack const& current)
 {
     auto profile = (dynamic_cast<MinecraftInstance*>((dynamic_cast<ModPage*>(parent()))->m_instance))->getPackProfile();
 
-    m_parent->apiProvider()->getVersions(this, { current.addonId.toString(), getMineVersions(), profile->getModLoader() });
+    m_parent->apiProvider()->getVersions(this, { current.addonId.toString(), getMineVersions(), profile->getModLoaders() });
 }
 
 void ListModel::performPaginatedSearch()
@@ -76,7 +76,7 @@ void ListModel::performPaginatedSearch()
     auto profile = (dynamic_cast<MinecraftInstance*>((dynamic_cast<ModPage*>(parent()))->m_instance))->getPackProfile();
 
     m_parent->apiProvider()->searchMods(
-        this, { nextSearchOffset, currentSearchTerm, getSorts()[currentSort], profile->getModLoader(), getMineVersions() });
+        this, { nextSearchOffset, currentSearchTerm, getSorts()[currentSort], profile->getModLoaders(), getMineVersions() });
 }
 
 void ListModel::refresh()

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -175,7 +175,7 @@ void ModPage::updateModVersions(int prev_count)
         bool valid = false;
         for(auto& mcVer : m_filter->versions){
             //NOTE: Flame doesn't care about loader, so passing it changes nothing.
-            if (validateVersion(version, mcVer.toString(), packProfile->getModLoader())) {
+            if (validateVersion(version, mcVer.toString(), packProfile->getModLoaders())) {
                 valid = true;
                 break;
             }

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -37,7 +37,7 @@ class ModPage : public QWidget, public BasePage {
     void retranslate() override;
 
     auto shouldDisplay() const -> bool override = 0;
-    virtual auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderType loader = ModAPI::Unspecified) const -> bool = 0;
+    virtual auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool = 0;
 
     auto apiProvider() const -> const ModAPI* { return api.get(); };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -61,9 +61,9 @@ FlameModPage::FlameModPage(ModDownloadDialog* dialog, BaseInstance* instance)
     connect(ui->modSelectionButton, &QPushButton::clicked, this, &FlameModPage::onModSelected);
 }
 
-auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderType loader) const -> bool
+auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders) const -> bool
 {
-    Q_UNUSED(loader);
+    Q_UNUSED(loaders);
     return ver.mcVersion.contains(mineVer);
 }
 

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -55,7 +55,7 @@ class FlameModPage : public ModPage {
     inline auto debugName() const -> QString override { return "Flame"; }
     inline auto metaEntryBase() const -> QString override { return "FlameMods"; };
 
-    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderType loader = ModAPI::Unspecified) const -> bool override;
+    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool override;
 
     auto shouldDisplay() const -> bool override;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.cpp
@@ -61,9 +61,9 @@ ModrinthModPage::ModrinthModPage(ModDownloadDialog* dialog, BaseInstance* instan
     connect(ui->modSelectionButton, &QPushButton::clicked, this, &ModrinthModPage::onModSelected);
 }
 
-auto ModrinthModPage::validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderType loader) const -> bool
+auto ModrinthModPage::validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders) const -> bool
 {
-    auto loaderStrings = ModrinthAPI::getModLoaderStrings(loader);
+    auto loaderStrings = ModrinthAPI::getModLoaderStrings(loaders);
 
     auto loaderCompatible = false;
     for (auto remoteLoader : ver.loaders)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.h
@@ -55,7 +55,7 @@ class ModrinthModPage : public ModPage {
     inline auto debugName() const -> QString override { return "Modrinth"; }
     inline auto metaEntryBase() const -> QString override { return "ModrinthPacks"; };
 
-    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderType loader = ModAPI::Unspecified) const -> bool override;
+    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool override;
 
     auto shouldDisplay() const -> bool override;
 };


### PR DESCRIPTION
Closes #508

1. Now only enabled mod loaders are returned by PackProfile::getModLoader()
2. Code around ModLoaderType is now working with [QFlags](https://doc.qt.io/qt-5/qflags.html#details) to allow carrying multiple mod loader types.