### PR TITLE
Launch: Match Vanilla launcher version string behaviour

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -487,9 +488,8 @@ QStringList MinecraftInstance::processMinecraftArgs(
         }
     }
 
-    // blatant self-promotion.
-    token_mapping["profile_name"] = token_mapping["version_name"] = BuildConfig.LAUNCHER_NAME;
-
+    token_mapping["profile_name"] = name();
+    token_mapping["version_name"] = profile->getMinecraftVersion();
     token_mapping["version_type"] = profile->getMinecraftVersionType();
 
     QString absRootDir = QDir(gameRoot()).absolutePath();

--- a/launcher/minecraft/VersionFile.cpp
+++ b/launcher/minecraft/VersionFile.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -55,7 +56,7 @@ void VersionFile::applyTo(LaunchProfile *profile)
     // Only real Minecraft can set those. Don't let anything override them.
     if (isMinecraftVersion(uid))
     {
-        profile->applyMinecraftVersion(minecraftVersion);
+        profile->applyMinecraftVersion(version);
         profile->applyMinecraftVersionType(type);
         // HACK: ignore assets from other version files than Minecraft
         // workaround for stupid assets issue caused by amazon:


### PR DESCRIPTION
This removes a means of profiling users.

---

The commit(s) contained within this pull request have been cherry-picked from my own private fork of MultiMC from circa September 2021.

**For the benefit of PolyMC**: My fork is prior to multiple licences covering the MultiMC codebase, and no longer pulls changes from MultiMC as a result of these developments.

**For the benefit of PolyMC and MultiMC**: I only do development on a PolyMC or MultiMC workspace to resolve merge-conflicts, and to get changes building. No commits are ever cherry-picked onto my fork from a PolyMC or MultiMC workspace - nor between the two in either direction.