### PR TITLE
Fix mrpack manual import in languages that don't use dots

### DIFF
--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -110,11 +110,13 @@ void ImportPage::updateState()
         {
             // FIXME: actually do some validation of what's inside here... this is fake AF
             QFileInfo fi(input);
-            // mrpack is a modrinth pack
 
             // Allow non-latin people to use ZIP files!
-            auto zip = QMimeDatabase().mimeTypeForUrl(url).suffixes().contains("zip");
-            if(fi.exists() && (zip || fi.suffix() == "mrpack" || fi.fileName().endsWith("mrpack")))
+            bool isZip = QMimeDatabase().mimeTypeForUrl(url).suffixes().contains("zip");
+            // mrpack is a modrinth pack
+            bool isMRPack = fi.suffix() == "mrpack";
+
+            if(fi.exists() && (isZip || isMRPack))
             {
                 QFileInfo fi(url.fileName());
                 dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url,this));
@@ -149,7 +151,8 @@ void ImportPage::setUrl(const QString& url)
 void ImportPage::on_modpackBtn_clicked()
 {
     auto filter = QMimeDatabase().mimeTypeForName("application/zip").filterString();
-    filter += ";;" + tr("Modrinth pack (*.mrpack *mrpack)");
+    //: Option for filtering for *.mrpack files when importing
+    filter += ";;" + tr("Modrinth pack") + " (*.mrpack)";
     const QUrl url = QFileDialog::getOpenFileUrl(this, tr("Choose modpack"), modpackUrl(), filter);
     if (url.isValid())
     {

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -114,7 +114,7 @@ void ImportPage::updateState()
 
             // Allow non-latin people to use ZIP files!
             auto zip = QMimeDatabase().mimeTypeForUrl(url).suffixes().contains("zip");
-            if(fi.exists() && (zip || fi.suffix() == "mrpack"))
+            if(fi.exists() && (zip || fi.suffix() == "mrpack" || fi.fileName().endsWith("mrpack")))
             {
                 QFileInfo fi(url.fileName());
                 dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url,this));
@@ -149,7 +149,7 @@ void ImportPage::setUrl(const QString& url)
 void ImportPage::on_modpackBtn_clicked()
 {
     auto filter = QMimeDatabase().mimeTypeForName("application/zip").filterString();
-    filter += ";;" + tr("Modrinth pack (*.mrpack)");
+    filter += ";;" + tr("Modrinth pack (*.mrpack *mrpack)");
     const QUrl url = QFileDialog::getOpenFileUrl(this, tr("Choose modpack"), modpackUrl(), filter);
     if (url.isValid())
     {


### PR DESCRIPTION
Closes #777

I tried going directly with the specified mimetype ([`application/x-modrinth-modpack+zip`](https://docs.modrinth.com/docs/modpacks/format_definition/#storage)), but it didn't work :c