### PR TITLE
Add WinGet Releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: PolyMC.PolyMC
+          installers-regex: '\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Closes #793

This pull request adds a workflow that automatically publishes PolyMC to WinGet every release (#793). *Please do not merge this pull request without reading the below and making the required changes* (The token part is the important bit) :)

- `runs-on: windows-latest`

The WinGet Releaser action can only run on Windows.

</br>

- `identifier: PolyMC.PolyMC`

This is the identifier for PolyMC on Winget. It will use this to find PolyMC's current package on WinGet.

</br>

- `installers-regex: '\.exe$'`

This will include all `.exe` files in the assets of the latest PolyMC release (The x64 and x86 variation) in the pull request.

</br>

- `token: ${{ secrets.WINGET_TOKEN }}`

This is the bit that will require action from the person whose account will be used for the pull requests (a member of the PolyMC GitHub organisation). This is a GitHub token with which the action will authenticate with GitHub and create a pull request on the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

To do this, you will need to:

1. Create a Personal Access Token (PAT) with `public_repo` scope.

![image](https://user-images.githubusercontent.com/74878137/170548538-0d689177-5c9e-4bb2-8a87-e09eb5ca64e8.png)

2. Create a repository secret containing the token. **Super important: call this token: `WINGET_TOKEN`**.
See [using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) for more details.

</br>

**Finally, a fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) needs to be created under the PolyMC organisation. Please do not delete the fork after a pull request has been merged as the action will use that fork for making a branch and merging it with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every PolyMC release.**

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro) and the source code is [here](https://github.com/vedantmgoyal2009/winget-releaser).

Edit: If you would like for only the latest version of PolyMC to be available on WinGet, WinGet Releaser allows for the previous version to be deleted when a new manifest is created, if that is desired, by adding `delete-previous-version: 'true'`.