### PR TITLE
Remove CurseForge workaround

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -31,21 +31,7 @@ void Flame::FileResolvingTask::netJobFinished()
     for (auto& bytes : results) {
         auto& out = m_toProcess.files[index];
         try {
-            bool fail = (!out.parseFromBytes(bytes));
-            if(fail){
-                //failed :( probably disabled mod, try to add to the list
-                auto doc = Json::requireDocument(bytes);
-                if (!doc.isObject()) {
-                    throw JSONValidationError(QString("data is not an object? that's not supposed to happen"));
-                }
-                auto obj = Json::ensureObject(doc.object(), "data");
-                //FIXME : HACK, MAY NOT WORK FOR LONG
-                out.url = QUrl(QString("https://media.forgecdn.net/files/%1/%2/%3")
-                        .arg(QString::number(QString::number(out.fileId).leftRef(4).toInt())
-                             ,QString::number(QString::number(out.fileId).rightRef(3).toInt())
-                             ,QUrl::toPercentEncoding(out.fileName)), QUrl::TolerantMode);
-            }
-            failed &= fail;
+            failed &= (!out.parseFromBytes(bytes));
         } catch (const JSONValidationError& e) {
             qCritical() << "Resolving of" << out.projectId << out.fileId << "failed because of a parsing error:";
             qCritical() << e.cause();

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -56,15 +56,8 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
         file.fileId = Json::requireInteger(obj, "id");
         file.date = Json::requireString(obj, "fileDate");
         file.version = Json::requireString(obj, "displayName");
+        file.downloadUrl = Json::requireString(obj, "downloadUrl");
         file.fileName = Json::requireString(obj, "fileName");
-        file.downloadUrl = Json::ensureString(obj, "downloadUrl", "");
-        if(file.downloadUrl.isEmpty()){
-            //FIXME : HACK, MAY NOT WORK FOR LONG
-            file.downloadUrl = QString("https://media.forgecdn.net/files/%1/%2/%3")
-                                   .arg(QString::number(QString::number(file.fileId.toInt()).leftRef(4).toInt())
-                                           ,QString::number(QString::number(file.fileId.toInt()).rightRef(3).toInt())
-                                           ,QUrl::toPercentEncoding(file.fileName));
-        }
 
         unsortedVersions.append(file);
     }

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -71,6 +71,11 @@ bool Flame::File::parseFromBytes(const QByteArray& bytes)
 
     fileName = Json::requireString(obj, "fileName");
 
+    QString rawUrl = Json::requireString(obj, "downloadUrl");
+    url = QUrl(rawUrl, QUrl::TolerantMode);
+    if (!url.isValid()) {
+        throw JSONValidationError(QString("Invalid URL: %1").arg(rawUrl));
+    }
     // This is a piece of a Flame project JSON pulled out into the file metadata (here) for convenience
     // It is also optional
     type = File::Type::SingleFile;
@@ -82,17 +87,7 @@ bool Flame::File::parseFromBytes(const QByteArray& bytes)
         // this is probably a mod, dunno what else could modpacks download
         targetFolder = "mods";
     }
-    QString rawUrl = Json::ensureString(obj, "downloadUrl");
 
-    if(rawUrl.isEmpty()){
-        //either there somehow is an emtpy string as a link, or it's null either way it's invalid
-        //soft failing
-        return false;
-    }
-    url = QUrl(rawUrl, QUrl::TolerantMode);
-    if (!url.isValid()) {
-        throw JSONValidationError(QString("Invalid URL: %1").arg(rawUrl));
-    }
     resolved = true;
     return true;
 }


### PR DESCRIPTION
We have been asked by CurseForge to remove this workaround as it violates their terms of service.
This is just a partial revert, as the UI changes were otherwise unrelated.

~~This also closes #611~~