### PR TITLE
fix: Add extra-cmake-modules to the nix build

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -15,6 +15,7 @@
 , libGL
 , msaClientID ? ""
 , extraJDKs ? [ ]
+, extra-cmake-modules
 
   # flake
 , self
@@ -47,7 +48,7 @@ stdenv.mkDerivation rec {
 
   src = lib.cleanSource self;
 
-  nativeBuildInputs = [ cmake ninja jdk file wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk file wrapQtAppsHook ];
   buildInputs = [ qtbase quazip zlib ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
#784 added extra-cmake-modules in the dependencies but did not add them to the dependencies of the nix derivation, causing build failures. This PR fixes that.