### PR TITLE
Lazy-load type-specific instance settings

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -52,6 +52,7 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     : QObject()
 {
     m_settings = settings;
+    m_global_settings = globalSettings;
     m_rootDir = rootDir;
 
     m_settings->registerSetting("name", "Unnamed Instance");

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -149,7 +149,7 @@ void BaseInstance::setManagedPack(const QString& type, const QString& id, const 
 
 int BaseInstance::getConsoleMaxLines() const
 {
-    auto lineSetting = settings()->getSetting("ConsoleMaxLines");
+    auto lineSetting = m_settings->getSetting("ConsoleMaxLines");
     bool conversionOk = false;
     int maxLines = lineSetting->get().toInt(&conversionOk);
     if(!conversionOk)
@@ -162,7 +162,7 @@ int BaseInstance::getConsoleMaxLines() const
 
 bool BaseInstance::shouldStopOnConsoleOverflow() const
 {
-    return settings()->get("ConsoleOverflowStop").toBool();
+    return m_settings->get("ConsoleOverflowStop").toBool();
 }
 
 void BaseInstance::iconUpdated(QString key)
@@ -237,7 +237,7 @@ void BaseInstance::setRunning(bool running)
 
 int64_t BaseInstance::totalTimePlayed() const
 {
-    qint64 current = settings()->get("totalTimePlayed").toLongLong();
+    qint64 current = m_settings->get("totalTimePlayed").toLongLong();
     if(m_isRunning)
     {
         QDateTime timeNow = QDateTime::currentDateTime();
@@ -253,7 +253,7 @@ int64_t BaseInstance::lastTimePlayed() const
         QDateTime timeNow = QDateTime::currentDateTime();
         return m_timeStarted.secsTo(timeNow);
     }
-    return settings()->get("lastTimePlayed").toLongLong();
+    return m_settings->get("lastTimePlayed").toLongLong();
 }
 
 void BaseInstance::resetTimePlayed()
@@ -272,8 +272,10 @@ QString BaseInstance::instanceRoot() const
     return m_rootDir;
 }
 
-SettingsObjectPtr BaseInstance::settings() const
+SettingsObjectPtr BaseInstance::settings()
 {
+    loadSpecificSettings();
+
     return m_settings;
 }
 
@@ -340,7 +342,7 @@ QString BaseInstance::windowTitle() const
 }
 
 // FIXME: why is this here? move it to MinecraftInstance!!!
-QStringList BaseInstance::extraArguments() const
+QStringList BaseInstance::extraArguments()
 {
     return Commandline::splitArgs(settings()->get("JvmArgs").toString());
 }

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -58,9 +58,15 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     m_settings->registerSetting("name", "Unnamed Instance");
     m_settings->registerSetting("iconKey", "default");
     m_settings->registerSetting("notes", "");
+
     m_settings->registerSetting("lastLaunchTime", 0);
     m_settings->registerSetting("totalTimePlayed", 0);
     m_settings->registerSetting("lastTimePlayed", 0);
+
+    // Game time override
+    auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
+    m_settings->registerOverride(globalSettings->getSetting("ShowGameTime"), gameTimeOverride);
+    m_settings->registerOverride(globalSettings->getSetting("RecordGameTime"), gameTimeOverride);
 
     // NOTE: Sometimees InstanceType is already registered, as it was used to identify the type of
     // a locally stored instance

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -174,6 +174,11 @@ public:
      */
     virtual SettingsObjectPtr settings() const;
 
+    /*!
+     * \brief Loads instance settings if they're not already loaded.
+     */
+    virtual void loadSettingsIfNeeded() = 0;
+
     /// returns a valid update task
     virtual Task::Ptr createUpdateTask(Net::Mode mode) = 0;
 
@@ -285,7 +290,11 @@ protected slots:
 
 protected: /* data */
     QString m_rootDir;
+
     SettingsObjectPtr m_settings;
+    SettingsObjectWeakPtr m_global_settings;
+    bool m_settings_loaded = false;
+
     // InstanceFlags m_flags;
     bool m_isRunning = false;
     shared_qobject_ptr<LaunchTask> m_launchProcess;

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -154,7 +154,7 @@ public:
         return level;
     };
 
