### PR TITLE
Update whitelisted hosts in Modrinth modpacks

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -644,11 +644,15 @@ void InstanceImportTask::processModrinth()
 
                 file.download = Json::requireString(Json::ensureArray(modInfo, "downloads").first(), "Download URL for " + file.path);
 
-                if(!file.download.isValid())
+                if (!file.download.isValid()) {
+                    qDebug() << QString("Download URL (%1) for %2 is not a correctly formatted URL").arg(file.download.toString(), file.path);
                     throw JSONValidationError(tr("Download URL for %1 is not a correctly formatted URL").arg(file.path));
-                else if(!Modrinth::validateDownloadUrl(file.download))
+                }
+                else if (!Modrinth::validateDownloadUrl(file.download)) {
+                    qDebug() << QString("Download URL (%1) for %2 is from a non-whitelisted by Modrinth domain").arg(file.download.toString(), file.path);
                     throw JSONValidationError(
                             tr("Download URL for %1 is from a non-whitelisted by Modrinth domain: %2").arg(file.path, file.download.host()));
+                }
 
                 files.push_back(file);
             }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -641,10 +641,15 @@ void InstanceImportTask::processModrinth()
                 file.hashAlgorithm = hashAlgorithm;
                 // Do not use requireUrl, which uses StrictMode, instead use QUrl's default TolerantMode
                 // (as Modrinth seems to incorrectly handle spaces)
+
                 file.download = Json::requireString(Json::ensureArray(modInfo, "downloads").first(), "Download URL for " + file.path);
-                if (!file.download.isValid() || !Modrinth::validateDownloadUrl(file.download)) {
-                    throw JSONValidationError("Download URL for " + file.path + " is not a correctly formatted URL");
-                }
+
+                if(!file.download.isValid())
+                    throw JSONValidationError(tr("Download URL for %1 is not a correctly formatted URL").arg(file.path));
+                else if(!Modrinth::validateDownloadUrl(file.download))
+                    throw JSONValidationError(
+                            tr("Download URL for %1 is from a non-whitelisted by Modrinth domain: %2").arg(file.path, file.download.host()));
+
                 files.push_back(file);
             }
 

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -42,6 +42,8 @@
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 
+#include <QSet>
+
 static ModrinthAPI api;
 
 namespace Modrinth {
@@ -95,17 +97,15 @@ void loadIndexedVersions(Modpack& pack, QJsonDocument& doc)
 
 auto validateDownloadUrl(QUrl url) -> bool
 {
-    auto domain = url.host();
-    if(domain == "cdn.modrinth.com")
-        return true;
-    if(domain == "github.com")
-        return true;
-    if(domain == "raw.githubusercontent.com")
-        return true;
-    if(domain == "gitlab.com")
-        return true;
+    static QSet<QString> domainWhitelist{
+        "cdn.modrinth.com",
+        "github.com",
+        "raw.githubusercontent.com",
+        "gitlab.com"
+    };
 
-    return false;
+    auto domain = url.host();
+    return domainWhitelist.contains(domain);
 }
 
 auto loadIndexedVersion(QJsonObject &obj) -> ModpackVersion

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -102,6 +102,8 @@ auto validateDownloadUrl(QUrl url) -> bool
         return true;
     if(domain == "raw.githubusercontent.com")
         return true;
+    if(domain == "gitlab.com")
+        return true;
 
     return false;
 }

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -98,10 +98,6 @@ auto validateDownloadUrl(QUrl url) -> bool
     auto domain = url.host();
     if(domain == "cdn.modrinth.com")
         return true;
-    if(domain == "edge.forgecdn.net")
-        return true;
-    if(domain == "media.forgecdn.net")
-        return true;
     if(domain == "github.com")
         return true;
     if(domain == "raw.githubusercontent.com")


### PR DESCRIPTION
Due to CF being CF, [Modrinth will disallow direct CDN links from CF](https://blog.modrinth.com/modpack-changes/) in the modpack specification. This removes such support, while addind `gitlab.com` as a new whitelisted host. This also makes it so that non-whitelisted URLs prompt a warning window instead of failing.

Also fixes a missing `tr()` btw :D