### PR TITLE
Hide channel from version for tagged commits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,9 +136,11 @@ set(Launcher_CURSEFORGE_API_KEY "$2a$10$1Oqr2MX3O4n/ilhFGc597u8tfI3L2Hyr9/rtWDAM
 
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)
+git_get_exact_tag(Launcher_GIT_TAG)
 get_git_head_revision(Launcher_GIT_REFSPEC Launcher_GIT_COMMIT)
 
 message(STATUS "Git commit: ${Launcher_GIT_COMMIT}")
+message(STATUS "Git tag: ${Launcher_GIT_TAG}")
 message(STATUS "Git refspec: ${Launcher_GIT_REFSPEC}")
 
 set(Launcher_RELEASE_VERSION_NAME "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_HOTFIX}")

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -115,7 +115,7 @@ QString Config::printableVersionString() const
     // if a build number is set, also add it to the end
     if(VERSION_BUILD >= 0)
     {
-        vstr += "-" + QString::number(VERSION_BUILD);
+        vstr += "+build." + QString::number(VERSION_BUILD);
     }
     return vstr;
 }

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -64,12 +64,16 @@ Config::Config()
     GIT_COMMIT = "@Launcher_GIT_COMMIT@";
     GIT_TAG = "@Launcher_GIT_TAG@";
     GIT_REFSPEC = "@Launcher_GIT_REFSPEC@";
+
+    // Assume that builds outside of Git repos are "stable"
     if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND")
-        || GIT_TAG == QStringLiteral("-128-NOTFOUND"))
+        || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND"))
     {
-        VERSION_CHANNEL = QStringLiteral("stable");
+        GIT_REFSPEC = "refs/heads/stable";
+        GIT_TAG = versionString();
     }
-    else if(GIT_REFSPEC.startsWith("refs/heads/"))
+
+    if (GIT_REFSPEC.startsWith("refs/heads/"))
     {
         VERSION_CHANNEL = GIT_REFSPEC;
         VERSION_CHANNEL.remove("refs/heads/");
@@ -83,7 +87,7 @@ Config::Config()
     }
     else
     {
-        VERSION_CHANNEL = QObject::tr("unknown");
+        VERSION_CHANNEL = "unknown";
     }
 
     VERSION_STR = "@Launcher_VERSION_STRING@";
@@ -102,9 +106,14 @@ Config::Config()
     SUBREDDIT_URL = "@Launcher_SUBREDDIT_URL@";
 }
 
+QString Config::versionString() const
+{
+    return QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_HOTFIX);
+}
+
 QString Config::printableVersionString() const
 {
-    QString vstr = QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_HOTFIX);
+    QString vstr = versionString();
 
     // If the build is not a main release, append the channel
     if(VERSION_CHANNEL != "stable" && GIT_TAG != vstr)

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -62,8 +62,10 @@ Config::Config()
     UPDATER_BASE = "@Launcher_UPDATER_BASE@";
 
     GIT_COMMIT = "@Launcher_GIT_COMMIT@";
+    GIT_TAG = "@Launcher_GIT_TAG@";
     GIT_REFSPEC = "@Launcher_GIT_REFSPEC@";
-    if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND"))
+    if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND")
+        || GIT_TAG == QStringLiteral("-128-NOTFOUND"))
     {
         VERSION_CHANNEL = QStringLiteral("stable");
     }

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -104,10 +104,10 @@ Config::Config()
 
 QString Config::printableVersionString() const
 {
-    QString vstr = QString("%1.%2.%3").arg(QString::number(VERSION_MAJOR), QString::number(VERSION_MINOR), QString::number(VERSION_HOTFIX));
+    QString vstr = QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_HOTFIX);
 
     // If the build is not a main release, append the channel