-    virtual QStringList extraArguments() const;
+    virtual QStringList extraArguments();
 
     /// Traits. Normally inside the version, depends on instance implementation.
     virtual QSet <QString> traits() const = 0;
@@ -170,14 +170,18 @@ public:
     /*!
      * \brief Gets this instance's settings object.
      * This settings object stores instance-specific settings.
+     *
+     * Note that this method is not const.
+     * It may call loadSpecificSettings() to ensure those are loaded.
+     *
      * \return A pointer to this instance's settings object.
      */
-    virtual SettingsObjectPtr settings() const;
+    virtual SettingsObjectPtr settings();
 
     /*!
-     * \brief Loads instance settings if they're not already loaded.
+     * \brief Loads settings specific to an instance type if they're not already loaded.
      */
-    virtual void loadSettingsIfNeeded() = 0;
+    virtual void loadSpecificSettings() = 0;
 
     /// returns a valid update task
     virtual Task::Ptr createUpdateTask(Net::Mode mode) = 0;
@@ -211,7 +215,7 @@ public:
     virtual QString instanceConfigFolder() const = 0;
 
     /// get variables this instance exports
-    virtual QMap<QString, QString> getVariables() const = 0;
+    virtual QMap<QString, QString> getVariables() = 0;
 
     virtual QString typeName() const = 0;
 
@@ -273,6 +277,11 @@ public:
 protected:
     void changeStatus(Status newStatus);
 
+    SettingsObjectPtr globalSettings() const { return m_global_settings.lock(); };
+
+    bool isSpecificSettingsLoaded() const { return m_specific_settings_loaded; }
+    void setSpecificSettingsLoaded(bool loaded) { m_specific_settings_loaded = loaded; }
+
 signals:
     /*!
      * \brief Signal emitted when properties relevant to the instance view change
@@ -290,11 +299,7 @@ protected slots:
 
 protected: /* data */
     QString m_rootDir;
-
     SettingsObjectPtr m_settings;
-    SettingsObjectWeakPtr m_global_settings;
-    bool m_settings_loaded = false;
-
     // InstanceFlags m_flags;
     bool m_isRunning = false;
     shared_qobject_ptr<LaunchTask> m_launchProcess;
@@ -305,6 +310,10 @@ private: /* data */
     bool m_crashed = false;
     bool m_hasUpdate = false;
     bool m_hasBrokenVersion = false;
+
+    SettingsObjectWeakPtr m_global_settings;
+    bool m_specific_settings_loaded = false;
+
 };
 
 Q_DECLARE_METATYPE(shared_qobject_ptr<BaseInstance>)

--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -15,6 +15,10 @@ public:
     void saveNow() override
     {
     }
+    void loadSettingsIfNeeded() override
+    {
+        m_settings_loaded = true;
+    }
     QString getStatusbarDescription() override
     {
         return tr("Unknown instance type");

--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -15,9 +15,9 @@ public:
     void saveNow() override
     {
     }
-    void loadSettingsIfNeeded() override
+    void loadSpecificSettings() override
     {
-        m_settings_loaded = true;
+        setSpecificSettingsLoaded(true);
     }
     QString getStatusbarDescription() override
     {
@@ -47,7 +47,7 @@ public:
     {
         return QProcessEnvironment();
     }
-    QMap<QString, QString> getVariables() const override
+    QMap<QString, QString> getVariables() override
     {
         return QMap<QString, QString>();
     }

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -174,11 +174,6 @@ void MinecraftInstance::loadSpecificSettings()
         m_settings->registerOverride(global_settings->getSetting("EnableMangoHud"), performanceOverride);
         m_settings->registerOverride(global_settings->getSetting("UseDiscreteGpu"), performanceOverride);
 
-        // Game time
-        auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
-        m_settings->registerOverride(global_settings->getSetting("ShowGameTime"), gameTimeOverride);
-        m_settings->registerOverride(global_settings->getSetting("RecordGameTime"), gameTimeOverride);
-
         // Miscellaneous
         auto miscellaneousOverride = m_settings->registerSetting("OverrideMiscellaneous", false);
         m_settings->registerOverride(global_settings->getSetting("CloseAfterLaunch"), miscellaneousOverride);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -115,8 +115,6 @@ private:
 MinecraftInstance::MinecraftInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr settings, const QString &rootDir)
     : BaseInstance(globalSettings, settings, rootDir)
 {
-    loadSettingsIfNeeded();
-
     m_components.reset(new PackProfile(this));
 }
 
@@ -125,9 +123,9 @@ void MinecraftInstance::saveNow()
     m_components->saveNow();
 }
 
