### PR TITLE
Some small fixes and improvements to modpacks

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -412,12 +412,8 @@ void InstanceImportTask::processFlame()
                                                           "You will need to manually download them and add them to the modpack"),
                                                        text);
             message_dialog->setModal(true);
-            message_dialog->show();
-            connect(message_dialog, &QDialog::rejected, [&]() {
-                m_modIdResolver.reset();
-                emitFailed("Canceled");
-            });
-            connect(message_dialog, &QDialog::accepted, [&]() {
+
+            if (message_dialog->exec()) {
                 m_filesNetJob = new NetJob(tr("Mod download"), APPLICATION->network());
                 for (const auto &result: m_modIdResolver->getResults().files) {
                     QString filename = result.fileName;
@@ -469,8 +465,11 @@ void InstanceImportTask::processFlame()
                 });
                 setStatus(tr("Downloading mods..."));
                 m_filesNetJob->start();
-            });
-        }else{
+            } else {
+                m_modIdResolver.reset();
+                emitFailed("Canceled");
+            }
+        } else {
             //TODO extract to function ?
             m_filesNetJob = new NetJob(tr("Mod download"), APPLICATION->network());
             for (const auto &result: m_modIdResolver->getResults().files) {

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -167,12 +167,16 @@ void ModFolderModel::finishUpdate()
     {
         QSet<QString> added = newSet;
         added.subtract(currentSet);
-        beginInsertRows(QModelIndex(), mods.size(), mods.size() + added.size() - 1);
-        for(auto & addedMod: added) {
-            mods.append(newMods[addedMod]);
-            resolveMod(mods.last());
+
+        // When you have a Qt build with assertions turned on, proceeding here will abort the application
+        if (added.size() > 0) {
+            beginInsertRows(QModelIndex(), mods.size(), mods.size() + added.size() - 1);
+            for (auto& addedMod : added) {
+                mods.append(newMods[addedMod]);
+                resolveMod(mods.last());
+            }
+            endInsertRows();
         }
-        endInsertRows();
     }
 
     // update index

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -10,7 +10,7 @@ Flame::FileResolvingTask::FileResolvingTask(const shared_qobject_ptr<QNetworkAcc
 void Flame::FileResolvingTask::executeTask()
 {
     setStatus(tr("Resolving mod IDs..."));
-    setProgress(0, m_toProcess.files.size());
+    setProgress(0, 3);
     m_dljob = new NetJob("Mod id resolver", m_network);
     result.reset(new QByteArray());
     //build json data to send
@@ -29,6 +29,7 @@ void Flame::FileResolvingTask::executeTask()
 
 void Flame::FileResolvingTask::netJobFinished()
 {
+    setProgress(1, 3);
     int index = 0;
     // job to check modrinth for blocked projects
     auto job = new NetJob("Modrinth check", m_network);
@@ -63,6 +64,7 @@ void Flame::FileResolvingTask::netJobFinished()
 }
 
 void Flame::FileResolvingTask::modrinthCheckFinished() {
+    setProgress(2, 3);
     qDebug() << "Finished with blocked mods : " << blockedProjects.size();
 
     for (auto it = blockedProjects.keyBegin(); it != blockedProjects.keyEnd(); it++) {

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -219,6 +219,10 @@ void ListModel::searchRequestFinished(QJsonDocument& doc)
         searchState = CanPossiblyFetchMore;
     }
 
+    // When you have a Qt build with assertions turned on, proceeding here will abort the application
+    if (newList.size() == 0)
+        return;
+
     beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size() + newList.size() - 1);
     modpacks.append(newList);
     endInsertRows();

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -57,6 +57,17 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
     return QVariant();
 }
 
+bool ListModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    int pos = index.row();
+    if (pos >= modpacks.size() || pos < 0 || !index.isValid())
+        return false;
+
+    modpacks[pos] = value.value<Flame::IndexedPack>();
+
+    return true;
+}
+
 void ListModel::logoLoaded(QString logo, QIcon out)
 {
     m_loadingLogos.removeAll(logo);

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -221,6 +221,11 @@ void Flame::ListModel::searchRequestFinished()
         nextSearchOffset += 25;
         searchState = CanPossiblyFetchMore;
     }
+
+    // When you have a Qt build with assertions turned on, proceeding here will abort the application
+    if (newList.size() == 0)
+        return;
+
     beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size() + newList.size() - 1);
     modpacks.append(newList);
     endInsertRows();

--- a/launcher/ui/pages/modplatform/flame/FlameModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.h
@@ -34,6 +34,7 @@ public:
     int rowCount(const QModelIndex &parent) const override;
     int columnCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role) const override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     bool canFetchMore(const QModelIndex & parent) const override;
     void fetchMore(const QModelIndex & parent) override;

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -157,6 +157,10 @@ void FlamePage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
             if (!listModel->setData(curr, current_updated, Qt::UserRole))
                 qWarning() << "Failed to cache versions for the current pack!";
 
+            // TODO: Check whether it's a connection issue or the project disabled 3rd-party distribution.
+            if (current.versionsLoaded && ui->versionSelectionBox->count() < 1) {
+                ui->versionSelectionBox->addItem(tr("No version is available!"), -1);
+            }
             suggestCurrent();
         });
         QObject::connect(netJob, &NetJob::finished, this, [response, netJob] {
@@ -172,6 +176,11 @@ void FlamePage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
         suggestCurrent();
     }
 
+    // TODO: Check whether it's a connection issue or the project disabled 3rd-party distribution.
+    if (current.versionsLoaded && ui->versionSelectionBox->count() < 1) {
+        ui->versionSelectionBox->addItem(tr("No version is available!"), -1);
+    }
+
     updateUi();
 }
 
