### PR TITLE
Improve the account selection window

### DIFF
--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -473,7 +473,7 @@ QString AccountData::accountDisplayString() const {
             return userName();
         }
         case AccountType::Offline: {
-            return userName();
+            return "<Offline>";
         }
         case AccountType::MSA: {
             if(xboxApiToken.extra.contains("gtg")) {

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -473,7 +473,7 @@ QString AccountData::accountDisplayString() const {
             return userName();
         }
         case AccountType::Offline: {
-            return "<Offline>";
+            return QObject::tr("<Offline>");
         }
         case AccountType::MSA: {
             if(xboxApiToken.extra.contains("gtg")) {

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -473,7 +473,7 @@ QString AccountData::accountDisplayString() const {
             return userName();
         }
         case AccountType::Offline: {
-            return "<Offline>";
+            return tr("<Offline>");
         }
         case AccountType::MSA: {
             if(xboxApiToken.extra.contains("gtg")) {

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -282,6 +282,10 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
         case Qt::DisplayRole:
             switch (index.column())
             {
+            case ProfileNameColumn: {
+                return account->profileName();
+            }
+
             case NameColumn:
                 return account->accountDisplayString();
 
@@ -318,10 +322,6 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                         return tr("Gone", "Account status");
                     }
                 }
-            }
-
-            case ProfileNameColumn: {
-                return account->profileName();
             }
 
             case MigrationColumn: {
@@ -365,6 +365,8 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
     case Qt::DisplayRole:
         switch (section)
         {
+        case ProfileNameColumn:
+            return tr("Profile");
         case NameColumn:
             return tr("Account");
         case TypeColumn:
@@ -373,8 +375,6 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
             return tr("Status");
         case MigrationColumn:
             return tr("Can Migrate?");
-        case ProfileNameColumn:
-            return tr("Profile");
         default:
             return QVariant();
         }
@@ -382,6 +382,8 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
     case Qt::ToolTipRole:
         switch (section)
         {
+        case ProfileNameColumn:
+            return tr("Name of the Minecraft profile associated with the account.");
         case NameColumn:
             return tr("User name of the account.");
         case TypeColumn:
@@ -390,8 +392,6 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
             return tr("Current status of the account.");
         case MigrationColumn:
             return tr("Can this account migrate to Microsoft account?");
-        case ProfileNameColumn:
-            return tr("Name of the Minecraft profile associated with the account.");
         default:
             return QVariant();
         }

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -304,7 +304,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                         return tr("Offline", "Account status");
                     }
                     case AccountState::Online: {
-                        return tr("Online", "Account status");
+                        return tr("Ready", "Account status");
                     }
                     case AccountState::Working: {
                         return tr("Working", "Account status");

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -366,7 +366,7 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
         switch (section)
         {
         case ProfileNameColumn:
-            return tr("Profile");
+            return tr("Username");
         case NameColumn:
             return tr("Account");
         case TypeColumn:
@@ -383,7 +383,7 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
         switch (section)
         {
         case ProfileNameColumn:
-            return tr("Name of the Minecraft profile associated with the account.");
+            return tr("Minecraft username associated with the account.");
         case NameColumn:
             return tr("User name of the account.");
         case TypeColumn:
@@ -391,7 +391,7 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
         case StatusColumn:
             return tr("Current status of the account.");
         case MigrationColumn:
-            return tr("Can this account migrate to Microsoft account?");
+            return tr("Can this account migrate to a Microsoft account?");
         default:
             return QVariant();
         }

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -349,7 +349,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
         case Qt::CheckStateRole:
             switch (index.column())
             {
-                case NameColumn:
+                case ProfileNameColumn:
                     return account == m_defaultAccount ? Qt::Checked : Qt::Unchecked;
             }
 

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -58,8 +58,8 @@ public:
     enum VListColumns
     {
         // TODO: Add icon column.
-        NameColumn = 0,
-        ProfileNameColumn,
+        ProfileNameColumn = 0,
+        NameColumn,
         MigrationColumn,
         TypeColumn,
         StatusColumn,

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -73,9 +73,11 @@ AccountListPage::AccountListPage(QWidget *parent)
     m_accounts = APPLICATION->accounts();
 
     ui->listView->setModel(m_accounts.get());
-    ui->listView->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-    ui->listView->header()->setSectionResizeMode(1, QHeaderView::Stretch);
-    ui->listView->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::ProfileNameColumn, QHeaderView::Stretch);
+    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::NameColumn, QHeaderView::Stretch);
+    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::MigrationColumn, QHeaderView::ResizeToContents);
+    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::TypeColumn, QHeaderView::ResizeToContents);
+    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::StatusColumn, QHeaderView::ResizeToContents);
     ui->listView->setSelectionMode(QAbstractItemView::SingleSelection);
 
     // Expand the account column

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -269,7 +269,7 @@ void AccountListPage::updateButtonStates()
     ui->actionSetDefault->setEnabled(accountIsReady);
     ui->actionUploadSkin->setEnabled(accountIsReady && accountIsOnline);
     ui->actionDeleteSkin->setEnabled(accountIsReady && accountIsOnline);
-    ui->actionRefresh->setEnabled(accountIsReady);
+    ui->actionRefresh->setEnabled(accountIsReady && accountIsOnline);
 
     if(m_accounts->defaultAccount().get() == nullptr) {
         ui->actionNoDefault->setEnabled(false);

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -255,18 +255,20 @@ void AccountListPage::updateButtonStates()
 {
     // If there is no selection, disable buttons that require something selected.
     QModelIndexList selection = ui->listView->selectionModel()->selectedIndexes();
-    bool hasSelection = selection.size() > 0;
+    bool hasSelection = !selection.empty();
     bool accountIsReady = false;
+    bool accountIsOnline;
     if (hasSelection)
     {
         QModelIndex selected = selection.first();
         MinecraftAccountPtr account = selected.data(AccountList::PointerRole).value<MinecraftAccountPtr>();
         accountIsReady = !account->isActive();
+        accountIsOnline = !account->isOffline();
     }
     ui->actionRemove->setEnabled(accountIsReady);
     ui->actionSetDefault->setEnabled(accountIsReady);
-    ui->actionUploadSkin->setEnabled(accountIsReady);
-    ui->actionDeleteSkin->setEnabled(accountIsReady);
+    ui->actionUploadSkin->setEnabled(accountIsReady && accountIsOnline);
+    ui->actionDeleteSkin->setEnabled(accountIsReady && accountIsOnline);
     ui->actionRefresh->setEnabled(accountIsReady);
 
     if(m_accounts->defaultAccount().get() == nullptr) {


### PR DESCRIPTION
Implements most suggestions in #361.

### User-facing changes:

- Renamed the Profile column to "Username" and updated the tooltip.
	- Also fixed a minor typo.
- Moved the Username column to the left.
- Shows `<Offline>` instead of the minecraft username in the Account name column for offline accounts.
- Set the Username and and Account columns to `Stretch` and the remaining columns to `ResizeToContents`.
- Disabled the refresh, upload skin and delete skin buttons for offline accounts.
- Renamed the `Online` account state to `Ready`

### Internal changes:

- Uses the `AccountList::VListColumns` enum to set column resize modes instead of raw numbers.

### Not implemented in this PR:

- Automatic column hiding.
- Renaming the Account column.
	- The proposed name doesn't make much sense while Mojang accounts are still supported.