### PR TITLE
Workaround Qt bug to fix menu bar separators on macOS

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -503,6 +503,8 @@ public:
         menuBar->setVisible(APPLICATION->settings()->get("MenuBarInsteadOfToolBar").toBool());
 
         fileMenu = menuBar->addMenu(tr("&File"));
+        // Workaround for QTBUG-94802 (https://bugreports.qt.io/browse/QTBUG-94802); also present for other menus
+        fileMenu->setSeparatorsCollapsible(false);
         fileMenu->addAction(actionAddInstance);
         fileMenu->addAction(actionLaunchInstance);
         fileMenu->addAction(actionLaunchInstanceOffline);
@@ -526,15 +528,18 @@ public:
         fileMenu->addAction(actionSettings);
 
         viewMenu = menuBar->addMenu(tr("&View"));
+        viewMenu->setSeparatorsCollapsible(false);
         viewMenu->addAction(actionCAT);
         viewMenu->addSeparator();
 
         menuBar->addMenu(foldersMenu);
 
         profileMenu = menuBar->addMenu(tr("&Profiles"));
+        profileMenu->setSeparatorsCollapsible(false);
         profileMenu->addAction(actionManageAccounts);
 
         helpMenu = menuBar->addMenu(tr("&Help"));
+        helpMenu->setSeparatorsCollapsible(false);
         helpMenu->addAction(actionAbout);
         helpMenu->addAction(actionOpenWiki);
         helpMenu->addAction(actionNewsMenuBar);


### PR DESCRIPTION
Fixes #825 using a workaround suggested at https://bugreports.qt.io/browse/QTBUG-94802.

> QMenu separators are not visible with Qt5.15.5. This can be easily reproduced with Qt's Menu Example.
> It seems that in QCocoaMenu::syncSeparatorCollapsable()
> cocoaItem->setVisible(!previousIsSeparator &&
> cocoaItem->isVisible());
> 
> makes separator visible only when it is not hidden from the collapsible
> separator logic AND if it wasn't hidden before.
> 
> So setting setSeparatorsCollapsible(false) makes it work as workaround