-void MinecraftInstance::loadSettingsIfNeeded()
+void MinecraftInstance::loadSpecificSettings()
 {
-    if (m_settings_loaded)
+    if (isSpecificSettingsLoaded())
         return;
 
     // Java Settings
@@ -139,52 +137,52 @@ void MinecraftInstance::loadSettingsIfNeeded()
     auto javaOrLocation = std::make_shared<OrSetting>("JavaOrLocationOverride", javaOverride, locationOverride);
     auto javaOrArgs = std::make_shared<OrSetting>("JavaOrArgsOverride", javaOverride, argsOverride);
 
-    if (auto globalSettings = m_global_settings.lock()) {
-        m_settings->registerOverride(globalSettings->getSetting("JavaPath"), javaOrLocation);
-        m_settings->registerOverride(globalSettings->getSetting("JvmArgs"), javaOrArgs);
-        m_settings->registerOverride(globalSettings->getSetting("IgnoreJavaCompatibility"), javaOrLocation);
+    if (auto global_settings = globalSettings()) {
+        m_settings->registerOverride(global_settings->getSetting("JavaPath"), javaOrLocation);
+        m_settings->registerOverride(global_settings->getSetting("JvmArgs"), javaOrArgs);
+        m_settings->registerOverride(global_settings->getSetting("IgnoreJavaCompatibility"), javaOrLocation);
 
         // special!
-        m_settings->registerPassthrough(globalSettings->getSetting("JavaTimestamp"), javaOrLocation);
-        m_settings->registerPassthrough(globalSettings->getSetting("JavaVersion"), javaOrLocation);
-        m_settings->registerPassthrough(globalSettings->getSetting("JavaArchitecture"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaTimestamp"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaVersion"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaArchitecture"), javaOrLocation);
 
         // Window Size
         auto windowSetting = m_settings->registerSetting("OverrideWindow", false);
-        m_settings->registerOverride(globalSettings->getSetting("LaunchMaximized"), windowSetting);
-        m_settings->registerOverride(globalSettings->getSetting("MinecraftWinWidth"), windowSetting);
-        m_settings->registerOverride(globalSettings->getSetting("MinecraftWinHeight"), windowSetting);
+        m_settings->registerOverride(global_settings->getSetting("LaunchMaximized"), windowSetting);
+        m_settings->registerOverride(global_settings->getSetting("MinecraftWinWidth"), windowSetting);
+        m_settings->registerOverride(global_settings->getSetting("MinecraftWinHeight"), windowSetting);
 
         // Memory
         auto memorySetting = m_settings->registerSetting("OverrideMemory", false);
-        m_settings->registerOverride(globalSettings->getSetting("MinMemAlloc"), memorySetting);
-        m_settings->registerOverride(globalSettings->getSetting("MaxMemAlloc"), memorySetting);
-        m_settings->registerOverride(globalSettings->getSetting("PermGen"), memorySetting);
+        m_settings->registerOverride(global_settings->getSetting("MinMemAlloc"), memorySetting);
+        m_settings->registerOverride(global_settings->getSetting("MaxMemAlloc"), memorySetting);
+        m_settings->registerOverride(global_settings->getSetting("PermGen"), memorySetting);
 
         // Minecraft launch method
         auto launchMethodOverride = m_settings->registerSetting("OverrideMCLaunchMethod", false);
-        m_settings->registerOverride(globalSettings->getSetting("MCLaunchMethod"), launchMethodOverride);
+        m_settings->registerOverride(global_settings->getSetting("MCLaunchMethod"), launchMethodOverride);
 
         // Native library workarounds
         auto nativeLibraryWorkaroundsOverride = m_settings->registerSetting("OverrideNativeWorkarounds", false);
-        m_settings->registerOverride(globalSettings->getSetting("UseNativeOpenAL"), nativeLibraryWorkaroundsOverride);
-        m_settings->registerOverride(globalSettings->getSetting("UseNativeGLFW"), nativeLibraryWorkaroundsOverride);
+        m_settings->registerOverride(global_settings->getSetting("UseNativeOpenAL"), nativeLibraryWorkaroundsOverride);
+        m_settings->registerOverride(global_settings->getSetting("UseNativeGLFW"), nativeLibraryWorkaroundsOverride);
 
         // Peformance related options
         auto performanceOverride = m_settings->registerSetting("OverridePerformance", false);
-        m_settings->registerOverride(globalSettings->getSetting("EnableFeralGamemode"), performanceOverride);
-        m_settings->registerOverride(globalSettings->getSetting("EnableMangoHud"), performanceOverride);
-        m_settings->registerOverride(globalSettings->getSetting("UseDiscreteGpu"), performanceOverride);
+        m_settings->registerOverride(global_settings->getSetting("EnableFeralGamemode"), performanceOverride);
+        m_settings->registerOverride(global_settings->getSetting("EnableMangoHud"), performanceOverride);
+        m_settings->registerOverride(global_settings->getSetting("UseDiscreteGpu"), performanceOverride);
 
         // Game time
         auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
-        m_settings->registerOverride(globalSettings->getSetting("ShowGameTime"), gameTimeOverride);
-        m_settings->registerOverride(globalSettings->getSetting("RecordGameTime"), gameTimeOverride);
+        m_settings->registerOverride(global_settings->getSetting("ShowGameTime"), gameTimeOverride);
+        m_settings->registerOverride(global_settings->getSetting("RecordGameTime"), gameTimeOverride);
 
         // Miscellaneous
         auto miscellaneousOverride = m_settings->registerSetting("OverrideMiscellaneous", false);
-        m_settings->registerOverride(globalSettings->getSetting("CloseAfterLaunch"), miscellaneousOverride);
-        m_settings->registerOverride(globalSettings->getSetting("QuitAfterGameStop"), miscellaneousOverride);
+        m_settings->registerOverride(global_settings->getSetting("CloseAfterLaunch"), miscellaneousOverride);
+        m_settings->registerOverride(global_settings->getSetting("QuitAfterGameStop"), miscellaneousOverride);
 
         m_settings->set("InstanceType", "OneSix");
     }
@@ -193,7 +191,9 @@ void MinecraftInstance::loadSettingsIfNeeded()
     m_settings->registerSetting("JoinServerOnLaunch", false);
     m_settings->registerSetting("JoinServerOnLaunchAddress", "");
 
-    m_settings_loaded = true;
+    qDebug() << "Instance-type specific settings were loaded!";
+
+    setSpecificSettingsLoaded(true);
 }
 
 QString MinecraftInstance::typeName() const
@@ -320,7 +320,7 @@ QDir MinecraftInstance::versionsPath() const
     return QDir::current().absoluteFilePath("versions");
 }
 
-QStringList MinecraftInstance::getClassPath() const
+QStringList MinecraftInstance::getClassPath()
 {
     QStringList jars, nativeJars;
     auto javaArchitecture = settings()->get("JavaArchitecture").toString();
@@ -335,7 +335,7 @@ QString MinecraftInstance::getMainClass() const
     return profile->getMainClass();
 }
 
-QStringList MinecraftInstance::getNativeJars() const
+QStringList MinecraftInstance::getNativeJars()
 {
     QStringList jars, nativeJars;
     auto javaArchitecture = settings()->get("JavaArchitecture").toString();
@@ -344,7 +344,7 @@ QStringList MinecraftInstance::getNativeJars() const
     return nativeJars;
 }
 
-QStringList MinecraftInstance::extraArguments() const
+QStringList MinecraftInstance::extraArguments()
 {
     auto list = BaseInstance::extraArguments();
     auto version = getPackProfile();
@@ -370,7 +370,7 @@ QStringList MinecraftInstance::extraArguments() const
     return list;
 }
 
-QStringList MinecraftInstance::javaArguments() const
+QStringList MinecraftInstance::javaArguments()
 {
     QStringList args;
 
@@ -427,7 +427,7 @@ QStringList MinecraftInstance::javaArguments() const
     return args;
 }
 
-QMap<QString, QString> MinecraftInstance::getVariables() const
+QMap<QString, QString> MinecraftInstance::getVariables()
 {
     QMap<QString, QString> out;
     out.insert("INST_NAME", name());
@@ -951,9 +951,9 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         process->appendStep(new CreateGameFolders(pptr));
     }
 
-    if (!serverToJoin && m_settings->get("JoinServerOnLaunch").toBool())
+    if (!serverToJoin && settings()->get("JoinServerOnLaunch").toBool())
     {
-        QString fullAddress = m_settings->get("JoinServerOnLaunchAddress").toString();
+        QString fullAddress = settings()->get("JoinServerOnLaunchAddress").toString();
         serverToJoin.reset(new MinecraftServerTarget(MinecraftServerTarget::parse(fullAddress)));
     }
 
@@ -1061,10 +1061,10 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
 
 QString MinecraftInstance::launchMethod()
 {
-    return m_settings->get("MCLaunchMethod").toString();
+    return settings()->get("MCLaunchMethod").toString();
 }
 
-JavaVersion MinecraftInstance::getJavaVersion() const
+JavaVersion MinecraftInstance::getJavaVersion()
 {
     return JavaVersion(settings()->get("JavaVersion").toString());
 }

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -20,7 +20,7 @@ public:
     virtual ~MinecraftInstance() {};
     virtual void saveNow() override;
 
-    void loadSettingsIfNeeded() override;
+    void loadSpecificSettings() override;
 
     // FIXME: remove
     QString typeName() const override;
@@ -81,15 +81,15 @@ public:
     //////  Launch stuff //////
     Task::Ptr createUpdateTask(Net::Mode mode) override;
     shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override;
-    QStringList extraArguments() const override;
+    QStringList extraArguments() override;
     QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
     QList<Mod> getJarMods() const;
     QString createLaunchScript(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin);
     /// get arguments passed to java
-    QStringList javaArguments() const;
+    QStringList javaArguments();
 
     /// get variables for launch command variable substitution/environment
-    QMap<QString, QString> getVariables() const override;
+    QMap<QString, QString> getVariables() override;
 
     /// create an environment for launching processes
     QProcessEnvironment createEnvironment() override;
@@ -105,16 +105,16 @@ public:
     QString getStatusbarDescription() override;
 
     // FIXME: remove
-    virtual QStringList getClassPath() const;
+    virtual QStringList getClassPath();
     // FIXME: remove
-    virtual QStringList getNativeJars() const;
+    virtual QStringList getNativeJars();
     // FIXME: remove
     virtual QString getMainClass() const;
 
     // FIXME: remove
     virtual QStringList processMinecraftArgs(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) const;
 
-    virtual JavaVersion getJavaVersion() const;
+    virtual JavaVersion getJavaVersion();
 
 protected:
     QMap<QString, QString> createCensorFilterFromSession(AuthSessionPtr session);

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -20,6 +20,8 @@ public:
     virtual ~MinecraftInstance() {};
     virtual void saveNow() override;
 
+    void loadSettingsIfNeeded() override;
+
     // FIXME: remove
     QString typeName() const override;
     // FIXME: remove

--- a/launcher/settings/SettingsObject.h
+++ b/launcher/settings/SettingsObject.h
@@ -25,6 +25,7 @@ class Setting;
 class SettingsObject;
 
 typedef std::shared_ptr<SettingsObject> SettingsObjectPtr;
+typedef std::weak_ptr<SettingsObject> SettingsObjectWeakPtr;
 
 /*!
  * \brief The SettingsObject handles communicating settings between the application and a


### PR DESCRIPTION
Until now, we used to load all instance settings on startup. This was specially costly for `MinecraftInstance`, which dominated perf data on startup.
Now, we lazy load those settings once someone needs to access them, usually when they click 'Edit instance' or go play the instance.

On a config with 28 instances, some very basics tests provided a reduction from ~1.6s to ~0.6s until the UI popped up. Of course, not the biggest changes in the world, but the more instances you have, the bigger the difference will be (also, makes valgrind sessions a bit more bearable) :D