### PR TITLE
Show MC version of instance in status bar

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -826,8 +826,16 @@ QString MinecraftInstance::getStatusbarDescription()
         traits.append(tr("broken"));
     }
 
+    QString mcVersion = m_components->getComponentVersion("net.minecraft");
+    if (mcVersion.isEmpty())
+    {
+        // Load component info if needed
+        m_components->reload(Net::Mode::Offline);
+        mcVersion = m_components->getComponentVersion("net.minecraft");
+    }
+
     QString description;
-    description.append(tr("Minecraft %1 (%2)").arg(m_components->getComponentVersion("net.minecraft")).arg(typeName()));
+    description.append(tr("Minecraft %1 (%2)").arg(mcVersion).arg(typeName()));
     if(m_settings->get("ShowGameTime").toBool())
     {
         if (lastTimePlayed() > 0) {

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -835,7 +835,7 @@ QString MinecraftInstance::getStatusbarDescription()
     }
 
     QString description;
-    description.append(tr("Minecraft %1 (%2)").arg(mcVersion).arg(typeName()));
+    description.append(tr("Minecraft %1").arg(mcVersion));
     if(m_settings->get("ShowGameTime").toBool())
     {
         if (lastTimePlayed() > 0) {


### PR DESCRIPTION
Fix #854 by loading instance component info if necessary

Also removes a redundant "(Minecraft)" in every description.