### PR TITLE
Separate launch and kill instance actions

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -224,6 +224,7 @@ public:
     TranslatedAction actionMoreNews;
     TranslatedAction actionManageAccounts;
     TranslatedAction actionLaunchInstance;
+    TranslatedAction actionKillInstance;
     TranslatedAction actionRenameInstance;
     TranslatedAction actionChangeInstGroup;
     TranslatedAction actionChangeInstIcon;
@@ -282,27 +283,6 @@ public:
     TranslatedToolbar instanceToolBar;
     TranslatedToolbar newsToolBar;
     QVector<TranslatedToolbar *> all_toolbars;
-    bool m_kill = false;
-
-    void updateLaunchAction()
-    {
-        if(m_kill)
-        {
-            actionLaunchInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Kill"));
-            actionLaunchInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Kill the running instance"));
-        }
-        else
-        {
-            actionLaunchInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Launch"));
-            actionLaunchInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Launch the selected instance."));
-        }
-        actionLaunchInstance.retranslate();
-    }
-    void setLaunchAction(bool kill)
-    {
-        m_kill = kill;
-        updateLaunchAction();
-    }
 
     void createMainToolbarActions(QMainWindow *MainWindow)
     {
@@ -506,6 +486,7 @@ public:
         fileMenu->addAction(actionAddInstance);
         fileMenu->addAction(actionLaunchInstance);
         fileMenu->addAction(actionLaunchInstanceOffline);
+        fileMenu->addAction(actionKillInstance);
         fileMenu->addAction(actionCloseWindow);
         fileMenu->addSeparator();
         fileMenu->addAction(actionEditInstance);
@@ -580,10 +561,9 @@ public:
     }
 
     // "Instance actions" are actions that require an instance to be selected (i.e. "new instance" is not here)
+    // Actions that also require other conditions (e.g. a running instance) won't be changed.
     void setInstanceActionsEnabled(bool enabled)
     {
-        actionLaunchInstance->setEnabled(enabled);
-        actionLaunchInstanceOffline->setEnabled(enabled);
         actionEditInstance->setEnabled(enabled);
         actionEditInstNotes->setEnabled(enabled);
         actionMods->setEnabled(enabled);
@@ -669,6 +649,14 @@ public:
         actionLaunchInstanceOffline.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Launch &Offline"));
         actionLaunchInstanceOffline.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Launch the selected instance in offline mode."));
         all_actions.append(&actionLaunchInstanceOffline);
+
+        actionKillInstance = TranslatedAction(MainWindow);
+        actionKillInstance->setObjectName(QStringLiteral("actionKillInstance"));
+        actionKillInstance->setDisabled(true);
+        actionKillInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Kill"));
+        actionKillInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Kill the running instance"));
+        actionKillInstance->setShortcut(QKeySequence(tr("Ctrl+K")));
+        all_actions.append(&actionKillInstance);
 
         actionEditInstance = TranslatedAction(MainWindow);
         actionEditInstance->setObjectName(QStringLiteral("actionEditInstance"));
@@ -785,6 +773,7 @@ public:
 
         instanceToolBar->addAction(actionLaunchInstance);
         instanceToolBar->addAction(actionLaunchInstanceOffline);
+        instanceToolBar->addAction(actionKillInstance);
 
         instanceToolBar->addSeparator();
 
@@ -1184,14 +1173,10 @@ void MainWindow::updateToolsMenu()
     QToolButton *launchButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstance));
     QToolButton *launchOfflineButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstanceOffline));
 
-    if(m_selectedInstance && m_selectedInstance->isRunning())
-    {
-        ui->actionLaunchInstance->setMenu(nullptr);
-        ui->actionLaunchInstanceOffline->setMenu(nullptr);
-        launchButton->setPopupMode(QToolButton::InstantPopup);
-        launchOfflineButton->setPopupMode(QToolButton::InstantPopup);
-        return;
-    }
+    bool currentInstanceRunning = m_selectedInstance && m_selectedInstance->isRunning();
+
+    ui->actionLaunchInstance->setDisabled(!m_selectedInstance || currentInstanceRunning);
+    ui->actionLaunchInstanceOffline->setDisabled(!m_selectedInstance || currentInstanceRunning);
 
     QMenu *launchMenu = ui->actionLaunchInstance->menu();
     QMenu *launchOfflineMenu = ui->actionLaunchInstanceOffline->menu();
