### PR TITLE
Add news reader in the launcher

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -845,6 +845,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/NewComponentDialog.h
     ui/dialogs/NewInstanceDialog.cpp
     ui/dialogs/NewInstanceDialog.h
+    ui/dialogs/NewsDialog.cpp
+    ui/dialogs/NewsDialog.h
     ui/pagedialog/PageDialog.cpp
     ui/pagedialog/PageDialog.h
     ui/dialogs/ProgressDialog.cpp
@@ -954,6 +956,7 @@ qt5_wrap_ui(LAUNCHER_UI
     ui/dialogs/NewInstanceDialog.ui
     ui/dialogs/UpdateDialog.ui
     ui/dialogs/NewComponentDialog.ui
+    ui/dialogs/NewsDialog.ui
     ui/dialogs/ProfileSelectDialog.ui
     ui/dialogs/SkinUploadDialog.ui
     ui/dialogs/ExportInstanceDialog.ui

--- a/launcher/news/NewsEntry.cpp
+++ b/launcher/news/NewsEntry.cpp
@@ -54,7 +54,7 @@ inline QString childValue(const QDomElement& element, const QString& childName, 
 bool NewsEntry::fromXmlElement(const QDomElement& element, NewsEntry* entry, QString* errorMsg)
 {
     QString title = childValue(element, "title", tr("Untitled"));
-    QString content = childValue(element, "description", tr("No content."));
+    QString content = childValue(element, "content", tr("No content."));
     QString link = childValue(element, "id");
 
     entry->title = title;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -95,6 +95,7 @@
 #include "ui/instanceview/InstanceDelegate.h"
 #include "ui/widgets/LabeledToolButton.h"
 #include "ui/dialogs/NewInstanceDialog.h"
+#include "ui/dialogs/NewsDialog.h"
 #include "ui/dialogs/ProgressDialog.h"
 #include "ui/dialogs/AboutDialog.h"
 #include "ui/dialogs/VersionSelectDialog.h"
@@ -1952,20 +1953,17 @@ void MainWindow::on_actionOpenWiki_triggered()
 
 void MainWindow::on_actionMoreNews_triggered()
 {
-    DesktopServices::openUrl(QUrl(BuildConfig.NEWS_OPEN_URL));
+    auto entries = m_newsChecker->getNewsEntries();
+    NewsDialog news_dialog(entries, this);
+    news_dialog.exec();
 }
 
 void MainWindow::newsButtonClicked()
 {
-    QList<NewsEntryPtr> entries = m_newsChecker->getNewsEntries();
-    if (entries.count() > 0)
-    {
-        DesktopServices::openUrl(QUrl(entries[0]->link));
-    }
-    else
-    {
-        DesktopServices::openUrl(QUrl(BuildConfig.NEWS_OPEN_URL));
-    }
+    auto entries = m_newsChecker->getNewsEntries();
+    NewsDialog news_dialog(entries, this);
+    news_dialog.toggleArticleList();
+    news_dialog.exec();
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/launcher/ui/dialogs/NewsDialog.cpp
+++ b/launcher/ui/dialogs/NewsDialog.cpp
@@ -1,0 +1,49 @@
+#include "NewsDialog.h"
+#include "ui_NewsDialog.h"
+
+NewsDialog::NewsDialog(QList<NewsEntryPtr> entries, QWidget* parent) : QDialog(parent), ui(new Ui::NewsDialog())
+{
+    ui->setupUi(this);
+
+    for (auto entry : entries) {
+        ui->articleListWidget->addItem(entry->title);
+        m_entries.insert(entry->title, entry);
+    }
+
+    connect(ui->articleListWidget, &QListWidget::currentTextChanged, this, &NewsDialog::selectedArticleChanged);
+    connect(ui->toggleListButton, &QPushButton::clicked, this, &NewsDialog::toggleArticleList);
+
+    m_article_list_hidden = ui->articleListWidget->isHidden();
+
+    auto first_item = ui->articleListWidget->item(0);
+    ui->articleListWidget->setItemSelected(first_item, true);
+
+    auto article_entry = m_entries.constFind(first_item->text()).value();
+    ui->articleTitleLabel->setText(QString("<a href='%1'>%2</a>").arg(article_entry->link, first_item->text()));
+    ui->currentArticleContentBrowser->setText(article_entry->content);
+}
+
+NewsDialog::~NewsDialog()
+{
+    delete ui;
+}
+
+void NewsDialog::selectedArticleChanged(const QString& new_title)
+{
+    auto const& article_entry = m_entries.constFind(new_title).value();
+
+    ui->articleTitleLabel->setText(QString("<a href='%1'>%2</a>").arg(article_entry->link, new_title));
+    ui->currentArticleContentBrowser->setText(article_entry->content);
+}
+
+void NewsDialog::toggleArticleList()
+{
+    m_article_list_hidden = !m_article_list_hidden;
+
+    ui->articleListWidget->setHidden(m_article_list_hidden);
+
+    if (m_article_list_hidden)
+        ui->toggleListButton->setText(tr("Show article list"));
+    else
+        ui->toggleListButton->setText(tr("Hide article list"));
+}

--- a/launcher/ui/dialogs/NewsDialog.h
+++ b/launcher/ui/dialogs/NewsDialog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QDialog>
+#include <QHash>
+
+#include "news/NewsEntry.h"
+
+namespace Ui {
+class NewsDialog;
+}
+
+class NewsDialog : public QDialog {
+    Q_OBJECT
+
+   public:
+    NewsDialog(QList<NewsEntryPtr> entries, QWidget* parent = nullptr);
+    ~NewsDialog();
+
+   public slots:
+    void toggleArticleList();
+
+   private slots:
+    void selectedArticleChanged(const QString& new_title);
+
+   private:
+    Ui::NewsDialog* ui;
+
+    QHash<QString, NewsEntryPtr> m_entries;
+    bool m_article_list_hidden = false;
+};

--- a/launcher/ui/dialogs/NewsDialog.ui
+++ b/launcher/ui/dialogs/NewsDialog.ui
@@ -95,7 +95,7 @@
  <connections>
   <connection>
    <sender>closeButton</sender>
-   <signal>pressed()</signal>
+   <signal>clicked()</signal>
    <receiver>NewsDialog</receiver>
    <slot>accept()</slot>
    <hints>

--- a/launcher/ui/dialogs/NewsDialog.ui
+++ b/launcher/ui/dialogs/NewsDialog.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>NewsDialog</class>
+ <widget class="QDialog" name="NewsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>News</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="leftVerticalLayout">
+       <item>
+        <widget class="QListWidget" name="articleListWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="rightVerticalLayout">
+       <item>
+        <widget class="QLabel" name="articleTitleLabel">
+         <property name="text">
+          <string notr="true">Placeholder</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTextBrowser" name="currentArticleContentBrowser">
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="openLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <widget class="QPushButton" name="closeButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>10</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Close</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QPushButton" name="toggleListButton">
+       <property name="text">
+        <string>Hide article list</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>closeButton</sender>
+   <signal>pressed()</signal>
+   <receiver>NewsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>199</x>
+     <y>277</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>199</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Closes #536

Clicking the latest news button:
![only the latest news post is shown](https://user-images.githubusercontent.com/9145768/175793258-6cdf4c14-51df-458c-a8bd-9581dae6e399.png)

Clicking the "More news" button:
![the latest news post is selected, and there's a list at the left of other news posts](https://user-images.githubusercontent.com/9145768/175793269-d8ecf8c4-b9d0-4517-85ed-53a2b38d46bf.png)

I don't know if this one-click change is worth having two buttons, but removing the "More news" button altogether would also make it harder for the user to realize those buttons are clickable imo, so i think it's fine leaving it as it was before!
