### PR TITLE
Fix some Modrinth `mrpack` import issues

### DIFF
--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -124,4 +124,8 @@ QString getDesktopDir();
 // call it *name* and assign it the icon *icon*
 // return true if operation succeeded
 bool createShortCut(QString location, QString dest, QStringList args, QString name, QString iconLocation);
+
+// Overrides one folder with the contents of another, preserving items exclusive to the first folder
+// Equivalent to doing QDir::rename, but allowing for overrides
+bool overrideFolder(QString overwritten_path, QString override_path);
 }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -744,7 +744,7 @@ void InstanceImportTask::processModrinth()
     {
         auto path = FS::PathCombine(m_stagingPath, ".minecraft", file.path);
         qDebug() << "Will try to download" << file.downloads.front() << "to" << path;
-        auto dl = Net::Download::makeFile(file.downloads.front(), path);
+        auto dl = Net::Download::makeFile(file.downloads.dequeue(), path);
         dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
         m_filesNetJob->addNetAction(dl);
 

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -696,12 +696,22 @@ void InstanceImportTask::processModrinth()
         emitFailed(tr("Could not understand pack index:\n") + e.cause());
         return;
     }
+    
+    auto mcPath = FS::PathCombine(m_stagingPath, ".minecraft");
 
-    QString overridePath = FS::PathCombine(m_stagingPath, "overrides");
-    if (QFile::exists(overridePath)) {
-        QString mcPath = FS::PathCombine(m_stagingPath, ".minecraft");
-        if (!QFile::rename(overridePath, mcPath)) {
+    auto override_path = FS::PathCombine(m_stagingPath, "overrides");
+    if (QFile::exists(override_path)) {
+        if (!QFile::rename(override_path, mcPath)) {
             emitFailed(tr("Could not rename the overrides folder:\n") + "overrides");
+            return;
+        }
+    }
+
+    // Do client overrides
+    auto client_override_path = FS::PathCombine(m_stagingPath, "client-overrides");
+    if (QFile::exists(client_override_path)) {
+        if (!FS::overrideFolder(mcPath, client_override_path)) {
+            emitFailed(tr("Could not rename the client overrides folder:\n") + "client overrides");
             return;
         }
     }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -748,7 +748,7 @@ void InstanceImportTask::processModrinth()
         dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
         m_filesNetJob->addNetAction(dl);
 
-        if (file.downloads.size() > 1) {
+        if (file.downloads.size() > 0) {
             // FIXME: This really needs to be put into a ConcurrentTask of
             // MultipleOptionsTask's , once those exist :)
             connect(dl.get(), &NetAction::failed, [this, &file, path, dl]{

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -95,19 +95,6 @@ void loadIndexedVersions(Modpack& pack, QJsonDocument& doc)
     pack.versionsLoaded = true;
 }
 
-auto validateDownloadUrl(QUrl url) -> bool
-{
-    static QSet<QString> domainWhitelist{
-        "cdn.modrinth.com",
-        "github.com",
-        "raw.githubusercontent.com",
-        "gitlab.com"
-    };
-
-    auto domain = url.host();
-    return domainWhitelist.contains(domain);
-}
-
 auto loadIndexedVersion(QJsonObject &obj) -> ModpackVersion
 {
     ModpackVersion file;
@@ -136,9 +123,6 @@ auto loadIndexedVersion(QJsonObject &obj) -> ModpackVersion
         }
 
         auto url = Json::requireString(parent, "url");
-
-        if(!validateDownloadUrl(url))
-            continue;
 
         file.download_url = url;
         if(is_primary)

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -40,6 +40,7 @@
 
 #include <QByteArray>
 #include <QCryptographicHash>
+#include <QQueue>
 #include <QString>
 #include <QUrl>
 #include <QVector>
@@ -48,14 +49,12 @@ class MinecraftInstance;
 
 namespace Modrinth {
 
-struct File
-{
+struct File {
     QString path;
 
     QCryptographicHash::Algorithm hashAlgorithm;
     QByteArray hash;
-    // TODO: should this support multiple download URLs, like the JSON does?
-    QUrl download;
+    QQueue<QUrl> downloads;
 };
 
 struct ModpackExtra {


### PR DESCRIPTION
Closes #766 (but CC @DioEgizio test this to be sure, please :p)

Actually, most modpacks weren't working because we were considering the `env` field to be required, but it's optional x.x

The download array is now properly parsed as well, though trying to use the secondary downloads in case the first fails is :pofat: tech :tm:, since we don't **yet** have the proper task mechanisms to do it right (those are being worked on ;) )

This removes the whitelisted hosts check, since people didn't like it and it was causing some issues trying to integrate with multiple download urls anyways
 
 Lastly, this fixes an issue where client overrides where not taken into consideration when importing `mrpack`s!