### PR TITLE
Add missing connections to the abort signal in some tasks

### DIFF
--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -197,6 +197,10 @@ void ComponentUpdateTask::loadComponents()
             {
                 remoteLoadFailed(taskIndex, error);
             });
+            connect(indexLoadTask.get(), &Task::aborted, [=]()
+            {
+                remoteLoadFailed(taskIndex, tr("Aborted"));
+            });
             taskIndex++;
         }
     }
@@ -242,6 +246,10 @@ void ComponentUpdateTask::loadComponents()
             connect(loadTask.get(), &Task::failed, [=](const QString & error)
             {
                 remoteLoadFailed(taskIndex, error);
+            });
+            connect(loadTask.get(), &Task::aborted, [=]()
+            {
+                remoteLoadFailed(taskIndex, tr("Aborted"));
             });
             RemoteLoadStatus status;
             status.type = loadType;

--- a/launcher/minecraft/MinecraftLoadAndCheck.cpp
+++ b/launcher/minecraft/MinecraftLoadAndCheck.cpp
@@ -20,6 +20,7 @@ void MinecraftLoadAndCheck::executeTask()
     }
     connect(m_task.get(), &Task::succeeded, this, &MinecraftLoadAndCheck::subtaskSucceeded);
     connect(m_task.get(), &Task::failed, this, &MinecraftLoadAndCheck::subtaskFailed);
+    connect(m_task.get(), &Task::aborted, this, [this]{ subtaskFailed(tr("Aborted")); });
     connect(m_task.get(), &Task::progress, this, &MinecraftLoadAndCheck::progress);
     connect(m_task.get(), &Task::status, this, &MinecraftLoadAndCheck::setStatus);
 }

--- a/launcher/minecraft/MinecraftUpdate.cpp
+++ b/launcher/minecraft/MinecraftUpdate.cpp
@@ -98,6 +98,7 @@ void MinecraftUpdate::next()
         auto task = m_tasks[m_currentTask - 1];
         disconnect(task.get(), &Task::succeeded, this, &MinecraftUpdate::subtaskSucceeded);
         disconnect(task.get(), &Task::failed, this, &MinecraftUpdate::subtaskFailed);
+        disconnect(task.get(), &Task::aborted, this, &Task::abort);
         disconnect(task.get(), &Task::progress, this, &MinecraftUpdate::progress);
         disconnect(task.get(), &Task::status, this, &MinecraftUpdate::setStatus);
     }
@@ -115,6 +116,7 @@ void MinecraftUpdate::next()
     }
     connect(task.get(), &Task::succeeded, this, &MinecraftUpdate::subtaskSucceeded);
     connect(task.get(), &Task::failed, this, &MinecraftUpdate::subtaskFailed);
+    connect(task.get(), &Task::aborted, this, &Task::abort);
     connect(task.get(), &Task::progress, this, &MinecraftUpdate::progress);
     connect(task.get(), &Task::status, this, &MinecraftUpdate::setStatus);
     // if the task is already running, do not start it again

--- a/launcher/minecraft/MinecraftUpdate.h
+++ b/launcher/minecraft/MinecraftUpdate.h
@@ -27,6 +27,8 @@
 class MinecraftVersion;
 class MinecraftInstance;
 
+// FIXME: This looks very similar to a SequentialTask. Maybe we can reduce code duplications? :^)
+
 class MinecraftUpdate : public Task
 {
     Q_OBJECT

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -346,6 +346,7 @@ void PackProfile::resolve(Net::Mode netmode)
     d->m_updateTask.reset(updateTask);
     connect(updateTask, &ComponentUpdateTask::succeeded, this, &PackProfile::updateSucceeded);
     connect(updateTask, &ComponentUpdateTask::failed, this, &PackProfile::updateFailed);
+    connect(updateTask, &ComponentUpdateTask::aborted, this, [this]{ updateFailed(tr("Aborted")); });
     d->m_updateTask->start();
 }
 

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -135,6 +135,7 @@ shared_qobject_ptr<AccountTask> MinecraftAccount::login(QString password) {
     m_currentTask.reset(new MojangLogin(&data, password));
     connect(m_currentTask.get(), SIGNAL(succeeded()), SLOT(authSucceeded()));
     connect(m_currentTask.get(), SIGNAL(failed(QString)), SLOT(authFailed(QString)));
+    connect(m_currentTask.get(), &Task::aborted, this, [this]{ authFailed(tr("Aborted")); });
     emit activityChanged(true);
     return m_currentTask;
 }
