### PR TITLE
Don't create unnecessary folders when extracting ZIPs

### DIFF
--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -305,7 +305,7 @@ nonstd::optional<QStringList> MMCZip::extractSubDir(QuaZip *zip, const QString &
         QString path;
         if(name.contains('/') && !name.endsWith('/')){
             path = name.section('/', 0, -2) + "/";
-            FS::ensureFolderPathExists(path);
+            FS::ensureFolderPathExists(FS::PathCombine(target, path));
 
             name = name.split('/').last();
         }


### PR DESCRIPTION
Fixes creating empty, useless folders in the root directory when importing ZIPs (especially the `override` file structure from mrpacks). Still good to have that line there though, as some malformed ZIP could come up again in the future, who knows.

whoever added that line must be really dumb!
~oh wait it was me~ :sob: 