### PR TITLE
Revert "Revert "Merge pull request #315 from txtsd/display_scaling""

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -27,6 +27,10 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
+
     // initialize Qt
     Application app(argc, argv);
 


### PR DESCRIPTION
This reverts #718 which reverts #315 which closed #307.
It creates an accessibility problem for people using high DPI displays (including myself);

Furthermore, #307 wasn't re-opened by #718, even though it should have been.

This reopens #331.
Icon scaling is less important than accessibility.