### PR TITLE
Refactor filtering of environment variables

### DIFF
--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -18,13 +18,17 @@ LAUNCHER_NAME=@Launcher_APP_BINARY_NAME@
 LAUNCHER_DIR="$(dirname "$(readlink -f "$0")")"
 echo "Launcher Dir: ${LAUNCHER_DIR}"
 
-# Set up env - filter out input LD_ variables but pass them in under different names
-export GAME_LIBRARY_PATH=${GAME_LIBRARY_PATH-${LD_LIBRARY_PATH}}
-export GAME_PRELOAD=${GAME_PRELOAD-${LD_PRELOAD}}
-export LD_LIBRARY_PATH="${LAUNCHER_DIR}/lib@LIB_SUFFIX@":$LAUNCHER_LIBRARY_PATH
-export LD_PRELOAD=$LAUNCHER_PRELOAD
-export QT_PLUGIN_PATH="${LAUNCHER_DIR}/plugins"
-export QT_FONTPATH="${LAUNCHER_DIR}/fonts"
+# Set up env.
+# Pass our custom variables separately so that the launcher can remove them for child processes
+export LAUNCHER_LD_LIBRARY_PATH="${LAUNCHER_DIR}/lib@LIB_SUFFIX@"
+export LAUNCHER_LD_PRELOAD=""
+export LAUNCHER_QT_PLUGIN_PATH="${LAUNCHER_DIR}/plugins"
+export LAUNCHER_QT_FONTPATH="${LAUNCHER_DIR}/fonts"
+
+export LD_LIBRARY_PATH="$LAUNCHER_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
+export LD_PRELOAD="$LAUNCHER_LD_PRELOAD:$LD_PRELOAD"
+export QT_PLUGIN_PATH="$LAUNCHER_QT_PLUGIN_PATH:$QT_PLUGIN_PATH"
+export QT_FONTPATH="$LAUNCHER_QT_FONTPATH:$QT_FONTPATH"
 
 # Detect missing dependencies...
 DEPS_LIST=`ldd "${LAUNCHER_DIR}"/plugins/*/*.so 2>/dev/null | grep "not found" | sort -u | awk -vORS=", " '{ print $1 }'`

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -52,25 +52,24 @@ JavaUtils::JavaUtils()
 {
 }
 
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-static QString processLD_LIBRARY_PATH(const QString & LD_LIBRARY_PATH)
+QString stripVariableEntries(QString name, QString target, QString remove)
 {
-    QDir mmcBin(QCoreApplication::applicationDirPath());
-    auto items = LD_LIBRARY_PATH.split(':');
-    QStringList final;
-    for(auto & item: items)
-    {
-        QDir test(item);
-        if(test == mmcBin)
-        {
-            qDebug() << "Env:LD_LIBRARY_PATH ignoring path" << item;
-            continue;
-        }
-        final.append(item);
-    }
-    return final.join(':');
-}
+    char delimiter = ':';
+#ifdef Q_OS_WIN32
+    delimiter = ';';
 #endif
+
+    auto targetItems = target.split(delimiter);
+    auto toRemove = remove.split(delimiter);
+
+    for (QString item : toRemove) {
+        bool removed = targetItems.removeOne(item);
+        if (!removed)
+            qWarning() << "Entry" << item
+                << "could not be stripped from variable" << name;
+    }
+    return targetItems.join(delimiter);
+}
 
 QProcessEnvironment CleanEnviroment()
 {
@@ -89,6 +88,16 @@ QProcessEnvironment CleanEnviroment()
         "JAVA_OPTIONS",
         "JAVA_TOOL_OPTIONS"
     };
+
+    QStringList stripped =
+    {
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+#endif
+        "QT_PLUGIN_PATH",
+        "QT_FONTPATH"
+    };
     for(auto key: rawenv.keys())
     {
         auto value = rawenv.value(key);
@@ -98,19 +107,22 @@ QProcessEnvironment CleanEnviroment()
             qDebug() << "Env: ignoring" << key << value;
             continue;
         }