@@ -181,7 +190,7 @@ void FlamePage::suggestCurrent()
         return;
     }
 
-    if (selectedVersion.isEmpty()) {
+    if (selectedVersion.isEmpty() || selectedVersion == "-1") {
         dialog->setSuggestedPack();
         return;
     }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -290,6 +290,10 @@ void ModpackListModel::searchRequestFinished(QJsonDocument& doc_all)
         searchState = CanPossiblyFetchMore;
     }
 
+    // When you have a Qt build with assertions turned on, proceeding here will abort the application
+    if (newList.size() == 0)
+        return;
+
     beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size() + newList.size() - 1);
     modpacks.append(newList);
     endInsertRows();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -104,6 +104,17 @@ auto ModpackListModel::data(const QModelIndex& index, int role) const -> QVarian
     return {};
 }
 
+bool ModpackListModel::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+    int pos = index.row();
+    if (pos >= modpacks.size() || pos < 0 || !index.isValid())
+        return false;
+
+    modpacks[pos] = value.value<Modrinth::Modpack>();
+
+    return true;
+}
+
 void ModpackListModel::performPaginatedSearch()
 {
     // TODO: Move to standalone API

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -64,6 +64,7 @@ class ModpackListModel : public QAbstractListModel {
 
     /* Retrieve information from the model at a given index with the given role */
     auto data(const QModelIndex& index, int role) const -> QVariant override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
 
     inline void setActiveJob(NetJob::Ptr ptr) { jobPtr = ptr; }
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -199,7 +199,10 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
             }
 
             for (auto version : current.versions) {
-                ui->versionSelectionBox->addItem(version.version, QVariant(version.id));
+                if (!version.name.contains(version.version))
+                    ui->versionSelectionBox->addItem(QString("%1 — %2").arg(version.name, version.version), QVariant(version.id));
+                else
+                    ui->versionSelectionBox->addItem(version.name, QVariant(version.id));
             }
 
             QVariant current_updated;
@@ -218,7 +221,10 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
 
     } else {
         for (auto version : current.versions) {
-            ui->versionSelectionBox->addItem(QString("%1 - %2").arg(version.name, version.version), QVariant(version.id));
+            if (!version.name.contains(version.version))
+                ui->versionSelectionBox->addItem(QString("%1 - %2").arg(version.name, version.version), QVariant(version.id));
+            else
+                ui->versionSelectionBox->addItem(version.name, QVariant(version.id));
         }
 
         suggestCurrent();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
@@ -63,9 +63,6 @@
          <height>48</height>
         </size>
        </property>
-       <property name="uniformItemSizes">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
      <item>

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -217,6 +217,11 @@ void Technic::ListModel::searchRequestFinished()
         return;
     }
     searchState = Finished;
+
+    // When you have a Qt build with assertions turned on, proceeding here will abort the application
+    if (newList.size() == 0)
+        return;
+
     beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size() + newList.size() - 1);
     modpacks.append(newList);
     endInsertRows();


### PR DESCRIPTION
95f7e1a44d4ebc84416244f2fba2c74de14d9bfe fixes #828
0d4f1b6b6aafae3cfbaa236f31b009ba720752e1 improves a little bit the UX when importing a modpack
c295819a3c529adaaba1e76f4a32cd189a466349 and 4a62cd03c809a1f7dcfb235d2e8b27d667fe42d2 improve the performance of Modrinth and Flame modpack browsing, respectively.
e3a453a2f0e50e9446d6230144521ab556de5b66 fixes #619
5e2e73e5ef66f6d509792954ff27e1ee246e2bb5 is a temporary workaround for #697 (the part where it doesn't show anything if a modpack is opted out :p)
d8c09b58b9c6e123da2d8c6ca8f9586506bf6281 prevents aborts in mod/modpack downloaders in some Qt configurations