-    if(VERSION_CHANNEL != "stable")
+    if(VERSION_CHANNEL != "stable" && GIT_TAG != vstr)
     {
         vstr += "-" + VERSION_CHANNEL;
     }

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -83,6 +83,9 @@ class Config {
     /// The git commit hash of this build
     QString GIT_COMMIT;
 
+    /// The git tag of this build
+    QString GIT_TAG;
+
     /// The git refspec of this build
     QString GIT_REFSPEC;
 

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -157,6 +157,7 @@ class Config {
     QString MODRINTH_STAGING_URL = "https://staging-api.modrinth.com/v2";
     QString MODRINTH_PROD_URL = "https://api.modrinth.com/v2";
 
+    QString versionString() const;
     /**
      * \brief Converts the Version to a string.
      * \return The version number in string format (major.minor.revision.build).

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -3,7 +3,7 @@
 # These functions force a re-configure on each git commit so that you can
 # trust the values of the variables in your build system.
 #
-#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#  get_git_head_revision(<refspecvar> <hashvar> [ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR])
 #
 # Returns the refspec and sha hash of the current head revision
 #
@@ -12,20 +12,33 @@
 # Returns the results of git describe on the source tree, and adjusting
 # the output so that it tests false if an error occurs.
 #
+#  git_describe_working_tree(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the working tree (--dirty option),
+# and adjusting the output so that it tests false if an error occurs.
+#
 #  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
 #
 # Returns the results of git describe --exact-match on the source tree,
 # and adjusting the output so that it tests false if there was no exact
 # matching tag.
 #
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
 # Requires CMake 2.6 or newer (uses the 'function' command)
 #
 # Original Author:
-# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# 2009-2020 Ryan Pavlik <ryan.pavlik@gmail.com> <abiryan@ryand.net>
 # http://academic.cleardefinition.com
-# Iowa State University HCI Graduate Program/VRAC
 #
-# Copyright Iowa State University 2009-2010.
+# Copyright 2009-2013, Iowa State University.
+# Copyright 2013-2020, Ryan Pavlik
+# Copyright 2013-2020, Contributors
+# SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
@@ -39,45 +52,124 @@ set(__get_git_revision_description YES)
 # to find the path to this module rather than the path to a calling list file
 get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
 
-function(get_git_head_revision _refspecvar _hashvar)
-    set(GIT_PARENT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-    set(GIT_DIR "${GIT_PARENT_DIR}/.git")
-    while(NOT EXISTS "${GIT_DIR}") # .git dir not found, search parent directories
-        set(GIT_PREVIOUS_PARENT "${GIT_PARENT_DIR}")
-        get_filename_component(GIT_PARENT_DIR ${GIT_PARENT_DIR} PATH)
-        if(GIT_PARENT_DIR STREQUAL GIT_PREVIOUS_PARENT)
+# Function _git_find_closest_git_dir finds the next closest .git directory
+# that is part of any directory in the path defined by _start_dir.
+# The result is returned in the parent scope variable whose name is passed
+# as variable _git_dir_var. If no .git directory can be found, the
+# function returns an empty string via _git_dir_var.
+#
+# Example: Given a path C:/bla/foo/bar and assuming C:/bla/.git exists and
+# neither foo nor bar contain a file/directory .git. This wil return
+# C:/bla/.git
+#
+function(_git_find_closest_git_dir _start_dir _git_dir_var)
+    set(cur_dir "${_start_dir}")
+    set(git_dir "${_start_dir}/.git")
+    while(NOT EXISTS "${git_dir}")
+        # .git dir not found, search parent directories
+        set(git_previous_parent "${cur_dir}")
+        get_filename_component(cur_dir "${cur_dir}" DIRECTORY)
+        if(cur_dir STREQUAL git_previous_parent)
             # We have reached the root directory, we are not in git
-            set(${_refspecvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
-            set(${_hashvar} "GITDIR-NOTFOUND" PARENT_SCOPE)
+            set(${_git_dir_var}
+                ""
+                PARENT_SCOPE)
             return()
         endif()
-        set(GIT_DIR "${GIT_PARENT_DIR}/.git")
+        set(git_dir "${cur_dir}/.git")
     endwhile()
-    # check if this is a submodule
+    set(${_git_dir_var}
+        "${git_dir}"
+        PARENT_SCOPE)
+endfunction()
+
+function(get_git_head_revision _refspecvar _hashvar)
+    _git_find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
+
+    if("${ARGN}" STREQUAL "ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR")
+        set(ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR TRUE)
+    else()
+        set(ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR FALSE)
+    endif()
+    if(NOT "${GIT_DIR}" STREQUAL "")
+        file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
+             "${GIT_DIR}")
+        if("${_relative_to_source_dir}" MATCHES "[.][.]" AND NOT ALLOW_LOOKING_ABOVE_CMAKE_SOURCE_DIR)
+            # We've gone above the CMake root dir.
+            set(GIT_DIR "")
+        endif()
+    endif()
+    if("${GIT_DIR}" STREQUAL "")
+        set(${_refspecvar}
+            "GITDIR-NOTFOUND"
+            PARENT_SCOPE)
+        set(${_hashvar}
+            "GITDIR-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    # Check if the current source dir is a git submodule or a worktree.
+    # In both cases .git is a file instead of a directory.
+    #
     if(NOT IS_DIRECTORY ${GIT_DIR})
-        file(READ ${GIT_DIR} submodule)
-        string(REGEX REPLACE "gitdir: (.*)\n$" "\\1" GIT_DIR_RELATIVE ${submodule})
-        get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
-        get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
+        # The following git command will return a non empty string that
+        # points to the super project working tree if the current
+        # source dir is inside a git submodule.
+        # Otherwise the command will return an empty string.
+        #
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" rev-parse
+                    --show-superproject-working-tree
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+            OUTPUT_VARIABLE out
+            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+        if(NOT "${out}" STREQUAL "")
+            # If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
+            file(READ ${GIT_DIR} submodule)
+            string(REGEX REPLACE "gitdir: (.*)$" "\\1" GIT_DIR_RELATIVE
+                                 ${submodule})
+            string(STRIP ${GIT_DIR_RELATIVE} GIT_DIR_RELATIVE)
+            get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+            get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE}
+                                   ABSOLUTE)
+            set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+        else()
+            # GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a worktree
+            file(READ ${GIT_DIR} worktree_ref)
+            # The .git directory contains a path to the worktree information directory
+            # inside the parent git repo of the worktree.
+            #
+            string(REGEX REPLACE "gitdir: (.*)$" "\\1" git_worktree_dir
+                                 ${worktree_ref})
+            string(STRIP ${git_worktree_dir} git_worktree_dir)
+            _git_find_closest_git_dir("${git_worktree_dir}" GIT_DIR)
+            set(HEAD_SOURCE_FILE "${git_worktree_dir}/HEAD")
+        endif()
+    else()
+        set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
     endif()
     set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
     if(NOT EXISTS "${GIT_DATA}")
         file(MAKE_DIRECTORY "${GIT_DATA}")
     endif()
 
-    if(NOT EXISTS "${GIT_DIR}/HEAD")
+    if(NOT EXISTS "${HEAD_SOURCE_FILE}")
         return()
     endif()
     set(HEAD_FILE "${GIT_DATA}/HEAD")
-    configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+    configure_file("${HEAD_SOURCE_FILE}" "${HEAD_FILE}" COPYONLY)
 
     configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
-        "${GIT_DATA}/grabRef.cmake"
-        @ONLY)
+                   "${GIT_DATA}/grabRef.cmake" @ONLY)
     include("${GIT_DATA}/grabRef.cmake")
 
-    set(${_refspecvar} "${HEAD_REF}" PARENT_SCOPE)
-    set(${_hashvar} "${HEAD_HASH}" PARENT_SCOPE)
+    set(${_refspecvar}
+        "${HEAD_REF}"
+        PARENT_SCOPE)
+    set(${_hashvar}
+        "${HEAD_HASH}"
+        PARENT_SCOPE)
 endfunction()
 
 function(git_describe _var)
@@ -86,45 +178,107 @@ function(git_describe _var)
     endif()
     get_git_head_revision(refspec hash)
     if(NOT GIT_FOUND)
-        set(${_var} "GIT-NOTFOUND" PARENT_SCOPE)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
         return()
     endif()
     if(NOT hash)
-        set(${_var} "HEAD-HASH-NOTFOUND" PARENT_SCOPE)
+        set(${_var}
+            "HEAD-HASH-NOTFOUND"
+            PARENT_SCOPE)
         return()
     endif()
 
     # TODO sanitize
     #if((${ARGN}" MATCHES "&&") OR
-    #    (ARGN MATCHES "||") OR
-    #    (ARGN MATCHES "\\;"))
-    #    message("Please report the following error to the project!")
-    #    message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+    #	(ARGN MATCHES "||") OR
+    #	(ARGN MATCHES "\\;"))
+    #	message("Please report the following error to the project!")
+    #	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
     #endif()
 
     #message(STATUS "Arguments to execute_process: ${ARGN}")
 
-    execute_process(COMMAND
-        "${GIT_EXECUTABLE}"
-        describe
-        ${hash}
-        ${ARGN}
-        WORKING_DIRECTORY
-        "${CMAKE_CURRENT_SOURCE_DIR}"
-        RESULT_VARIABLE
-        res
-        OUTPUT_VARIABLE
-        out
-        ERROR_QUIET
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --always ${hash} ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT res EQUAL 0)
         set(out "${out}-${res}-NOTFOUND")
     endif()
 
-    set(${_var} "${out}" PARENT_SCOPE)
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_describe_working_tree _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --dirty ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
 endfunction()
 
 function(git_get_exact_tag _var)
     git_describe(out --exact-match ${ARGN})
-    set(${_var} "${out}" PARENT_SCOPE)
+    set(${_var}
+        "${out}"
+        PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+    if(NOT GIT_FOUND)
+        find_package(Git QUIET)
+    endif()
+    get_git_head_revision(refspec hash)
+    if(NOT GIT_FOUND)
+        set(${_var}
+            "GIT-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+    if(NOT hash)
+        set(${_var}
+            "HEAD-HASH-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" diff-index --quiet HEAD --
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(res EQUAL 0)
+        set(${_var}
+            "CLEAN"
+            PARENT_SCOPE)
+    else()
+        set(${_var}
+            "DIRTY"
+            PARENT_SCOPE)
+    endif()
 endfunction()

--- a/cmake/GetGitRevisionDescription.cmake.in
+++ b/cmake/GetGitRevisionDescription.cmake.in
@@ -8,10 +8,12 @@
 # http://academic.cleardefinition.com
 # Iowa State University HCI Graduate Program/VRAC
 #
-# Copyright Iowa State University 2009-2010.
+# Copyright 2009-2012, Iowa State University
+# Copyright 2011-2015, Contributors
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
 
 set(HEAD_HASH)
 
@@ -19,23 +21,23 @@ file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
 
 string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
 if(HEAD_CONTENTS MATCHES "ref")
-    # named branch
-    string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
-    if(EXISTS "@GIT_DIR@/${HEAD_REF}")
-        configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
-    else()
-        configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
-        file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
-        if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
-            set(HEAD_HASH "${CMAKE_MATCH_1}")
-        endif()
-    endif()
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
 else()
-    # detached HEAD
-    configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
 endif()
 
 if(NOT HEAD_HASH)
-    file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
-    string(STRIP "${HEAD_HASH}" HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
 endif()


### PR DESCRIPTION
With this PR, our official builds from GHA should not include the `-<commit sha>` suffix.