-        // filter PolyMC-related things
-        if(key.startsWith("QT_"))
+
+        // These are used to strip the original variables
+        // If there is "LD_LIBRARY_PATH" and "LAUNCHER_LD_LIBRARY_PATH", we want to
+        // remove all values in "LAUNCHER_LD_LIBRARY_PATH" from "LD_LIBRARY_PATH"
+        if(key.startsWith("LAUNCHER_"))
         {
             qDebug() << "Env: ignoring" << key << value;
             continue;
+        }
+        if(stripped.contains(key))
+        {
+            QString newValue = stripVariableEntries(key, value, rawenv.value("LAUNCHER_" + key));
+
+            qDebug() << "Env: stripped" << key << value << "to" << newValue;
         }
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-        // Do not pass LD_* variables to java. They were intended for PolyMC
-        if(key.startsWith("LD_"))
-        {
-            qDebug() << "Env: ignoring" << key << value;
-            continue;
-        }
         // Strip IBus
         // IBus is a Linux IME framework. For some reason, it breaks MC?
         if (key == "XMODIFIERS" && value.contains(IBUS))
@@ -119,22 +131,12 @@ QProcessEnvironment CleanEnviroment()
             value.replace(IBUS, "");
             qDebug() << "Env: stripped" << IBUS << "from" << save << ":" << value;
         }
-        if(key == "GAME_PRELOAD")
-        {
-            env.insert("LD_PRELOAD", value);
-            continue;
-        }
-        if(key == "GAME_LIBRARY_PATH")
-        {
-            env.insert("LD_LIBRARY_PATH", processLD_LIBRARY_PATH(value));
-            continue;
-        }
 #endif
         // qDebug() << "Env: " << key << value;
         env.insert(key, value);
     }
 #ifdef Q_OS_LINUX
-    // HACK: Workaround for QTBUG42500
+    // HACK: Workaround for QTBUG-42500
     if(!env.contains("LD_LIBRARY_PATH"))
     {
         env.insert("LD_LIBRARY_PATH", "");

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -91,7 +91,7 @@ QProcessEnvironment CleanEnviroment()
 
     QStringList stripped =
     {
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
         "LD_LIBRARY_PATH",
         "LD_PRELOAD",
 #endif
@@ -122,7 +122,7 @@ QProcessEnvironment CleanEnviroment()
 
             qDebug() << "Env: stripped" << key << value << "to" << newValue;
         }
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
         // Strip IBus
         // IBus is a Linux IME framework. For some reason, it breaks MC?
         if (key == "XMODIFIERS" && value.contains(IBUS))

--- a/launcher/java/JavaUtils.h
+++ b/launcher/java/JavaUtils.h
@@ -24,6 +24,7 @@
 #include <windows.h>
 #endif
 
+QString stripVariableEntries(QString name, QString target, QString remove);
 QProcessEnvironment CleanEnviroment();
 
 class JavaUtils : public QObject

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -71,8 +71,8 @@ stdenv.mkDerivation rec {
   postInstall = ''
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapQtApp $out/bin/polymc \
-      --run '[ -f /etc/NIXOS ] && export GAME_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib"' \
-      --prefix GAME_LIBRARY_PATH : ${gameLibraryPath} \
+      --run '[ -f /etc/NIXOS ] && export LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"' \
+      --prefix LD_LIBRARY_PATH : ${gameLibraryPath} \
       --prefix POLYMC_JAVA_PATHS : ${javaPaths} \
       --prefix PATH : ${lib.makeBinPath [ xorg.xrandr ]}
   '';

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
       their associated options with a simple interface.
     '';
     platforms = platforms.unix;
-    license = licenses.gpl3Plus;
+    license = licenses.gpl3Only;
     maintainers = with maintainers; [ starcraft66 kloenk ];
   };
 }


### PR DESCRIPTION
Closes #302 
Closes #874

Before this change, you had to specify custom `LD_*` variables using the
prefix `GAME_LD_*`. Now instead of dropping all `LD_*` variables by default,
we should just filter them and remove the values we *know* are from our
start script.