@@ -1219,6 +1204,9 @@ void MainWindow::updateToolsMenu()
     normalLaunchOffline->setShortcut(QKeySequence(tr("Ctrl+Shift+O")));
     if (m_selectedInstance)
     {
+        normalLaunch->setEnabled(m_selectedInstance->canLaunch());
+        normalLaunchOffline->setEnabled(m_selectedInstance->canLaunch());
+
         connect(normalLaunch, &QAction::triggered, [this]() {
             APPLICATION->launch(m_selectedInstance, true);
         });
@@ -1249,6 +1237,9 @@ void MainWindow::updateToolsMenu()
         }
         else if (m_selectedInstance)
         {
+            profilerAction->setEnabled(m_selectedInstance->canLaunch());
+            profilerOfflineAction->setEnabled(m_selectedInstance->canLaunch());
+
             connect(profilerAction, &QAction::triggered, [this, profiler]()
                     {
                         APPLICATION->launch(m_selectedInstance, true, profiler.get());
@@ -2081,15 +2072,7 @@ void MainWindow::instanceActivated(QModelIndex index)
 
 void MainWindow::on_actionLaunchInstance_triggered()
 {
-    if (!m_selectedInstance)
-    {
-        return;
-    }
-    if(m_selectedInstance->isRunning())
-    {
-        APPLICATION->kill(m_selectedInstance);
-    }
-    else
+    if(m_selectedInstance && !m_selectedInstance->isRunning())
     {
         APPLICATION->launch(m_selectedInstance);
     }
@@ -2105,6 +2088,14 @@ void MainWindow::on_actionLaunchInstanceOffline_triggered()
     if (m_selectedInstance)
     {
         APPLICATION->launch(m_selectedInstance, false);
+    }
+}
+
+void MainWindow::on_actionKillInstance_triggered()
+{
+    if(m_selectedInstance && m_selectedInstance->isRunning())
+    {
+        APPLICATION->kill(m_selectedInstance);
     }
 }
 
@@ -2141,17 +2132,9 @@ void MainWindow::instanceChanged(const QModelIndex &current, const QModelIndex &
     {
         ui->instanceToolBar->setEnabled(true);
         ui->setInstanceActionsEnabled(true);
-        if(m_selectedInstance->isRunning())
-        {
-            ui->actionLaunchInstance->setEnabled(true);
-            ui->setLaunchAction(true);
-        }
-        else
-        {
-            ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch());
-            ui->setLaunchAction(false);
-        }
+        ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch());
         ui->actionLaunchInstanceOffline->setEnabled(m_selectedInstance->canLaunch());
+        ui->actionKillInstance->setEnabled(m_selectedInstance->isRunning());
         ui->actionExportInstance->setEnabled(m_selectedInstance->canExport());
         ui->renameButton->setText(m_selectedInstance->name());
         m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
@@ -2168,6 +2151,9 @@ void MainWindow::instanceChanged(const QModelIndex &current, const QModelIndex &
     {
         ui->instanceToolBar->setEnabled(false);
         ui->setInstanceActionsEnabled(false);
+        ui->actionLaunchInstance->setEnabled(false);
+        ui->actionLaunchInstanceOffline->setEnabled(false);
+        ui->actionKillInstance->setEnabled(false);
         APPLICATION->settings()->set("SelectedInstance", QString());
         selectionBad();
         return;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2183,6 +2183,7 @@ void MainWindow::selectionBad()
     statusBar()->clearMessage();
     ui->instanceToolBar->setEnabled(false);
     ui->setInstanceActionsEnabled(false);
+    updateToolsMenu();
     ui->renameButton->setText(tr("Rename Instance"));
     updateInstanceToolIcon("grass");
 

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -148,6 +148,8 @@ private slots:
 
     void on_actionLaunchInstanceOffline_triggered();
 
+    void on_actionKillInstance_triggered();
+
     void on_actionDeleteInstance_triggered();
 
     void deleteGroup();


### PR DESCRIPTION
Fixes #695. While the bug fix is for macOS, the overall change to do so affects all platforms. (I couldn't find another sensible solution, but I think these changes have benefits anyway.)

"Launch" and "Kill" are now entirely separate actions that are both always visible. The buttons are grayed out when appropriate (e.g. "Kill" is only enabled if the instance is running). This is opposed to the old behavior, where the launch and kill actions were actually the same, and the label just changed depending on whether the instance was running.

<img width="117" alt="Screen Shot 2022-06-21 at 8 34 25 PM" src="https://user-images.githubusercontent.com/79120643/174918847-0a14e2f1-cca5-4735-85dc-0f303738fe53.png">


This also has some additional benefits that affect people on all platforms:

- New keyboard shortcut for killing the selected instance (Ctrl + K)
- For those working on the main window code, `actionLaunchInstance` no longer sometimes launches and sometimes kills the instance. Now `actionLaunchInstance` always launches, and `actionKillInstance` always kills. This helps reduce confusion.