### PR TITLE
Make version labels in About dialog selectable

### DIFF
--- a/launcher/ui/dialogs/AboutDialog.ui
+++ b/launcher/ui/dialogs/AboutDialog.ui
@@ -89,6 +89,9 @@
    </item>
    <item>
     <widget class="QLabel" name="versionLabel">
+     <property name="cursor">
+      <cursorShape>IBeamCursor</cursorShape>
+     </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
@@ -166,6 +169,9 @@
        </item>
        <item>
         <widget class="QLabel" name="platformLabel">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>Platform:</string>
          </property>
@@ -179,6 +185,9 @@
        </item>
        <item>
         <widget class="QLabel" name="buildNumLabel">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>Build Number:</string>
          </property>
@@ -192,6 +201,9 @@
        </item>
        <item>
         <widget class="QLabel" name="channelLabel">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>Channel:</string>
          </property>

--- a/launcher/ui/dialogs/AboutDialog.ui
+++ b/launcher/ui/dialogs/AboutDialog.ui
@@ -92,6 +92,9 @@
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+     <property name="textInteractionFlags">
+      <set>Qt::TextSelectableByMouse</set>
+     </property>
     </widget>
    </item>
    <item>
@@ -166,6 +169,9 @@
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item>
@@ -176,6 +182,9 @@
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item>
@@ -185,6 +194,9 @@
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>

--- a/launcher/ui/dialogs/AboutDialog.ui
+++ b/launcher/ui/dialogs/AboutDialog.ui
@@ -136,6 +136,9 @@
          <property name="alignment">
           <set>Qt::AlignCenter</set>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
![Screenshot of version label in About dialog being selected](https://user-images.githubusercontent.com/23169302/174443542-3cd5e600-1650-4e32-a399-c395c311a865.png)

- Make the version/platform/build/channel labels in About dialog selectable by mouse for easy copying.
- Selectable labels have a beam cursor
- Also make the GitHub link focusable by keyboard (Tab/Shift-Tab)

~~Not sure if it should be done in the ui file or by code in AboutDialog.cpp?~~