### PR TITLE
Unset Qt High-DPI scaling policy

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -27,10 +27,6 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
-#endif
-
     // initialize Qt
     Application app(argc, argv);
 


### PR DESCRIPTION
Closes #331 

It's causing more issues than what it solves, so let's just revert it and wait for #575 (qt6) to do it properly