### PR TITLE
PackPlatforms: Record where packs come from

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -76,6 +77,14 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
 
     m_settings->registerPassthrough(globalSettings->getSetting("ConsoleMaxLines"), nullptr);
     m_settings->registerPassthrough(globalSettings->getSetting("ConsoleOverflowStop"), nullptr);
+
+    // Managed Packs
+    m_settings->registerSetting("ManagedPack", false);
+    m_settings->registerSetting("ManagedPackType", "");
+    m_settings->registerSetting("ManagedPackID", "");
+    m_settings->registerSetting("ManagedPackName", "");
+    m_settings->registerSetting("ManagedPackVersionID", "");
+    m_settings->registerSetting("ManagedPackVersionName", "");
 }
 
 QString BaseInstance::getPreLaunchCommand()
@@ -91,6 +100,46 @@ QString BaseInstance::getWrapperCommand()
 QString BaseInstance::getPostExitCommand()
 {
     return settings()->get("PostExitCommand").toString();
+}
+
+bool BaseInstance::isManagedPack()
+{
+    return settings()->get("ManagedPack").toBool();
+}
+
+QString BaseInstance::getManagedPackType()
+{
+    return settings()->get("ManagedPackType").toString();
+}
+
+QString BaseInstance::getManagedPackID()
+{
+    return settings()->get("ManagedPackID").toString();
+}
+
+QString BaseInstance::getManagedPackName()
+{
+    return settings()->get("ManagedPackName").toString();
+}
+
+QString BaseInstance::getManagedPackVersionID()
+{
+    return settings()->get("ManagedPackVersionID").toString();
+}
+
+QString BaseInstance::getManagedPackVersionName()
+{
+    return settings()->get("ManagedPackVersionName").toString();
+}
+
+void BaseInstance::setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version)
+{
+    settings()->set("ManagedPack", true);
+    settings()->set("ManagedPackType", type);
+    settings()->set("ManagedPackID", id);
+    settings()->set("ManagedPackName", name);
+    settings()->set("ManagedPackVersionID", versionId);
+    settings()->set("ManagedPackVersionName", version);
 }
 
 int BaseInstance::getConsoleMaxLines() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -138,6 +139,14 @@ public:
     QString getPreLaunchCommand();
     QString getPostExitCommand();
     QString getWrapperCommand();
+
+    bool isManagedPack();
+    QString getManagedPackType();
+    QString getManagedPackID();
+    QString getManagedPackName();
+    QString getManagedPackVersionID();
+    QString getManagedPackVersionName();
+    void setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version);
 
     /// guess log level from a line of game log
     virtual MessageLevel::Enum guessLevel(const QString &line, MessageLevel::Enum level)

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -863,6 +863,7 @@ void PackInstallTask::install()
 
     instance.setName(m_instName);
     instance.setIconKey(m_instIcon);
