### PR TITLE
fix: do not show the "profile select" dialog if the user refused to add an account

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -105,6 +105,11 @@ void LaunchController::decideAccount()
             // Open the account manager.
             APPLICATION->ShowGlobalSettings(m_parentWidget, "accounts");
         }
+        else if (reply == QMessageBox::No)
+        {
+            // Do not open "profile select" dialog.
+            return;
+        }
     }
 
     m_accountToUse = accounts->defaultAccount();


### PR DESCRIPTION
As the title says, but I'm not sure, maybe it's was a feature :thinking: 