### PR TITLE
Don't censor offline access token

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -747,7 +747,9 @@ QMap<QString, QString> MinecraftInstance::createCensorFilterFromSession(AuthSess
     {
         addToFilter(sessionRef.session, tr("<SESSION ID>"));
     }
-    addToFilter(sessionRef.access_token, tr("<ACCESS TOKEN>"));
+    if (sessionRef.access_token != "offline") {
+        addToFilter(sessionRef.access_token, tr("<ACCESS TOKEN>"));
+    }
     if(sessionRef.client_token.size()) {
         addToFilter(sessionRef.client_token, tr("<CLIENT TOKEN>"));
     }


### PR DESCRIPTION
**Abstract:**
Microsoft servers were offline too much for my taste, so these days when I play single-player it's exclusively in the offline mode, with an offline account.
I usually do add various mods to the modpack to bring back features that are missing by being offline (like offlineskins mod).
But when looking in the logs, I've noticed that PolyMC censors every mentioning of "offline", and after some research this PR was born.

**Changes in this PR:**
When using an offline account - don't censor it's access token ("offline") in the logs, because it causes unnecessary obfuscation, and anyways easy to deduce that the token is "offline" by examining what exactly was censored (like mods' names).

For the record, in my current play-thru the following 2 lines in the latest.log are currently will become uncensored after applying this patch:
```
$ grep -i offline latest.log
	- offlineskins 1.18.2-v2-fabric
[15:09:52] [main/WARN]: Unrecognized user type: offline
```