### PR TITLE
Always scale mod icons to the right size

### DIFF
--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -53,7 +53,11 @@ auto ListModel::data(const QModelIndex& index, int role) const -> QVariant
         }
         case Qt::DecorationRole: {
             if (m_logoMap.contains(pack.logoName)) {
-                return (m_logoMap.value(pack.logoName));
+                auto icon = m_logoMap.value(pack.logoName);
+                // FIXME: This doesn't really belong here, but Qt doesn't offer a good way right now ;(
+                auto icon_scaled = QIcon(icon.pixmap(48, 48).scaledToWidth(48));
+
+                return icon_scaled;
             }
             QIcon icon = APPLICATION->getThemedIcon("screenshot-placeholder");
             // un-const-ify this

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -87,6 +87,7 @@ auto ModpackListModel::data(const QModelIndex& index, int role) const -> QVarian
     } else if (role == Qt::DecorationRole) {
         if (m_logoMap.contains(pack.iconName)) {
             auto icon = m_logoMap.value(pack.iconName);
+            // FIXME: This doesn't really belong here, but Qt doesn't offer a good way right now ;(
             auto icon_scaled = QIcon(icon.pixmap(48, 48).scaledToWidth(48));
 
             return icon_scaled;


### PR DESCRIPTION
Closes #813

This makes it consistent with icons in Modrinth modpacks that have the same issue.
Example of a mod I found with this problem, for testing: https://modrinth.com/mod/whizzy_wands (might be fixed when you see it :p)