### PR TITLE
Improvements to default Windows installer behavior

### DIFF
--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -245,6 +245,7 @@ Function .onInit
 ${GetParameters} $R0
 ${GetOptions} $R0 "/NoShortcuts" $R1
 ${IfNot} ${Errors}
+${OrIf} ${FileExists} "$InstDir\@Launcher_APP_BINARY_NAME@.exe"
   !insertmacro UnselectSection ${SM_SHORTCUTS}
   !insertmacro UnselectSection ${DESKTOP_SHORTCUTS}
 ${EndIf}

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -157,7 +157,7 @@ Section "Start Menu Shortcut" SM_SHORTCUTS
 
 SectionEnd
 
-Section "Desktop Shortcut" DESKTOP_SHORTCUTS
+Section /o "Desktop Shortcut" DESKTOP_SHORTCUTS
 
   CreateShortcut "$DESKTOP\@Launcher_CommonName@.lnk" "$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "" "$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" 0
 


### PR DESCRIPTION
Closes #730 by deselecting the options to install shortcuts by default when PolyMC is already installed (as determined by detecting a `polymc.exe`). Typically, running the installer when PolyMC is already installed means you want to do an update, and there's no need to reinstall these shortcuts (and doing so will annoy a user who originally elected not to install them).

Additionally, this also deselects the desktop shortcut by default to follow [Microsoft's guidelines](https://docs.microsoft.com/en-us/windows/win32/uxguide/winenv-desktop) and simply be less annoying.

~(Untested, I'm planning to test this tomorrow)~ works on my machine