+    instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
     instanceSettings->resumeSave();
 
     jarmods.clear();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -99,7 +99,7 @@ void PackInstallTask::onDownloadSucceeded()
     QJsonParseError parse_error {};
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ATLauncher at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -60,10 +60,11 @@ namespace ATLauncher {
 
 static Meta::VersionPtr getComponentVersion(const QString& uid, const QString& version);
 
-PackInstallTask::PackInstallTask(UserInteractionSupport *support, QString pack, QString version)
+PackInstallTask::PackInstallTask(UserInteractionSupport *support, QString packName, QString version)
 {
     m_support = support;
-    m_pack = pack;
+    m_pack_name = packName;
+    m_pack_safe_name = packName.replace(QRegularExpression("[^A-Za-z0-9]"), "");
     m_version_name = version;
 }
 
@@ -81,7 +82,7 @@ void PackInstallTask::executeTask()
     qDebug() << "PackInstallTask::executeTask: " << QThread::currentThreadId();
     auto *netJob = new NetJob("ATLauncher::VersionFetch", APPLICATION->network());
     auto searchUrl = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json")
-            .arg(m_pack).arg(m_version_name);
+            .arg(m_pack_safe_name).arg(m_version_name);
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
     jobPtr->start();
@@ -319,7 +320,7 @@ bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared
     auto patchFileName = FS::PathCombine(patchDir, target_id + ".json");
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack + " " + m_version_name + " (libraries)";
+    f->name = m_pack_name + " " + m_version_name + " (libraries)";
 
     const static QMap<QString, QString> liteLoaderMap = {
             { "61179803bcd5fb7790789b790908663d", "1.12-SNAPSHOT" },
@@ -465,7 +466,7 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
     }
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack + " " + m_version_name;
+    f->name = m_pack_name + " " + m_version_name;
     if (!mainClass.isEmpty() && !mainClasses.contains(mainClass)) {
         f->mainClass = mainClass;
     }
@@ -507,9 +508,9 @@ void PackInstallTask::installConfigs()
     setStatus(tr("Downloading configs..."));
     jobPtr = new NetJob(tr("Config download"), APPLICATION->network());
 
-    auto path = QString("Configs/%1/%2.zip").arg(m_pack).arg(m_version_name);
+    auto path = QString("Configs/%1/%2.zip").arg(m_pack_safe_name).arg(m_version_name);
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.zip")
-            .arg(m_pack).arg(m_version_name);
+            .arg(m_pack_safe_name).arg(m_version_name);
     auto entry = APPLICATION->metacache()->resolveEntry("ATLauncherPacks", path);
     entry->setStale(true);
 

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -75,7 +75,7 @@ class PackInstallTask : public InstanceTask
 Q_OBJECT
 
 public:
-    explicit PackInstallTask(UserInteractionSupport *support, QString pack, QString version);
+    explicit PackInstallTask(UserInteractionSupport *support, QString packName, QString version);
     virtual ~PackInstallTask(){}
 
     bool canAbort() const override { return true; }
@@ -117,7 +117,8 @@ private:
     NetJob::Ptr jobPtr;
     QByteArray response;
 
-    QString m_pack;
+    QString m_pack_name;
+    QString m_pack_safe_name;
     QString m_version_name;
     PackVersion m_version;
 

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -1,18 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
 /*
- * Copyright 2020-2021 Jamie Mansfield <jmansfield@cadixdev.org>
- * Copyright 2020-2021 Petr Mrazek <peterix@gmail.com>
+ *  PolyMC - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2020-2021 Jamie Mansfield <jmansfield@cadixdev.org>
+ *      Copyright 2020-2021 Petr Mrazek <peterix@gmail.com>
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
  */
 
 #include "FTBPackInstallTask.h"
@@ -220,6 +239,7 @@ void PackInstallTask::install()
 
     instance.setName(m_instName);
     instance.setIconKey(m_instIcon);
+    instance.setManagedPack("modpacksch", QString::number(m_pack.id), m_pack.name, QString::number(m_version.id), m_version.name);
     instanceSettings->resumeSave();
 
     emitSucceeded();

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -99,7 +99,7 @@ void PackInstallTask::onDownloadSucceeded()
     QJsonParseError parse_error;
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -117,7 +117,7 @@ void AtlPage::suggestCurrent()
         return;
     }
 
-    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ATLauncher::PackInstallTask(this, selected.safeName, selectedVersion));
+    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ATLauncher::PackInstallTask(this, selected.name, selectedVersion));
     auto editedLogoName = selected.safeName;
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/images/%1.png").arg(selected.safeName.toLower());
     listModel->getLogo(selected.safeName, url, [this, editedLogoName](QString logo)

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -122,10 +122,10 @@ void ListModel::requestFinished()
     jobPtr.reset();
     remainingPacks.clear();
 
-    QJsonParseError parse_error;
+    QJsonParseError parse_error {};
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }
@@ -169,7 +169,7 @@ void ListModel::packRequestFinished()
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
 
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }
@@ -184,7 +184,7 @@ void ListModel::packRequestFinished()
     catch (const JSONValidationError &e)
     {
         qDebug() << QString::fromUtf8(response);
-        qWarning() << "Error while reading pack manifest from FTB: " << e.cause();
+        qWarning() << "Error while reading pack manifest from ModpacksCH: " << e.cause();
         return;
     }
 
@@ -192,7 +192,7 @@ void ListModel::packRequestFinished()
     // ignore those "dud" packs.
     if (pack.versions.empty())
     {
-        qWarning() << "FTB Pack " << pack.id << " ignored. reason: lacking any versions";
+        qWarning() << "ModpacksCH Pack " << pack.id << " ignored. reason: lacking any versions";
     }
     else
     {
@@ -270,7 +270,7 @@ void ListModel::requestLogo(QString logo, QString url)
 
     bool stale = entry->isStale();
 
-    NetJob *job = new NetJob(QString("FTB Icon Download %1").arg(logo), APPLICATION->network());
+    NetJob *job = new NetJob(QString("ModpacksCH Icon Download %1").arg(logo), APPLICATION->network());
     job->addNetAction(Net::Download::makeCached(QUrl(url), entry));
 
     auto fullPath = entry->getFullPath();


### PR DESCRIPTION
Here lies some basic changes to support storing pack metadata (for managed packs). This lays the groundwork for supporting updating/reinstalling packs.

Currently metadata is stored for packs installed through ATLauncher and Feed The Beast (ModpacksCH).

---

The commit(s) contained within this pull request have been cherry-picked from my own private fork of MultiMC from circa September 2021.

**For the benefit of PolyMC**: My fork is prior to multiple licences covering the MultiMC codebase, and no longer pulls changes from MultiMC as a result of these developments.

**For the benefit of PolyMC and MultiMC**: I only do development on a PolyMC or MultiMC workspace to resolve merge-conflicts, and to get changes building. No commits are ever cherry-picked onto my fork from a PolyMC or MultiMC workspace - nor between the two in either direction.