### PR TITLE
Add initial sorting function

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -59,26 +59,9 @@ IconList::IconList(const QStringList &builtinPaths, QString path, QObject *paren
 void IconList::sortIconList()
 {
     qDebug() << "Sorting icon list...";
-
-    QVector<MMCIcon> newIcons = QVector<MMCIcon>();
-    QVectorIterator<MMCIcon> iconIter(icons);
-
-iconLoop:
-    while(iconIter.hasNext())
-    {
-        MMCIcon a = iconIter.next();
-        for(int i=0;i<newIcons.size();i++)
-        {
-            if(a.m_key.compare(newIcons[i].m_key) < 0)
-            {
-                newIcons.insert(i,a);
-                goto iconLoop;
-            }
-        }
-        newIcons.append(a);
-    }
-
-    icons = newIcons;
+    std::sort(icons.begin(), icons.end(), [](const MMCIcon& a, const MMCIcon& b) {
+        return a.m_key.compare(b.m_key) < 0;
+    });
     reindex();
 }
 

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -56,6 +56,32 @@ IconList::IconList(const QStringList &builtinPaths, QString path, QObject *paren
     emit iconUpdated({});
 }
 
+void IconList::sortIconList()
+{
+    qDebug() << "Sorting icon list...";
+
+    QVector<MMCIcon> newIcons = QVector<MMCIcon>();
+    QVectorIterator<MMCIcon> iconIter(icons);
+
+iconLoop:
+    while(iconIter.hasNext())
+    {
+        MMCIcon a = iconIter.next();
+        for(int i=0;i<newIcons.size();i++)
+        {
+            if(a.m_key.compare(newIcons[i].m_key) < 0)
+            {
+                newIcons.insert(i,a);
+                goto iconLoop;
+            }
+        }
+        newIcons.append(a);
+    }
+
+    icons = newIcons;
+    reindex();
+}
+
 void IconList::directoryChanged(const QString &path)
 {
     QDir new_dir (path);
@@ -141,6 +167,8 @@ void IconList::directoryChanged(const QString &path)
             emit iconUpdated(key);
         }
     }
+
+    sortIconList();
 }
 
 void IconList::fileChanged(const QString &path)

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -60,7 +60,7 @@ void IconList::sortIconList()
 {
     qDebug() << "Sorting icon list...";
     std::sort(icons.begin(), icons.end(), [](const MMCIcon& a, const MMCIcon& b) {
-        return a.m_key.compare(b.m_key) < 0;
+        return a.m_key.localeAwareCompare(b.m_key) < 0;
     });
     reindex();
 }

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -71,6 +71,7 @@ private:
     // hide assign op
     IconList &operator=(const IconList &) = delete;
     void reindex();
+    void sortIconList();
 
 public slots:
     void directoryChanged(const QString &path);


### PR DESCRIPTION
Fixes #691 
Added a function `void IconList::sortIconList()` to sort all the icons by their `m_key` value using insertion sort (maybe a better sorting algorithm could be used?).
This is called at the end of `IconList::directoryChanged(const QString &path)` to update the order of icons to make them easier to find.