### PR TITLE
Fix duplicate name in window title

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -226,7 +226,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     setOrganizationName(BuildConfig.LAUNCHER_NAME);
     setOrganizationDomain(BuildConfig.LAUNCHER_DOMAIN);
     setApplicationName(BuildConfig.LAUNCHER_NAME);
-    setApplicationDisplayName(BuildConfig.LAUNCHER_DISPLAYNAME);
+    setApplicationDisplayName(QString("%1 %2").arg(BuildConfig.LAUNCHER_DISPLAYNAME, BuildConfig.printableVersionString()));
     setApplicationVersion(BuildConfig.printableVersionString());
     setDesktopFileName(BuildConfig.LAUNCHER_DESKTOPFILENAME);
     startTime = QDateTime::currentDateTime();

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -822,7 +822,7 @@ public:
         }
         MainWindow->resize(800, 600);
         MainWindow->setWindowIcon(APPLICATION->getThemedIcon("logo"));
-        MainWindow->setWindowTitle(BuildConfig.LAUNCHER_DISPLAYNAME);
+        MainWindow->setWindowTitle(APPLICATION->applicationDisplayName());
 #ifndef QT_NO_ACCESSIBILITY
         MainWindow->setAccessibleName(BuildConfig.LAUNCHER_NAME);
 #endif
@@ -857,8 +857,6 @@ public:
 
     void retranslateUi(MainWindow *MainWindow)
     {
-        QString winTitle = tr("%1 - Version %2", "Launcher - Version X").arg(BuildConfig.LAUNCHER_DISPLAYNAME, BuildConfig.printableVersionString());
-        MainWindow->setWindowTitle(winTitle);
         // all the actions
         for(auto * item: all_actions)
         {


### PR DESCRIPTION
Fixes #335

## ~~With this PR~~ see latest https://github.com/PolyMC/PolyMC/pull/811#issuecomment-1160001665

- The main window will be named `Instances`
- The application display name will be `PolyMC <version>`

### Note on Qt platform-specific behaviour

On Windows and Linux, Qt appends the display name to all window titles.

![Screenshot of main window and Settings window on GNOME, with display name appended to window titles.](https://user-images.githubusercontent.com/23169302/174437269-bbc5872f-8173-47f4-a7ec-756201056967.png)

On macOS the display name is not appended to window titles.

## Alternative option

The main window could be named simply `PolyMC <version>`.

This will make the main window title consistent across all 3 platforms. Win/Linux will not have it duplicated; see https://github.com/PolyMC/PolyMC/pull/811#discussion_r901052005.

Please let me know if this is preferred and I'll update the PR.