### PR TITLE
Fix release builds

### DIFF
--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -257,7 +257,7 @@ void AccountListPage::updateButtonStates()
     QModelIndexList selection = ui->listView->selectionModel()->selectedIndexes();
     bool hasSelection = !selection.empty();
     bool accountIsReady = false;
-    bool accountIsOnline;
+    bool accountIsOnline = false;
     if (hasSelection)
     {
         QModelIndex selected = selection.first();


### PR DESCRIPTION
CC @Gingeh 

`CMAKE_BUILD_TYPE=Release` makes the build fail otherwise.

Complements #855

```
PolyMC/launcher/ui/pages/global/AccountListPage.cpp: In member function ‘void AccountListPage::updateButtonStates()’:
PolyMC/launcher/ui/pages/global/AccountListPage.cpp:270:53: error: ‘accountIsOnline’ may be used uninitialized [-Werror=maybe-uninitialized]
  270 |     ui->actionUploadSkin->setEnabled(accountIsReady && accountIsOnline);
      |                                      ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
PolyMC/launcher/ui/pages/global/AccountListPage.cpp:260:10: note: ‘accountIsOnline’ was declared here
  260 |     bool accountIsOnline;
      |          ^~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```