### PR TITLE
Add "mc" keyword to desktop file

### DIFF
--- a/program_info/org.polymc.PolyMC.desktop.in
+++ b/program_info/org.polymc.PolyMC.desktop.in
@@ -8,5 +8,5 @@ Exec=@Launcher_APP_BINARY_NAME@
 StartupNotify=true
 Icon=org.polymc.PolyMC
 Categories=Game;
-Keywords=game;minecraft;launcher;
+Keywords=game;minecraft;launcher;mc;
 StartupWMClass=PolyMC


### PR DESCRIPTION
Certain launchers (e.g. GNOME) only search from word boundaries, so typing "mc" doesn't currently match to "PolyMC".