### PR TITLE
Get to the point in the COC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,33 +5,17 @@ See commit history to see our changes.
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
-
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+community a harassment-free experience for everyone.
 
 ## Our Standards
-
-Examples of behavior that contributes to a positive environment for our
-community include:
-
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
-  community
 
 Examples of unacceptable behavior include:
 
 * The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling (antagonistic, inflammatory, insincere behaviour), insulting or derogatory comments, and personal or political attacks
+* Harmful, abusive, threatening or offensive conduct
+* Trolling (antagonistic, inflammatory, insincere behaviour), insulting or
+  derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or email address,
   without their explicit permission
@@ -42,29 +26,26 @@ Examples of unacceptable behavior include:
 
 Community leaders are responsible for clarifying and enforcing our standards of
 acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+response to any behavior that they deem unacceptable.
 
 Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+contributions that are not aligned to this Code of Conduct, and will communicate
+reasons for moderation decisions.
 
 ## Scope
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
 Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+posting via an official social media account.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement via email at
-[polymc-enforcement@scrumplex.net](mailto:polymc-enforcement@scrumplex.net) (Email
-address subject to change).
-All complaints will be reviewed and investigated promptly and fairly.
+Instances of unacceptable behavior may be reported to the community leaders
+responsible for enforcement via email at
+[polymc-enforcement@scrumplex.net](mailto:polymc-enforcement@scrumplex.net)
+(Email address subject to change). All complaints will be reviewed and
+investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -81,7 +62,7 @@ unprofessional or unwelcome in the community.
 
 **Consequence**: A private, written warning from community leaders, providing
 clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+behavior was inappropriate.
 
 ### 2. Warning
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ reasons for moderation decisions.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official e-mail address or
 posting via an official social media account.
 
 ## Enforcement


### PR DESCRIPTION
Removes repetitions and other pointless wording that doesn't apply specifically to the PolyMC community. This actually gets to the point about the standards that we expect and how they are enforced.

If you have any feedback please make it known, maybe I missed something or maybe I accidentally deleted something important or maybe I deleted something on purpose and you don't agree with that, please tell me.