### PR TITLE
nix: add package argument for extra jdks

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,6 +14,7 @@
 , quazip
 , libGL
 , msaClientID ? ""
+, extraJDKs ? [ ]
 
   # flake
 , self
@@ -36,6 +37,8 @@ let
 
   # This variable will be passed to Minecraft by PolyMC
   gameLibraryPath = libpath + ":/run/opengl-driver/lib";
+
+  javaPaths = lib.makeSearchPath "bin/java" ([ jdk jdk8 ] ++ extraJDKs);
 in
 
 stdenv.mkDerivation rec {
@@ -67,7 +70,7 @@ stdenv.mkDerivation rec {
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapQtApp $out/bin/polymc \
       --set GAME_LIBRARY_PATH ${gameLibraryPath} \
-      --prefix POLYMC_JAVA_PATHS : ${jdk}/lib/openjdk/bin/java:${jdk8}/lib/openjdk/bin/java \
+      --prefix POLYMC_JAVA_PATHS : ${javaPaths} \
       --prefix PATH : ${lib.makeBinPath [ xorg.xrandr ]}
   '';
 


### PR DESCRIPTION
Provides a better way to add different jdks that some mod packs require.
In the overlay in my flake this looks like 
```
polymc = polymc.packages.${system}.default.override { extraJDKs = [ pkgs.zulu8 ]; };
```