### PR TITLE
More links for CF / Modrinth mods / modpacks

### DIFF
--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -7,6 +7,7 @@
 
 namespace ModPlatform {
 class ListModel;
+struct IndexedPack;
 }
 
 class ModAPI {
@@ -35,6 +36,7 @@ class ModAPI {
     };
 
     virtual void searchMods(CallerType* caller, SearchArgs&& args) const = 0;
+    virtual void getModInfo(CallerType* caller, ModPlatform::IndexedPack& pack) = 0;
 
 
     struct VersionSearchArgs {

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -13,6 +13,12 @@ struct ModpackAuthor {
     QString url;
 };
 
+struct DonationData {
+    QString id;
+    QString platform;
+    QString url;
+};
+
 struct IndexedVersion {
     QVariant addonId;
     QVariant fileId;
@@ -22,6 +28,10 @@ struct IndexedVersion {
     QString date;
     QString fileName;
     QVector<QString> loaders = {};
+};
+
+struct ExtraPackData {
+    QList<DonationData> donate;
 };
 
 struct IndexedPack {
@@ -35,6 +45,10 @@ struct IndexedPack {
 
     bool versionsLoaded = false;
     QVector<IndexedVersion> versions;
+
+    // Don't load by default, since some modplatform don't have that info
+    bool extraDataLoaded = true;
+    ExtraPackData extraData;
 };
 
 }  // namespace ModPlatform

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -32,6 +32,11 @@ struct IndexedVersion {
 
 struct ExtraPackData {
     QList<DonationData> donate;
+
+    QString issuesUrl;
+    QString sourceUrl;
+    QString wikiUrl;
+    QString discordUrl;
 };
 
 struct IndexedPack {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -41,7 +41,10 @@ class FlameAPI : public NetworkModAPI {
             .arg(gameVersionStr);
     };
 
-    inline auto getModInfoURL(QString& id) const -> QString override { return {}; };
+    inline auto getModInfoURL(QString& id) const -> QString override
+    {
+        return QString("https://api.curseforge.com/v1/mods/%1").arg(id);
+    };
 
     inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -41,6 +41,8 @@ class FlameAPI : public NetworkModAPI {
             .arg(gameVersionStr);
     };
 
+    inline auto getModInfoURL(QString& id) const -> QString override { return {}; };
+
     inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {
         QString gameVersionQuery = args.mcVersions.size() == 1 ? QString("gameVersion=%1&").arg(args.mcVersions.front().toString()) : "";

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -25,6 +25,27 @@ void FlameMod::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
         packAuthor.url = Json::requireString(author, "url");
         pack.authors.append(packAuthor);
     }
+
+    loadExtraPackData(pack, obj);
+}
+
+void FlameMod::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& obj)
+{
+    auto links_obj = Json::ensureObject(obj, "links");
+
+    pack.extraData.issuesUrl = Json::ensureString(links_obj, "issuesUrl");
+    if(pack.extraData.issuesUrl.endsWith('/'))
+        pack.extraData.issuesUrl.chop(1);
+
+    pack.extraData.sourceUrl = Json::ensureString(links_obj, "sourceUrl");
+    if(pack.extraData.sourceUrl.endsWith('/'))
+        pack.extraData.sourceUrl.chop(1);
+
+    pack.extraData.wikiUrl = Json::ensureString(links_obj, "wikiUrl");
+    if(pack.extraData.wikiUrl.endsWith('/'))
+        pack.extraData.wikiUrl.chop(1);
+
+    pack.extraDataLoaded = true;
 }
 
 void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,

--- a/launcher/modplatform/flame/FlameModIndex.h
+++ b/launcher/modplatform/flame/FlameModIndex.h
@@ -12,6 +12,7 @@
 namespace FlameMod {
 
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
+void loadExtraPackData(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                              QJsonArray& arr,
                              const shared_qobject_ptr<QNetworkAccessManager>& network,

--- a/launcher/modplatform/flame/FlamePackIndex.cpp
+++ b/launcher/modplatform/flame/FlamePackIndex.cpp
@@ -6,7 +6,6 @@ void Flame::loadIndexedPack(Flame::IndexedPack& pack, QJsonObject& obj)
 {
     pack.addonId = Json::requireInteger(obj, "id");
     pack.name = Json::requireString(obj, "name");
-    pack.websiteUrl = Json::ensureString(Json::ensureObject(obj, "links"), "websiteUrl", "");
     pack.description = Json::ensureString(obj, "summary", "");
 
     auto logo = Json::requireObject(obj, "logo");
@@ -46,6 +45,32 @@ void Flame::loadIndexedPack(Flame::IndexedPack& pack, QJsonObject& obj)
     if (!found) {
         throw JSONValidationError(QString("Pack with no good file, skipping: %1").arg(pack.name));
     }
+
+    loadIndexedInfo(pack, obj);
+}
+
+void Flame::loadIndexedInfo(IndexedPack& pack, QJsonObject& obj)
+{
+    auto links_obj = Json::ensureObject(obj, "links");
+
+    pack.extra.websiteUrl = Json::ensureString(links_obj, "issuesUrl");
+    if(pack.extra.websiteUrl.endsWith('/'))
+        pack.extra.websiteUrl.chop(1);
+
+    pack.extra.issuesUrl = Json::ensureString(links_obj, "issuesUrl");
+    if(pack.extra.issuesUrl.endsWith('/'))
+        pack.extra.issuesUrl.chop(1);
+
+    pack.extra.sourceUrl = Json::ensureString(links_obj, "sourceUrl");
+    if(pack.extra.sourceUrl.endsWith('/'))
+        pack.extra.sourceUrl.chop(1);
+
+    pack.extra.wikiUrl = Json::ensureString(links_obj, "wikiUrl");
+    if(pack.extra.wikiUrl.endsWith('/'))
+        pack.extra.wikiUrl.chop(1);
+
+    pack.extraInfoLoaded = true;
+
 }
 
 void Flame::loadIndexedPackVersions(Flame::IndexedPack& pack, QJsonArray& arr)

--- a/launcher/modplatform/flame/FlamePackIndex.h
+++ b/launcher/modplatform/flame/FlamePackIndex.h
@@ -21,6 +21,13 @@ struct IndexedVersion {
     QString fileName;
 };
 
+struct ModpackExtra {
+    QString websiteUrl;
+    QString wikiUrl;
+    QString issuesUrl;
+    QString sourceUrl;
+};
+
 struct IndexedPack
 {
     int addonId;
@@ -29,13 +36,16 @@ struct IndexedPack
     QList<ModpackAuthor> authors;
     QString logoName;
     QString logoUrl;
-    QString websiteUrl;
 
     bool versionsLoaded = false;
     QVector<IndexedVersion> versions;
+
+    bool extraInfoLoaded = false;
+    ModpackExtra extra;
 };
 
 void loadIndexedPack(IndexedPack & m, QJsonObject & obj);
+void loadIndexedInfo(IndexedPack&, QJsonObject&);
 void loadIndexedPackVersions(IndexedPack & m, QJsonArray & arr);
 }
 

--- a/launcher/modplatform/helpers/NetworkModAPI.h
+++ b/launcher/modplatform/helpers/NetworkModAPI.h
@@ -5,9 +5,11 @@
 class NetworkModAPI : public ModAPI {
    public:
     void searchMods(CallerType* caller, SearchArgs&& args) const override;
+    void getModInfo(CallerType* caller, ModPlatform::IndexedPack& pack) override;
     void getVersions(CallerType* caller, VersionSearchArgs&& args) const override;
 
    protected:
     virtual auto getModSearchURL(SearchArgs& args) const -> QString = 0;
+    virtual auto getModInfoURL(QString& id) const -> QString = 0;
     virtual auto getVersionsURL(VersionSearchArgs& args) const -> QString = 0;
 };

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -75,6 +75,11 @@ class ModrinthAPI : public NetworkModAPI {
             .arg(getGameVersionsArray(args.versions));
     };
 
+    inline auto getModInfoURL(QString& id) const -> QString override
+    {
+        return BuildConfig.MODRINTH_PROD_URL + "/project/" + id;
+    };
+
     inline auto getVersionsURL(VersionSearchArgs& args) const -> QString override
     {
         return QString(BuildConfig.MODRINTH_PROD_URL +

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -52,6 +52,22 @@ void Modrinth::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 
 void Modrinth::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 {
+    pack.extraData.issuesUrl = Json::ensureString(obj, "issues_url");
+    if(pack.extraData.issuesUrl.endsWith('/'))
+        pack.extraData.issuesUrl.chop(1);
+
+    pack.extraData.sourceUrl = Json::ensureString(obj, "source_url");
+    if(pack.extraData.sourceUrl.endsWith('/'))
+        pack.extraData.sourceUrl.chop(1);
+
+    pack.extraData.wikiUrl = Json::ensureString(obj, "wiki_url");
+    if(pack.extraData.wikiUrl.endsWith('/'))
+        pack.extraData.wikiUrl.chop(1);
+
+    pack.extraData.discordUrl = Json::ensureString(obj, "discord_url");
+    if(pack.extraData.discordUrl.endsWith('/'))
+        pack.extraData.discordUrl.chop(1);
+
     auto donate_arr = Json::ensureArray(obj, "donation_urls");
     for(auto d : donate_arr){
         auto d_obj = Json::requireObject(d);

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -45,6 +45,27 @@ void Modrinth::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
     modAuthor.name = Json::requireString(obj, "author");
     modAuthor.url = api.getAuthorURL(modAuthor.name);
     pack.authors.append(modAuthor);
+
+    // Modrinth can have more data than what's provided by the basic search :)
+    pack.extraDataLoaded = false;
+}
+
+void Modrinth::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& obj)
+{
+    auto donate_arr = Json::ensureArray(obj, "donation_urls");
+    for(auto d : donate_arr){
+        auto d_obj = Json::requireObject(d);
+
+        ModPlatform::DonationData donate;
+
+        donate.id = Json::ensureString(d_obj, "id");
+        donate.platform = Json::ensureString(d_obj, "platform");
+        donate.url = Json::ensureString(d_obj, "url");
+
+        pack.extraData.donate.append(donate);
+    }
+
+    pack.extraDataLoaded = true;
 }
 
 void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.h
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.h
@@ -25,6 +25,7 @@
 namespace Modrinth {
 
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
+void loadExtraPackData(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                              QJsonArray& arr,
                              const shared_qobject_ptr<QNetworkAccessManager>& network,

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -62,8 +62,22 @@ void loadIndexedInfo(Modpack& pack, QJsonObject& obj)
 {
     pack.extra.body = Json::ensureString(obj, "body");
     pack.extra.projectUrl = QString("https://modrinth.com/modpack/%1").arg(Json::ensureString(obj, "slug"));
+
+    pack.extra.issuesUrl = Json::ensureString(obj, "issues_url");
+    if(pack.extra.issuesUrl.endsWith('/'))
+        pack.extra.issuesUrl.chop(1);
+
     pack.extra.sourceUrl = Json::ensureString(obj, "source_url");
+    if(pack.extra.sourceUrl.endsWith('/'))
+        pack.extra.sourceUrl.chop(1);
+
     pack.extra.wikiUrl = Json::ensureString(obj, "wiki_url");
+    if(pack.extra.wikiUrl.endsWith('/'))
+        pack.extra.wikiUrl.chop(1);
+
+    pack.extra.discordUrl = Json::ensureString(obj, "discord_url");
+    if(pack.extra.discordUrl.endsWith('/'))
+        pack.extra.discordUrl.chop(1);
 
     auto donate_arr = Json::ensureArray(obj, "donation_urls");
     for(auto d : donate_arr){

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -65,6 +65,19 @@ void loadIndexedInfo(Modpack& pack, QJsonObject& obj)
     pack.extra.sourceUrl = Json::ensureString(obj, "source_url");
     pack.extra.wikiUrl = Json::ensureString(obj, "wiki_url");
 
+    auto donate_arr = Json::ensureArray(obj, "donation_urls");
+    for(auto d : donate_arr){
+        auto d_obj = Json::requireObject(d);
+
+        DonationData donate;
+
+        donate.id = Json::ensureString(d_obj, "id");
+        donate.platform = Json::ensureString(d_obj, "platform");
+        donate.url = Json::ensureString(d_obj, "url");
+
+        pack.extra.donate.append(donate);
+    }
+
     pack.extraInfoLoaded = true;
 }
 

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -58,12 +58,21 @@ struct File
     QUrl download;
 };
 
+struct DonationData {
+    QString id;
+    QString platform;
+    QString url;
+};
+
 struct ModpackExtra {
     QString body;
 
     QString projectUrl;
     QString sourceUrl;
     QString wikiUrl;
+
+    QList<DonationData> donate;
+
 };
 
 struct ModpackVersion {

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -68,8 +68,11 @@ struct ModpackExtra {
     QString body;
 
     QString projectUrl;
+
+    QString issuesUrl;
     QString sourceUrl;
     QString wikiUrl;
+    QString discordUrl;
 
     QList<DonationData> donate;
 

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -79,6 +79,11 @@ void ListModel::performPaginatedSearch()
         this, { nextSearchOffset, currentSearchTerm, getSorts()[currentSort], profile->getModLoaders(), getMineVersions() });
 }
 
+void ListModel::requestModInfo(ModPlatform::IndexedPack& current)
+{
+    m_parent->apiProvider()->getModInfo(this, current);
+}
+
 void ListModel::refresh()
 {
     if (jobPtr) {
@@ -223,6 +228,21 @@ void ListModel::searchRequestFailed(QString reason)
     } else {
         searchState = Finished;
     }
+}
+
+void ListModel::infoRequestFinished(QJsonDocument& doc, ModPlatform::IndexedPack& pack)
+{
+    qDebug() << "Loading mod info";
+
+    try {
+        auto obj = Json::requireObject(doc);
+        loadExtraPackInfo(pack, obj);
+    } catch (const JSONValidationError& e) {
+        qDebug() << doc;
+        qWarning() << "Error while reading " << debugName() << " mod info: " << e.cause();
+    }
+
+    m_parent->updateUi();
 }
 
 void ListModel::versionRequestSucceeded(QJsonDocument doc, QString addonId)

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -36,9 +36,11 @@ class ListModel : public QAbstractListModel {
     void fetchMore(const QModelIndex& parent) override;
     void refresh();
     void searchWithTerm(const QString& term, const int sort, const bool filter_changed);
+    void requestModInfo(ModPlatform::IndexedPack& current);
     void requestModVersions(const ModPlatform::IndexedPack& current);
 
     virtual void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) = 0;
+    virtual void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) {};
     virtual void loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr) = 0;
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
@@ -48,6 +50,8 @@ class ListModel : public QAbstractListModel {
    public slots:
     void searchRequestFinished(QJsonDocument& doc);
     void searchRequestFailed(QString reason);
+
+    void infoRequestFinished(QJsonDocument& doc, ModPlatform::IndexedPack& pack);
 
     void versionRequestSucceeded(QJsonDocument doc, QString addonId);
 

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -216,7 +216,7 @@ void ModPage::updateUi()
     }
 
     if(!current.extraData.donate.isEmpty()) {
-        text += "<br><br>Donation information:<br>";
+        text += tr("<br><br>Donate information:<br>");
         auto donateToStr = [](ModPlatform::DonationData& donate) -> QString {
             return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
         };

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -215,19 +215,38 @@ void ModPage::updateUi()
         text += "<br>" + tr(" by ") + authorStrs.join(", ");
     }
 
-    if(!current.extraData.donate.isEmpty()) {
-        text += tr("<br><br>Donate information:<br>");
-        auto donateToStr = [](ModPlatform::DonationData& donate) -> QString {
-            return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
-        };
-        QStringList donates;
-        for (auto& donate : current.extraData.donate) {
-            donates.append(donateToStr(donate));
+    
+    if(current.extraDataLoaded) {
+        if (!current.extraData.donate.isEmpty()) {
+            text += "<br><br>" + tr("Donate information: ");
+            auto donateToStr = [](ModPlatform::DonationData& donate) -> QString {
+                return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
+            };
+            QStringList donates;
+            for (auto& donate : current.extraData.donate) {
+                donates.append(donateToStr(donate));
+            }
+            text += donates.join(", ");
         }
-        text += donates.join(", ");
+
+        if (!current.extraData.issuesUrl.isEmpty()
+         || !current.extraData.sourceUrl.isEmpty()
+         || !current.extraData.wikiUrl.isEmpty()
+         || !current.extraData.discordUrl.isEmpty()) {
+            text += "<br><br>" + tr("External links:") + "<br>";
+        }
+
+        if (!current.extraData.issuesUrl.isEmpty())
+            text += "- " + tr("Issues: <a href=%1>%1</a>").arg(current.extraData.issuesUrl) + "<br>";
+        if (!current.extraData.wikiUrl.isEmpty())
+            text += "- " + tr("Wiki: <a href=%1>%1</a>").arg(current.extraData.wikiUrl) + "<br>";
+        if (!current.extraData.sourceUrl.isEmpty())
+            text += "- " + tr("Source code: <a href=%1>%1</a>").arg(current.extraData.sourceUrl) + "<br>";
+        if (!current.extraData.discordUrl.isEmpty())
+            text += "- " + tr("Discord: <a href=%1>%1</a>").arg(current.extraData.discordUrl) + "<br>";
     }
 
-    text += "<br><br>";
+    text += "<hr>";
 
     ui->packDescription->setHtml(text + current.description);
 }

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -36,10 +36,12 @@ class ModPage : public QWidget, public BasePage {
 
     void retranslate() override;
 
+    void updateUi();
+
     auto shouldDisplay() const -> bool override = 0;
     virtual auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool = 0;
 
-    auto apiProvider() const -> const ModAPI* { return api.get(); };
+    auto apiProvider() -> ModAPI* { return api.get(); };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
 
     auto getCurrent() -> ModPlatform::IndexedPack& { return current; }

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -119,29 +119,6 @@ void FlamePage::onSelectionChanged(QModelIndex first, QModelIndex second)
     }
 
     current = listModel->data(first, Qt::UserRole).value<Flame::IndexedPack>();
-    QString text = "";
-    QString name = current.name;
-
-    if (current.websiteUrl.isEmpty())
-        text = name;
-    else
-        text = "<a href=\"" + current.websiteUrl + "\">" + name + "</a>";
-    if (!current.authors.empty()) {
-        auto authorToStr = [](Flame::ModpackAuthor& author) {
-            if (author.url.isEmpty()) {
-                return author.name;
-            }
-            return QString("<a href=\"%1\">%2</a>").arg(author.url, author.name);
-        };
-        QStringList authorStrs;
-        for (auto& author : current.authors) {
-            authorStrs.push_back(authorToStr(author));
-        }
-        text += "<br>" + tr(" by ") + authorStrs.join(", ");
-    }
-    text += "<br><br>";
-
-    ui->packDescription->setHtml(text + current.description);
 
     if (current.versionsLoaded == false) {
         qDebug() << "Loading flame modpack versions";
@@ -188,6 +165,8 @@ void FlamePage::onSelectionChanged(QModelIndex first, QModelIndex second)
 
         suggestCurrent();
     }
+
+    updateUi();
 }
 
 void FlamePage::suggestCurrent()
@@ -216,4 +195,47 @@ void FlamePage::onVersionSelectionChanged(QString data)
     }
     selectedVersion = ui->versionSelectionBox->currentData().toString();
     suggestCurrent();
+}
+
+void FlamePage::updateUi()
+{
+    QString text = "";
+    QString name = current.name;
+
+    if (current.extra.websiteUrl.isEmpty())
+        text = name;
+    else
+        text = "<a href=\"" + current.extra.websiteUrl + "\">" + name + "</a>";
+    if (!current.authors.empty()) {
+        auto authorToStr = [](Flame::ModpackAuthor& author) {
+            if (author.url.isEmpty()) {
+                return author.name;
+            }
+            return QString("<a href=\"%1\">%2</a>").arg(author.url, author.name);
+        };
+        QStringList authorStrs;
+        for (auto& author : current.authors) {
+            authorStrs.push_back(authorToStr(author));
+        }
+        text += "<br>" + tr(" by ") + authorStrs.join(", ");
+    }
+
+    if(current.extraInfoLoaded) {
+        if (!current.extra.issuesUrl.isEmpty()
+         || !current.extra.sourceUrl.isEmpty()
+         || !current.extra.wikiUrl.isEmpty()) {
+            text += "<br><br>" + tr("External links:") + "<br>";
+        }
+
+        if (!current.extra.issuesUrl.isEmpty())
+            text += "- " + tr("Issues: <a href=%1>%1</a>").arg(current.extra.issuesUrl) + "<br>";
+        if (!current.extra.wikiUrl.isEmpty())
+            text += "- " + tr("Wiki: <a href=%1>%1</a>").arg(current.extra.wikiUrl) + "<br>";
+        if (!current.extra.sourceUrl.isEmpty())
+            text += "- " + tr("Source code: <a href=%1>%1</a>").arg(current.extra.sourceUrl) + "<br>";
+    }
+
+    text += "<hr>";
+
+    ui->packDescription->setHtml(text + current.description);
 }

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -79,6 +79,8 @@ public:
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 
+    void updateUi();
+
     void openedImpl() override;
 
     bool eventFilter(QObject * watched, QEvent * event) override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModModel.cpp
@@ -30,6 +30,11 @@ void ListModel::loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj)
     Modrinth::loadIndexedPack(m, obj);
 }
 
+void ListModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj)
+{
+    Modrinth::loadExtraPackData(m, obj);
+}
+
 void ListModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
     Modrinth::loadIndexedPackVersions(m, arr, APPLICATION->network(), m_parent->m_instance);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModModel.h
@@ -31,6 +31,7 @@ class ListModel : public ModPlatform::ListModel {
 
    private:
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
+    void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr) override;
     
     auto documentToArray(QJsonDocument& obj) const -> QJsonArray override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -224,6 +224,18 @@ void ModrinthPage::updateUI()
     // TODO: Implement multiple authors with links
     text += "<br>" + tr(" by ") + QString("<a href=%1>%2</a>").arg(std::get<1>(current.author).toString(), std::get<0>(current.author));
 
+    if(!current.extra.donate.isEmpty()) {
+        text += "<br><br>Donation information:<br>";
+        auto donateToStr = [](Modrinth::DonationData& donate) -> QString {
+            return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
+        };
+        QStringList donates;
+        for (auto& donate : current.extra.donate) {
+            donates.append(donateToStr(donate));
+        }
+        text += donates.join(", ");
+    }
+
     text += "<br>";
 
     HoeDown h;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -224,19 +224,37 @@ void ModrinthPage::updateUI()
     // TODO: Implement multiple authors with links
     text += "<br>" + tr(" by ") + QString("<a href=%1>%2</a>").arg(std::get<1>(current.author).toString(), std::get<0>(current.author));
 
-    if(!current.extra.donate.isEmpty()) {
-        text += tr("<br><br>Donate information:<br>");
-        auto donateToStr = [](Modrinth::DonationData& donate) -> QString {
-            return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
-        };
-        QStringList donates;
-        for (auto& donate : current.extra.donate) {
-            donates.append(donateToStr(donate));
+    if(current.extraInfoLoaded) {
+        if (!current.extra.donate.isEmpty()) {
+            text += "<br><br>" + tr("Donate information: ");
+            auto donateToStr = [](Modrinth::DonationData& donate) -> QString {
+                return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
+            };
+            QStringList donates;
+            for (auto& donate : current.extra.donate) {
+                donates.append(donateToStr(donate));
+            }
+            text += donates.join(", ");
         }
-        text += donates.join(", ");
+
+        if (!current.extra.issuesUrl.isEmpty()
+         || !current.extra.sourceUrl.isEmpty()
+         || !current.extra.wikiUrl.isEmpty()
+         || !current.extra.discordUrl.isEmpty()) {
+            text += "<br><br>" + tr("External links:") + "<br>";
+        }
+
+        if (!current.extra.issuesUrl.isEmpty())
+            text += "- " + tr("Issues: <a href=%1>%1</a>").arg(current.extra.issuesUrl) + "<br>";
+        if (!current.extra.wikiUrl.isEmpty())
+            text += "- " + tr("Wiki: <a href=%1>%1</a>").arg(current.extra.wikiUrl) + "<br>";
+        if (!current.extra.sourceUrl.isEmpty())
+            text += "- " + tr("Source code: <a href=%1>%1</a>").arg(current.extra.sourceUrl) + "<br>";
+        if (!current.extra.discordUrl.isEmpty())
+            text += "- " + tr("Discord: <a href=%1>%1</a>").arg(current.extra.discordUrl) + "<br>";
     }
 
-    text += "<br>";
+    text += "<hr>";
 
     HoeDown h;
     text += h.process(current.extra.body.toUtf8());

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -225,7 +225,7 @@ void ModrinthPage::updateUI()
     text += "<br>" + tr(" by ") + QString("<a href=%1>%2</a>").arg(std::get<1>(current.author).toString(), std::get<0>(current.author));
 
     if(!current.extra.donate.isEmpty()) {
-        text += "<br><br>Donation information:<br>";
+        text += tr("<br><br>Donate information:<br>");
         auto donateToStr = [](Modrinth::DonationData& donate) -> QString {
             return QString("<a href=\"%1\">%2</a>").arg(donate.url, donate.platform);
         };


### PR DESCRIPTION
Currently, most devs that stay on CF, and opt-out of third-party access, do so because CF is able to generate them revenue via the points system. Sadly, Modrinth does not yet have Payouts, but my hope is that, through a little more donation incentives, more devs will be able to move to Modrinth.

This adds links for such donate platforms, in the hope of making at least some people go and donate to projects they like on Modrinth (just adding that, as far as I know, the CF API does not provide donate links, else I would have added to them as well).

---

Now this also adds the previously missing links (wiki, issues, etc) as well, on both Modrinth and CF. Still, donation links are on top, and should remain that way going forward! :)