### PR TITLE
Fix Steam overlay on Linux

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -68,7 +68,8 @@ QProcessEnvironment CleanEnviroment()
         "JAVA_OPTIONS",
         "JAVA_TOOL_OPTIONS"
     };
-    for(auto key: rawenv.keys())
+    auto keys = rawenv.keys();
+    for(auto key: keys)
     {
         auto value = rawenv.value(key);
         // filter out dangerous java crap
@@ -84,8 +85,8 @@ QProcessEnvironment CleanEnviroment()
             continue;
         }
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-        // Do not pass LD_* variables to java. They were intended for PolyMC
-        if(key.startsWith("LD_"))
+        // Do not pass LD_* variables to java unless GAME_* variables aren't defined. They were intended for PolyMC
+        if((keys.contains("GAME_PRELOAD") || keys.contains("GAME_LIBRARY_PATH")) && key.startsWith("LD_"))
         {
             qDebug() << "Env: ignoring" << key << value;
             continue;
@@ -103,7 +104,7 @@ QProcessEnvironment CleanEnviroment()
             env.insert("LD_PRELOAD", value);
             continue;
         }
-        if(key == "GAME_LIBRARY_PATH")
+        if(key == "GAME_LIBRARY_PATH" || key == "LD_LIBRARY_PATH")
         {
             env.insert("LD_LIBRARY_PATH", processLD_LIBRARY_PATH(value));
             continue;


### PR DESCRIPTION
Fix #302. I haven't tested this firsthand but someone did verify that the fix worked on their end: https://github.com/PolyMC/PolyMC/issues/302#issuecomment-1163816311. This change only affects Linux.

If the wrapper script is not used to launch the game, then the `GAME_*` variables aren't set. When that happens, I have PolyMC just pass the same variables to the game. I'm not too sure why this environment cleaning is needed in the first place, but I tried not to interfere with too much existing behavior. If the `GAME_*` variables are set (e.g. if someone uses the wrapper script in the .tar.gz to open the game), then the behavior should be the same as it currently is.

### To test

Download the generated archive, and add the `bin/polymc` executable to Steam. Launch PolyMC from Steam, then launch an instance and see if the overlay appears.