@@ -145,6 +146,7 @@ shared_qobject_ptr<AccountTask> MinecraftAccount::loginMSA() {
     m_currentTask.reset(new MSAInteractive(&data));
     connect(m_currentTask.get(), SIGNAL(succeeded()), SLOT(authSucceeded()));
     connect(m_currentTask.get(), SIGNAL(failed(QString)), SLOT(authFailed(QString)));
+    connect(m_currentTask.get(), &Task::aborted, this, [this]{ authFailed(tr("Aborted")); });
     emit activityChanged(true);
     return m_currentTask;
 }
@@ -155,6 +157,7 @@ shared_qobject_ptr<AccountTask> MinecraftAccount::loginOffline() {
     m_currentTask.reset(new OfflineLogin(&data));
     connect(m_currentTask.get(), SIGNAL(succeeded()), SLOT(authSucceeded()));
     connect(m_currentTask.get(), SIGNAL(failed(QString)), SLOT(authFailed(QString)));
+    connect(m_currentTask.get(), &Task::aborted, this, [this]{ authFailed(tr("Aborted")); });
     emit activityChanged(true);
     return m_currentTask;
 }
@@ -176,6 +179,7 @@ shared_qobject_ptr<AccountTask> MinecraftAccount::refresh() {
 
     connect(m_currentTask.get(), SIGNAL(succeeded()), SLOT(authSucceeded()));
     connect(m_currentTask.get(), SIGNAL(failed(QString)), SLOT(authFailed(QString)));
+    connect(m_currentTask.get(), &Task::aborted, this, [this]{ authFailed(tr("Aborted")); });
     emit activityChanged(true);
     return m_currentTask;
 }

--- a/launcher/minecraft/auth/steps/YggdrasilStep.cpp
+++ b/launcher/minecraft/auth/steps/YggdrasilStep.cpp
@@ -9,6 +9,7 @@ YggdrasilStep::YggdrasilStep(AccountData* data, QString password) : AuthStep(dat
 
     connect(m_yggdrasil, &Task::failed, this, &YggdrasilStep::onAuthFailed);
     connect(m_yggdrasil, &Task::succeeded, this, &YggdrasilStep::onAuthSucceeded);
+    connect(m_yggdrasil, &Task::aborted, this, &YggdrasilStep::onAuthFailed);
 }
 
 YggdrasilStep::~YggdrasilStep() noexcept = default;

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -43,6 +43,7 @@ void AssetUpdateTask::executeTask()
 
     connect(downloadJob.get(), &NetJob::succeeded, this, &AssetUpdateTask::assetIndexFinished);
     connect(downloadJob.get(), &NetJob::failed, this, &AssetUpdateTask::assetIndexFailed);
+    connect(downloadJob.get(), &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
     connect(downloadJob.get(), &NetJob::progress, this, &AssetUpdateTask::progress);
 
     qDebug() << m_inst->name() << ": Starting asset index download";
@@ -80,6 +81,7 @@ void AssetUpdateTask::assetIndexFinished()
         downloadJob = job;
         connect(downloadJob.get(), &NetJob::succeeded, this, &AssetUpdateTask::emitSucceeded);
         connect(downloadJob.get(), &NetJob::failed, this, &AssetUpdateTask::assetsFailed);
+        connect(downloadJob.get(), &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
         connect(downloadJob.get(), &NetJob::progress, this, &AssetUpdateTask::progress);
         downloadJob->start();
         return;

--- a/launcher/minecraft/update/FMLLibrariesTask.cpp
+++ b/launcher/minecraft/update/FMLLibrariesTask.cpp
@@ -72,6 +72,7 @@ void FMLLibrariesTask::executeTask()
 
     connect(dljob, &NetJob::succeeded, this, &FMLLibrariesTask::fmllibsFinished);
     connect(dljob, &NetJob::failed, this, &FMLLibrariesTask::fmllibsFailed);
+    connect(dljob, &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
     connect(dljob, &NetJob::progress, this, &FMLLibrariesTask::progress);
     downloadJob.reset(dljob);
     downloadJob->start();

--- a/launcher/minecraft/update/LibrariesTask.cpp
+++ b/launcher/minecraft/update/LibrariesTask.cpp
@@ -68,6 +68,7 @@ void LibrariesTask::executeTask()
 
     connect(downloadJob.get(), &NetJob::succeeded, this, &LibrariesTask::emitSucceeded);
     connect(downloadJob.get(), &NetJob::failed, this, &LibrariesTask::jarlibFailed);
+    connect(downloadJob.get(), &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
     connect(downloadJob.get(), &NetJob::progress, this, &LibrariesTask::progress);
     downloadJob->start();
 }


### PR DESCRIPTION
This fixes an issue where aborting the tasks of instance updating when running an instance for the first time would not close the dialog, and prevent any user interaction, effectively making PolyMC hang until you :gun: it in a task manager.