### PR TITLE
Fix modpack icon importing with non-standard icon paths

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -273,7 +273,7 @@ void IconList::installIcons(const QStringList &iconFiles)
         QFileInfo fileinfo(file);
         if (!fileinfo.isReadable() || !fileinfo.isFile())
             continue;
-        QString target = FS::PathCombine(m_dir.dirName(), fileinfo.fileName());
+        QString target = FS::PathCombine(getDirectory(), fileinfo.fileName());
 
         QString suffix = fileinfo.suffix();
         if (suffix != "jpeg" && suffix != "png" && suffix != "jpg" && suffix != "ico" && suffix != "svg" && suffix != "gif")
@@ -290,7 +290,7 @@ void IconList::installIcon(const QString &file, const QString &name)
     if(!fileinfo.isReadable() || !fileinfo.isFile())
         return;
 
-    QString target = FS::PathCombine(m_dir.dirName(), name);
+    QString target = FS::PathCombine(getDirectory(), name);
 
     QFile::copy(file, target);
 }


### PR DESCRIPTION
Closes #287

Before I used PolyMC, I used MultiMC. So, when I set up my folders in the new launcher, I set the instances folder to point to the MultiMC one, but I wanted the mods / icons folders to be the PolyMC ones. So, I ended up with this:
![image](https://user-images.githubusercontent.com/9145768/170697890-470fe26c-e883-4138-b6fb-9dc67a06b552.png)

The problems is that, previously, we used relative paths to get to the icon folder when importing a new icon from a modpack, so it didn't import into my right icon folder, and no icon was imported :(

This fixes it by using the absolute path instead of a relative one, so that icon importing works regardless of the folder you specified :)