### PR TITLE
Add early modpack updating system

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -154,6 +154,16 @@ void BaseInstance::setManagedPack(const QString& type, const QString& id, const 
     settings()->set("ManagedPackVersionName", version);
 }
 
+void BaseInstance::copyManagedPack(BaseInstance& other)
+{
+    settings()->set("ManagedPack", other.isManagedPack());
+    settings()->set("ManagedPackType", other.getManagedPackType());
+    settings()->set("ManagedPackID", other.getManagedPackID());
+    settings()->set("ManagedPackName", other.getManagedPackName());
+    settings()->set("ManagedPackVersionID", other.getManagedPackVersionID());
+    settings()->set("ManagedPackVersionName", other.getManagedPackVersionName());
+}
+
 int BaseInstance::getConsoleMaxLines() const
 {
     auto lineSetting = m_settings->getSetting("ConsoleMaxLines");

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -114,54 +114,54 @@ QString BaseInstance::getPostExitCommand()
     return settings()->get("PostExitCommand").toString();
 }
 
-bool BaseInstance::isManagedPack()
+bool BaseInstance::isManagedPack() const
 {
-    return settings()->get("ManagedPack").toBool();
+    return m_settings->get("ManagedPack").toBool();
 }
 
-QString BaseInstance::getManagedPackType()
+QString BaseInstance::getManagedPackType() const
 {
-    return settings()->get("ManagedPackType").toString();
+    return m_settings->get("ManagedPackType").toString();
 }
 
-QString BaseInstance::getManagedPackID()
+QString BaseInstance::getManagedPackID() const
 {
-    return settings()->get("ManagedPackID").toString();
+    return m_settings->get("ManagedPackID").toString();
 }
 
-QString BaseInstance::getManagedPackName()
+QString BaseInstance::getManagedPackName() const
 {
-    return settings()->get("ManagedPackName").toString();
+    return m_settings->get("ManagedPackName").toString();
 }
 
-QString BaseInstance::getManagedPackVersionID()
+QString BaseInstance::getManagedPackVersionID() const
 {
-    return settings()->get("ManagedPackVersionID").toString();
+    return m_settings->get("ManagedPackVersionID").toString();
 }
 
-QString BaseInstance::getManagedPackVersionName()
+QString BaseInstance::getManagedPackVersionName() const
 {
-    return settings()->get("ManagedPackVersionName").toString();
+    return m_settings->get("ManagedPackVersionName").toString();
 }
 
 void BaseInstance::setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version)
 {
-    settings()->set("ManagedPack", true);
-    settings()->set("ManagedPackType", type);
-    settings()->set("ManagedPackID", id);
-    settings()->set("ManagedPackName", name);
-    settings()->set("ManagedPackVersionID", versionId);
-    settings()->set("ManagedPackVersionName", version);
+    m_settings->set("ManagedPack", true);
+    m_settings->set("ManagedPackType", type);
+    m_settings->set("ManagedPackID", id);
+    m_settings->set("ManagedPackName", name);
+    m_settings->set("ManagedPackVersionID", versionId);
+    m_settings->set("ManagedPackVersionName", version);
 }
 
 void BaseInstance::copyManagedPack(BaseInstance& other)
 {
-    settings()->set("ManagedPack", other.isManagedPack());
-    settings()->set("ManagedPackType", other.getManagedPackType());
-    settings()->set("ManagedPackID", other.getManagedPackID());
-    settings()->set("ManagedPackName", other.getManagedPackName());
-    settings()->set("ManagedPackVersionID", other.getManagedPackVersionID());
-    settings()->set("ManagedPackVersionName", other.getManagedPackVersionName());
+    m_settings->set("ManagedPack", other.isManagedPack());
+    m_settings->set("ManagedPackType", other.getManagedPackType());
+    m_settings->set("ManagedPackID", other.getManagedPackID());
+    m_settings->set("ManagedPackName", other.getManagedPackName());
+    m_settings->set("ManagedPackVersionID", other.getManagedPackVersionID());
+    m_settings->set("ManagedPackVersionName", other.getManagedPackVersionName());
 }
 
 int BaseInstance::getConsoleMaxLines() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -147,6 +147,7 @@ public:
     QString getManagedPackVersionID();
     QString getManagedPackVersionName();
     void setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version);
+    void copyManagedPack(BaseInstance& other);
 
     /// guess log level from a line of game log
     virtual MessageLevel::Enum guessLevel(const QString &line, MessageLevel::Enum level)

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -140,12 +140,12 @@ public:
     QString getPostExitCommand();
     QString getWrapperCommand();
 
-    bool isManagedPack();
-    QString getManagedPackType();
-    QString getManagedPackID();
-    QString getManagedPackName();
-    QString getManagedPackVersionID();
-    QString getManagedPackVersionName();
+    bool isManagedPack() const;
+    QString getManagedPackType() const;
+    QString getManagedPackID() const;
+    QString getManagedPackName() const;
+    QString getManagedPackVersionID() const;
+    QString getManagedPackVersionName() const;
     void setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version);
     void copyManagedPack(BaseInstance& other);
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -461,6 +461,8 @@ set(API_SOURCES
     modplatform/helpers/NetworkModAPI.cpp
     modplatform/helpers/HashUtils.h
     modplatform/helpers/HashUtils.cpp
+    modplatform/helpers/OverrideUtils.h
+    modplatform/helpers/OverrideUtils.cpp
 )
 
 set(FTB_SOURCES

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -495,6 +495,8 @@ set(MODRINTH_SOURCES
     modplatform/modrinth/ModrinthPackManifest.h
     modplatform/modrinth/ModrinthCheckUpdate.cpp
     modplatform/modrinth/ModrinthCheckUpdate.h
+    modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+    modplatform/modrinth/ModrinthInstanceCreationTask.h
 )
 
 set(MODPACKSCH_SOURCES

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -486,6 +486,8 @@ set(FLAME_SOURCES
     modplatform/flame/FileResolvingTask.cpp
     modplatform/flame/FlameCheckUpdate.cpp
     modplatform/flame/FlameCheckUpdate.h
+    modplatform/flame/FlameInstanceCreationTask.h
+    modplatform/flame/FlameInstanceCreationTask.cpp
 )
 
 set(MODRINTH_SOURCES

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -297,6 +297,8 @@ set(MINECRAFT_SOURCES
     minecraft/Library.cpp
     minecraft/Library.h
     minecraft/MojangDownloadInfo.h
+    minecraft/VanillaInstanceCreationTask.cpp
+    minecraft/VanillaInstanceCreationTask.h
     minecraft/VersionFile.cpp
     minecraft/VersionFile.h
     minecraft/VersionFilterData.h

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -44,7 +44,7 @@ void InstanceCopyTask::copyFinished()
     auto instanceSettings = std::make_shared<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
 
     InstancePtr inst(new NullInstance(m_globalSettings, instanceSettings, m_stagingPath));
-    inst->setName(m_instName);
+    inst->setName(name());
     inst->setIconKey(m_instIcon);
     if(!m_keepPlaytime) {
         inst->resetTimePlayed();

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -1,6 +1,7 @@
 #include "InstanceCreationTask.h"
 
 #include <QDebug>
+#include <QFile>
 
 InstanceCreationTask::InstanceCreationTask() = default;
 
@@ -19,19 +20,37 @@ void InstanceCreationTask::executeTask()
         return;
     }
 
-    // If this is set, it means we're updating an instance. Since the previous step likely
-    // removed some old files, we'd better not let the user abort the next task, since it'd
-    // put the instance in an invalid state.
-    // TODO: Figure out an unexpensive way of making such file removal a recoverable transaction.
-    setAbortStatus(!shouldOverride());
+    if (!createInstance()) {
+        if (m_abort)
+            return;
 
-    if (createInstance()) {
-        emitSucceeded();
+        qWarning() << "Instance creation failed!";
+        if (!m_error_message.isEmpty())
+            qWarning() << "Reason: " << m_error_message;
+        emitFailed(tr("Error while creating new instance."));
         return;
     }
 
-    qWarning() << "Instance creation failed!";
-    if (!m_error_message.isEmpty())
-        qWarning() << "Reason: " << m_error_message;
-    emitFailed(tr("Error while creating new instance."));
+    // If this is set, it means we're updating an instance. So, we now need to remove the
+    // files scheduled to, and we'd better not let the user abort in the middle of it, since it'd
+    // put the instance in an invalid state.
+    if (shouldOverride()) {
+        setAbortStatus(false);
+        setStatus(tr("Removing old conflicting files..."));
+        qDebug() << "Removing old files";
+
+        for (auto path : m_files_to_remove) {
+            if (!QFile::exists(path))
+                continue;
+            qDebug() << "Removing" << path;
+            if (!QFile::remove(path)) {
+                qCritical() << "Couldn't remove the old conflicting files.";
+                emitFailed(tr("Failed to remove old conflicting files."));
+                return;
+            }
+        }
+    }
+
+    emitSucceeded();
+    return;
 }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -6,6 +6,8 @@ InstanceCreationTask::InstanceCreationTask() = default;
 
 void InstanceCreationTask::executeTask()
 {
+    setAbortStatus(true);
+
     if (updateInstance()) {
         emitSucceeded();
         return;

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -11,6 +11,12 @@ void InstanceCreationTask::executeTask()
         return;
     }
 
+    // When the user aborted in the update stage.
+    if (m_abort) {
+        emitAborted();
+        return;
+    }
+
     // If this is set, it means we're updating an instance. Since the previous step likely
     // removed some old files, we'd better not let the user abort the next task, since it'd
     // put the instance in an invalid state.

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -1,40 +1,18 @@
 #include "InstanceCreationTask.h"
-#include "settings/INISettingsObject.h"
-#include "FileSystem.h"
 
-//FIXME: remove this
-#include "minecraft/MinecraftInstance.h"
-#include "minecraft/PackProfile.h"
+#include <QDebug>
 
-InstanceCreationTask::InstanceCreationTask(BaseVersionPtr version)
-{
-    m_version = version;
-    m_usingLoader = false;
-}
-
-InstanceCreationTask::InstanceCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loaderVersion)
-{
-    m_version = version;
-    m_usingLoader = true;
-    m_loader = loader;
-    m_loaderVersion = loaderVersion;
-}
+InstanceCreationTask::InstanceCreationTask() {}
 
 void InstanceCreationTask::executeTask()
 {
-    setStatus(tr("Creating instance from version %1").arg(m_version->name()));
-    {
-        auto instanceSettings = std::make_shared<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
-        instanceSettings->suspendSave();
-        MinecraftInstance inst(m_globalSettings, instanceSettings, m_stagingPath);
-        auto components = inst.getPackProfile();
-        components->buildingFromScratch();
-        components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
-        if(m_usingLoader)
-            components->setComponentVersion(m_loader, m_loaderVersion->descriptor());
-        inst.setName(m_instName);
-        inst.setIconKey(m_instIcon);
-        instanceSettings->resumeSave();
+    if (updateInstance() || createInstance()) {
+        emitSucceeded();
+        return;
     }
-    emitSucceeded();
+
+    qWarning() << "Instance creation failed!";
+    if (!m_error_message.isEmpty())
+        qWarning() << "Reason: " << m_error_message;
+    emitFailed(tr("Error while creating new instance."));
 }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -2,11 +2,22 @@
 
 #include <QDebug>
 
-InstanceCreationTask::InstanceCreationTask() {}
+InstanceCreationTask::InstanceCreationTask() = default;
 
 void InstanceCreationTask::executeTask()
 {
-    if (updateInstance() || createInstance()) {
+    if (updateInstance()) {
+        emitSucceeded();
+        return;
+    }
+
+    // If this is set, it means we're updating an instance. Since the previous step likely
+    // removed some old files, we'd better not let the user abort the next task, since it'd
+    // put the instance in an invalid state.
+    // TODO: Figure out an unexpensive way of making such file removal a recoverable transaction.
+    setAbortStatus(!shouldOverride());
+
+    if (createInstance()) {
         emitSucceeded();
         return;
     }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -7,7 +7,7 @@ InstanceCreationTask::InstanceCreationTask() = default;
 
 void InstanceCreationTask::executeTask()
 {
-    setAbortStatus(true);
+    setAbortable(true);
 
     if (updateInstance()) {
         emitSucceeded();
@@ -35,7 +35,7 @@ void InstanceCreationTask::executeTask()
     // files scheduled to, and we'd better not let the user abort in the middle of it, since it'd
     // put the instance in an invalid state.
     if (shouldOverride()) {
-        setAbortStatus(false);
+        setAbortable(false);
         setStatus(tr("Removing old conflicting files..."));
         qDebug() << "Removing old files";
 

--- a/launcher/InstanceCreationTask.h
+++ b/launcher/InstanceCreationTask.h
@@ -36,6 +36,9 @@ class InstanceCreationTask : public InstanceTask {
    protected:
     void setError(QString message) { m_error_message = message; };
 
+   protected:
+    bool m_abort = false;
+
    private:
     QString m_error_message;
 };

--- a/launcher/InstanceCreationTask.h
+++ b/launcher/InstanceCreationTask.h
@@ -31,6 +31,8 @@ class InstanceCreationTask : public InstanceTask {
      */
     virtual bool createInstance() { return false; };
 
+    QString getError() const { return m_error_message; }
+
    protected:
     void setError(QString message) { m_error_message = message; };
 

--- a/launcher/InstanceCreationTask.h
+++ b/launcher/InstanceCreationTask.h
@@ -39,6 +39,8 @@ class InstanceCreationTask : public InstanceTask {
    protected:
     bool m_abort = false;
 
+    QStringList m_files_to_remove;
+
    private:
     QString m_error_message;
 };

--- a/launcher/InstanceCreationTask.h
+++ b/launcher/InstanceCreationTask.h
@@ -1,26 +1,39 @@
 #pragma once
 
-#include "tasks/Task.h"
-#include "net/NetJob.h"
-#include <QUrl>
-#include "settings/SettingsObject.h"
 #include "BaseVersion.h"
 #include "InstanceTask.h"
 
-class InstanceCreationTask : public InstanceTask
-{
+class InstanceCreationTask : public InstanceTask {
     Q_OBJECT
-public:
-    explicit InstanceCreationTask(BaseVersionPtr version);
-    explicit InstanceCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loaderVersion);
+   public:
+    InstanceCreationTask();
+    virtual ~InstanceCreationTask() = default;
 
-protected:
-    //! Entry point for tasks.
-    virtual void executeTask() override;
+   protected:
+    void executeTask() final override;
 
-private: /* data */
-    BaseVersionPtr m_version;
-    bool m_usingLoader;
-    QString m_loader;
-    BaseVersionPtr m_loaderVersion;
+    /**
+     * Tries to update an already existing instance.
+     *
+     * This can be implemented by subclasses to provide a way of updating an already existing
+     * instance, according to that implementation's concept of 'identity' (i.e. instances that
+     * are updates / downgrades of one another).
+     *
+     * If this returns true, createInstance() will not run, so you should do all update steps in here.
+     * Otherwise, createInstance() is run as normal.
+     */
+    virtual bool updateInstance() { return false; };
+
+    /**
+     * Creates a new instance.
+     *
+     * Returns whether the instance creation was successful (true) or not (false).
+     */
+    virtual bool createInstance() { return false; };
+
+   protected:
+    void setError(QString message) { m_error_message = message; };
+
+   private:
+    QString m_error_message;
 };

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -75,7 +75,7 @@ bool InstanceImportTask::abort()
 
 void InstanceImportTask::executeTask()
 {
-    setAbortStatus(true);
+    setAbortable(true);
 
     if (m_sourceUrl.isLocalFile()) {
         m_archivePath = m_sourceUrl.toLocalFile();
@@ -280,7 +280,7 @@ void InstanceImportTask::processFlame()
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
     connect(inst_creation_task, &Task::aborted, this, &Task::abort);
-    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
+    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortable);
 
     inst_creation_task->start();
 }
@@ -344,7 +344,7 @@ void InstanceImportTask::processModrinth()
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
     connect(inst_creation_task, &Task::aborted, this, &Task::abort);
-    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
+    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortable);
 
     inst_creation_task->start();
 }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -91,6 +91,7 @@ void InstanceImportTask::executeTask()
         connect(m_filesNetJob.get(), &NetJob::succeeded, this, &InstanceImportTask::downloadSucceeded);
         connect(m_filesNetJob.get(), &NetJob::progress, this, &InstanceImportTask::downloadProgressChanged);
         connect(m_filesNetJob.get(), &NetJob::failed, this, &InstanceImportTask::downloadFailed);
+        connect(m_filesNetJob.get(), &NetJob::aborted, this, &InstanceImportTask::downloadAborted);
 
         m_filesNetJob->start();
     }
@@ -111,6 +112,12 @@ void InstanceImportTask::downloadFailed(QString reason)
 void InstanceImportTask::downloadProgressChanged(qint64 current, qint64 total)
 {
     setProgress(current, total);
+}
+
+void InstanceImportTask::downloadAborted()
+{
+    emitAborted();
+    m_filesNetJob.reset();
 }
 
 void InstanceImportTask::processZipPack()
@@ -246,9 +253,7 @@ void InstanceImportTask::extractFinished()
 
 void InstanceImportTask::extractAborted()
 {
-    emitFailed(tr("Instance import has been aborted."));
-    emit aborted();
-    return;
+    emitAborted();
 }
 
 void InstanceImportTask::processFlame()

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -593,15 +593,16 @@ void InstanceImportTask::processModrinth()
     inst_creation_task->setIcon(m_instIcon);
     inst_creation_task->setGroup(m_instGroup);
     
-    connect(inst_creation_task, &Task::succeeded, this, &InstanceImportTask::emitSucceeded);
+    connect(inst_creation_task, &Task::succeeded, this, [this, inst_creation_task] {
+        setOverride(inst_creation_task->shouldOverride());
+        emitSucceeded();
+    });
     connect(inst_creation_task, &Task::failed, this, &InstanceImportTask::emitFailed);
     connect(inst_creation_task, &Task::progress, this, &InstanceImportTask::setProgress);
     connect(inst_creation_task, &Task::status, this, &InstanceImportTask::setStatus);
-    connect(inst_creation_task, &Task::finished, this, [inst_creation_task]{ inst_creation_task->deleteLater(); });
+    connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
 
-    connect(this, &Task::aborted, inst_creation_task, [inst_creation_task] {
-        inst_creation_task->abort();
-    });
+    connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
 
     inst_creation_task->start();
 }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -50,10 +50,9 @@
 #include "Json.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
-#include "modplatform/flame/FileResolvingTask.h"
-#include "modplatform/flame/PackManifest.h"
 #include "modplatform/technic/TechnicPackProcessor.h"
 #include "modplatform/modrinth/ModrinthInstanceCreationTask.h"
+#include "modplatform/flame/FlameInstanceCreationTask.h"
 
 #include "Application.h"
 #include "icons/IconList.h"
@@ -262,287 +261,24 @@ void InstanceImportTask::extractAborted()
 
 void InstanceImportTask::processFlame()
 {
-    const static QMap<QString,QString> forgemap = {
-        {"1.2.5", "3.4.9.171"},
-        {"1.4.2", "6.0.1.355"},
-        {"1.4.7", "6.6.2.534"},
-        {"1.5.2", "7.8.1.737"}
-    };
-    Flame::Manifest pack;
-    try
-    {
-        QString configPath = FS::PathCombine(m_stagingPath, "manifest.json");
-        Flame::loadManifest(pack, configPath);
-        QFile::remove(configPath);
-    }
-    catch (const JSONValidationError &e)
-    {
-        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
-        return;
-    }
-    if(!pack.overrides.isEmpty())
-    {
-        QString overridePath = FS::PathCombine(m_stagingPath, pack.overrides);
-        if (QFile::exists(overridePath))
-        {
-            QString mcPath = FS::PathCombine(m_stagingPath, "minecraft");
-            if (!QFile::rename(overridePath, mcPath))
-            {
-                emitFailed(tr("Could not rename the overrides folder:\n") + pack.overrides);
-                return;
-            }
-        }
-        else
-        {
-            logWarning(tr("The specified overrides folder (%1) is missing. Maybe the modpack was already used before?").arg(pack.overrides));
-        }
-    }
+    auto* inst_creation_task = new FlameCreationTask(m_stagingPath, m_globalSettings, m_parent);
 
-    QString forgeVersion;
-    QString fabricVersion;
-    // TODO: is Quilt relevant here?
-    for(auto &loader: pack.minecraft.modLoaders)
-    {
-        auto id = loader.id;
-        if(id.startsWith("forge-"))
-        {
-            id.remove("forge-");
-            forgeVersion = id;
-            continue;
-        }
-        if(id.startsWith("fabric-"))
-        {
-            id.remove("fabric-");
-            fabricVersion = id;
-            continue;
-        }
-        logWarning(tr("Unknown mod loader in manifest: %1").arg(id));
-    }
-
-    QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
-    auto mcVersion = pack.minecraft.version;
-    // Hack to correct some 'special sauce'...
-    if(mcVersion.endsWith('.'))
-    {
-        mcVersion.remove(QRegularExpression("[.]+$"));
-        logWarning(tr("Mysterious trailing dots removed from Minecraft version while importing pack."));
-    }
-    auto components = instance.getPackProfile();
-    components->buildingFromScratch();
-    components->setComponentVersion("net.minecraft", mcVersion, true);
-    if(!forgeVersion.isEmpty())
-    {
-        // FIXME: dirty, nasty, hack. Proper solution requires dependency resolution and knowledge of the metadata.
-        if(forgeVersion == "recommended")
-        {
-            if(forgemap.contains(mcVersion))
-            {
-                forgeVersion = forgemap[mcVersion];
-            }
-            else
-            {
-                logWarning(tr("Could not map recommended Forge version for Minecraft %1").arg(mcVersion));
-            }
-        }
-        components->setComponentVersion("net.minecraftforge", forgeVersion);
-    }
-    if(!fabricVersion.isEmpty())
-    {
-        components->setComponentVersion("net.fabricmc.fabric-loader", fabricVersion);
-    }
-    if (m_instIcon != "default")
-    {
-        instance.setIconKey(m_instIcon);
-    }
-    else
-    {
-        if(pack.name.contains("Direwolf20"))
-        {
-            instance.setIconKey("steve");
-        }
-        else if(pack.name.contains("FTB") || pack.name.contains("Feed The Beast"))
-        {
-            instance.setIconKey("ftb_logo");
-        }
-        else
-        {
-            // default to something other than the MultiMC default to distinguish these
-            instance.setIconKey("flame");
-        }
-    }
-    QString jarmodsPath = FS::PathCombine(m_stagingPath, "minecraft", "jarmods");
-    QFileInfo jarmodsInfo(jarmodsPath);
-    if(jarmodsInfo.isDir())
-    {
-        // install all the jar mods
-        qDebug() << "Found jarmods:";
-        QDir jarmodsDir(jarmodsPath);
-        QStringList jarMods;
-        for (auto info: jarmodsDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files))
-        {
-            qDebug() << info.fileName();
-            jarMods.push_back(info.absoluteFilePath());
-        }
-        auto profile = instance.getPackProfile();
-        profile->installJarMods(jarMods);
-        // nuke the original files
-        FS::deletePath(jarmodsPath);
-    }
-    instance.setName(m_instName);
-    m_modIdResolver = new Flame::FileResolvingTask(APPLICATION->network(), pack);
-    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::succeeded, [&]()
-    {
-        auto results = m_modIdResolver->getResults();
-        //first check for blocked mods
-        QString text;
-        QList<QUrl> urls;
-        auto anyBlocked = false;
-        for(const auto& result: results.files.values()) {
-            if (!result.resolved || result.url.isEmpty()) {
-                text += QString("%1: <a href='%2'>%2</a><br/>").arg(result.fileName, result.websiteUrl);
-                urls.append(QUrl(result.websiteUrl));
-                anyBlocked = true;
-            }
-        }
-        if(anyBlocked) {
-            qWarning() << "Blocked mods found, displaying mod list";
-
-            auto message_dialog = new BlockedModsDialog(m_parent,
-                                                       tr("Blocked mods found"),
-                                                       tr("The following mods were blocked on third party launchers.<br/>"
-                                                          "You will need to manually download them and add them to the modpack"),
-                                                       text,
-                                                       urls);
-            message_dialog->setModal(true);
-
-            if (message_dialog->exec()) {
-                m_filesNetJob = new NetJob(tr("Mod download"), APPLICATION->network());
-                for (const auto &result: m_modIdResolver->getResults().files) {
-                    QString filename = result.fileName;
-                    if (!result.required) {
-                        filename += ".disabled";
-                    }
-
-                    auto relpath = FS::PathCombine("minecraft", result.targetFolder, filename);
-                    auto path = FS::PathCombine(m_stagingPath, relpath);
-
-                    switch (result.type) {
-                        case Flame::File::Type::Folder: {
-                            logWarning(tr("This 'Folder' may need extracting: %1").arg(relpath));
-                            // fall-through intentional, we treat these as plain old mods and dump them wherever.
-                        }
-                        case Flame::File::Type::SingleFile:
-                        case Flame::File::Type::Mod: {
-                            if (!result.url.isEmpty()) {
-                                qDebug() << "Will download" << result.url << "to" << path;
-                                auto dl = Net::Download::makeFile(result.url, path);
-                                m_filesNetJob->addNetAction(dl);
-                            }
-                            break;
-                        }
-                        case Flame::File::Type::Modpack:
-                            logWarning(
-                                    tr("Nesting modpacks in modpacks is not implemented, nothing was downloaded: %1").arg(
-                                            relpath));
-                            break;
-                        case Flame::File::Type::Cmod2:
-                        case Flame::File::Type::Ctoc:
-                        case Flame::File::Type::Unknown:
-                            logWarning(tr("Unrecognized/unhandled PackageType for: %1").arg(relpath));
-                            break;
-                    }
-                }
-                m_modIdResolver.reset();
-                connect(m_filesNetJob.get(), &NetJob::succeeded, this, [&]() {
-                            m_filesNetJob.reset();
-                            emitSucceeded();
-                        }
-                );
-                connect(m_filesNetJob.get(), &NetJob::failed, [&](QString reason) {
-                    m_filesNetJob.reset();
-                    emitFailed(reason);
-                });
-                connect(m_filesNetJob.get(), &NetJob::progress, [&](qint64 current, qint64 total) {
-                    setProgress(current, total);
-                });
-                setStatus(tr("Downloading mods..."));
-                m_filesNetJob->start();
-            } else {
-                m_modIdResolver.reset();
-                emitFailed("Canceled");
-            }
-        } else {
-            //TODO extract to function ?
-            m_filesNetJob = new NetJob(tr("Mod download"), APPLICATION->network());
-            for (const auto &result: m_modIdResolver->getResults().files) {
-                QString filename = result.fileName;
-                if (!result.required) {
-                    filename += ".disabled";
-                }
-
-                auto relpath = FS::PathCombine("minecraft", result.targetFolder, filename);
-                auto path = FS::PathCombine(m_stagingPath, relpath);
-
-                switch (result.type) {
-                    case Flame::File::Type::Folder: {
-                        logWarning(tr("This 'Folder' may need extracting: %1").arg(relpath));
-                        // fall-through intentional, we treat these as plain old mods and dump them wherever.
-                    }
-                    case Flame::File::Type::SingleFile:
-                    case Flame::File::Type::Mod: {
-                        if (!result.url.isEmpty()) {
-                            qDebug() << "Will download" << result.url << "to" << path;
-                            auto dl = Net::Download::makeFile(result.url, path);
-                            m_filesNetJob->addNetAction(dl);
-                        }
-                        break;
-                    }
-                    case Flame::File::Type::Modpack:
-                        logWarning(
-                                tr("Nesting modpacks in modpacks is not implemented, nothing was downloaded: %1").arg(
-                                        relpath));
-                        break;
-                    case Flame::File::Type::Cmod2:
-                    case Flame::File::Type::Ctoc:
-                    case Flame::File::Type::Unknown:
-                        logWarning(tr("Unrecognized/unhandled PackageType for: %1").arg(relpath));
-                        break;
-                }
-            }
-            m_modIdResolver.reset();
-            connect(m_filesNetJob.get(), &NetJob::succeeded, this, [&]() {
-                        m_filesNetJob.reset();
-                        emitSucceeded();
-                    }
-            );
-            connect(m_filesNetJob.get(), &NetJob::failed, [&](QString reason) {
-                m_filesNetJob.reset();
-                emitFailed(reason);
-            });
-            connect(m_filesNetJob.get(), &NetJob::progress, [&](qint64 current, qint64 total) {
-                setProgress(current, total);
-            });
-            setStatus(tr("Downloading mods..."));
-            m_filesNetJob->start();
-        }
-    }
-    );
-    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::failed, [&](QString reason)
-    {
-        m_modIdResolver.reset();
-        emitFailed(tr("Unable to resolve mod IDs:\n") + reason);
+    inst_creation_task->setName(m_instName);
+    inst_creation_task->setIcon(m_instIcon);
+    inst_creation_task->setGroup(m_instGroup);
+    
+    connect(inst_creation_task, &Task::succeeded, this, [this, inst_creation_task] {
+        setOverride(inst_creation_task->shouldOverride());
+        emitSucceeded();
     });
-    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::progress, [&](qint64 current, qint64 total)
-    {
-        setProgress(current, total);
-    });
-    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::status, [&](QString status)
-    {
-        setStatus(status);
-    });
-    m_modIdResolver->start();
+    connect(inst_creation_task, &Task::failed, this, &InstanceImportTask::emitFailed);
+    connect(inst_creation_task, &Task::progress, this, &InstanceImportTask::setProgress);
+    connect(inst_creation_task, &Task::status, this, &InstanceImportTask::setStatus);
+    connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
+
+    connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
+
+    inst_creation_task->start();
 }
 
 void InstanceImportTask::processTechnic()

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -279,6 +279,7 @@ void InstanceImportTask::processFlame()
     connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
+    connect(inst_creation_task, &Task::aborted, this, &Task::abort);
     connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
 
     inst_creation_task->start();
@@ -342,6 +343,7 @@ void InstanceImportTask::processModrinth()
     connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
+    connect(inst_creation_task, &Task::aborted, this, &Task::abort);
     connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
 
     inst_creation_task->start();

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -255,7 +255,7 @@ void InstanceImportTask::processFlame()
 {
     auto* inst_creation_task = new FlameCreationTask(m_stagingPath, m_globalSettings, m_parent);
 
-    inst_creation_task->setName(m_instName);
+    inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);
     inst_creation_task->setGroup(m_instGroup);
     
@@ -278,7 +278,7 @@ void InstanceImportTask::processTechnic()
     shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &InstanceImportTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &InstanceImportTask::emitFailed);
-    packProcessor->run(m_globalSettings, m_instName, m_instIcon, m_stagingPath);
+    packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath);
 }
 
 void InstanceImportTask::processMultiMC()
@@ -292,7 +292,7 @@ void InstanceImportTask::processMultiMC()
     instance.resetTimePlayed();
 
     // set a new nice name
-    instance.setName(m_instName);
+    instance.setName(name());
 
     // if the icon was specified by user, use that. otherwise pull icon from the pack
     if (m_instIcon != "default") {
@@ -317,7 +317,7 @@ void InstanceImportTask::processModrinth()
 {
     auto* inst_creation_task = new ModrinthCreationTask(m_stagingPath, m_globalSettings, m_parent, m_sourceUrl.toString());
 
-    inst_creation_task->setName(m_instName);
+    inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);
     inst_creation_task->setGroup(m_instGroup);
     

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -63,15 +63,20 @@ InstanceImportTask::InstanceImportTask(const QUrl sourceUrl, QWidget* parent)
 
 bool InstanceImportTask::abort()
 {
+    if (!canAbort())
+        return false;
+
     if (m_filesNetJob)
         m_filesNetJob->abort();
     m_extractFuture.cancel();
 
-    return false;
+    return Task::abort();
 }
 
 void InstanceImportTask::executeTask()
 {
+    setAbortStatus(true);
+
     if (m_sourceUrl.isLocalFile()) {
         m_archivePath = m_sourceUrl.toLocalFile();
         processZipPack();
@@ -274,6 +279,7 @@ void InstanceImportTask::processFlame()
     connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
+    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
 
     inst_creation_task->start();
 }
@@ -336,6 +342,7 @@ void InstanceImportTask::processModrinth()
     connect(inst_creation_task, &Task::finished, inst_creation_task, &InstanceCreationTask::deleteLater);
 
     connect(this, &Task::aborted, inst_creation_task, &InstanceCreationTask::abort);
+    connect(inst_creation_task, &Task::abortStatusChanged, this, &Task::setAbortStatus);
 
     inst_creation_task->start();
 }

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -58,7 +58,6 @@ class InstanceImportTask : public InstanceTask
 public:
     explicit InstanceImportTask(const QUrl sourceUrl, QWidget* parent = nullptr);
 
-    bool canAbort() const override { return true; }
     bool abort() override;
     const QVector<Flame::File> &getBlockedFiles() const
     {

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -80,6 +80,7 @@ private slots:
     void downloadSucceeded();
     void downloadFailed(QString reason);
     void downloadProgressChanged(qint64 current, qint64 total);
+    void downloadAborted();
     void extractFinished();
     void extractAborted();
 

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -785,6 +785,7 @@ class InstanceStaging : public Task {
         connect(child, &Task::succeeded, this, &InstanceStaging::childSucceded);
         connect(child, &Task::failed, this, &InstanceStaging::childFailed);
         connect(child, &Task::aborted, this, &InstanceStaging::childAborted);
+        connect(child, &Task::abortStatusChanged, this, &InstanceStaging::setAbortStatus);
         connect(child, &Task::status, this, &InstanceStaging::setStatus);
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceded);

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -913,9 +913,11 @@ bool InstanceList::commitStagedInstance(QString path, InstanceName const& instan
                 qWarning() << "Failed to move" << path << "to" << destination;
                 return false;
             }
+
+            m_instanceGroupIndex[instID] = groupName;
+            m_groupNameCache.insert(groupName);
         }
-        m_instanceGroupIndex[instID] = groupName;
-        m_groupNameCache.insert(groupName);
+
         instanceSet.insert(instID);
 
         emit instancesChanged();

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -908,11 +908,6 @@ bool InstanceList::commitStagedInstance(QString path, InstanceName const& instan
                 qWarning() << "Failed to override" << path << "to" << destination;
                 return false;
             }
-
-            if (!inst)
-                inst = getInstanceById(instID);
-            if (inst)
-                inst->setName(instanceName.name());
         } else {
             if (!dir.rename(path, destination)) {
                 qWarning() << "Failed to move" << path << "to" << destination;

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -796,10 +796,12 @@ class InstanceStaging : public Task {
     // FIXME/TODO: add ability to abort during instance commit retries
     bool abort() override
     {
-        if (m_child && m_child->canAbort())
-            return m_child->abort();
+        if (!canAbort())
+            return false;
 
-        return false;
+        m_child->abort();
+
+        return Task::abort();
     }
     bool canAbort() const override
     {

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -785,7 +785,7 @@ class InstanceStaging : public Task {
         connect(child, &Task::succeeded, this, &InstanceStaging::childSucceded);
         connect(child, &Task::failed, this, &InstanceStaging::childFailed);
         connect(child, &Task::aborted, this, &InstanceStaging::childAborted);
-        connect(child, &Task::abortStatusChanged, this, &InstanceStaging::setAbortStatus);
+        connect(child, &Task::abortStatusChanged, this, &InstanceStaging::setAbortable);
         connect(child, &Task::status, this, &InstanceStaging::setStatus);
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceded);

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -535,7 +535,7 @@ InstancePtr InstanceList::getInstanceById(QString instId) const
     return InstancePtr();
 }
 
-InstancePtr InstanceList::getInstanceByManagedName(QString managed_name) const
+InstancePtr InstanceList::getInstanceByManagedName(const QString& managed_name) const
 {
     if (managed_name.isEmpty())
         return {};
@@ -880,7 +880,7 @@ QString InstanceList::getStagedInstancePath()
     return path;
 }
 
-bool InstanceList::commitStagedInstance(QString path, InstanceName const& instanceName, QString groupName, bool should_override)
+bool InstanceList::commitStagedInstance(const QString& path, InstanceName const& instanceName, const QString& groupName, bool should_override)
 {
     QDir dir;
     QString instID;

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -784,6 +784,7 @@ class InstanceStaging : public Task {
         m_child.reset(child);
         connect(child, &Task::succeeded, this, &InstanceStaging::childSucceded);
         connect(child, &Task::failed, this, &InstanceStaging::childFailed);
+        connect(child, &Task::aborted, this, &InstanceStaging::childAborted);
         connect(child, &Task::status, this, &InstanceStaging::setStatus);
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceded);
@@ -794,17 +795,14 @@ class InstanceStaging : public Task {
     // FIXME/TODO: add ability to abort during instance commit retries
     bool abort() override
     {
-        if (m_child && m_child->canAbort()) {
+        if (m_child && m_child->canAbort())
             return m_child->abort();
-        }
+
         return false;
     }
     bool canAbort() const override
     {
-        if (m_child && m_child->canAbort()) {
-            return true;
-        }
-        return false;
+        return (m_child && m_child->canAbort());
     }
 
    protected:
@@ -834,7 +832,12 @@ class InstanceStaging : public Task {
         emitFailed(reason);
     }
 
-   private:
+    void childAborted()
+    {
+        emitAborted();
+    }
+
+private:
     InstanceList * m_parent;
     /*
      * WHY: the whole reason why this uses an exponential backoff retry scheme is antivirus on Windows.

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -24,10 +24,10 @@
 
 #include "BaseInstance.h"
 
-#include "QObjectPtr.h"
-
 class QFileSystemWatcher;
 class InstanceTask;
+struct InstanceName;
+
 using InstanceId = QString;
 using GroupId = QString;
 using InstanceLocator = std::pair<InstancePtr, int>;
@@ -133,7 +133,7 @@ public:
      * should_override is used when another similar instance already exists, and we want to override it
      * - for instance, when updating it.
      */
-    bool commitStagedInstance(const QString & keyPath, const QString& instanceName, const QString & groupName, bool should_override);
+    bool commitStagedInstance(QString keyPath, const InstanceName& instanceName, QString groupName, bool should_override);
 
     /**
      * Destroy a previously created staging area given by @keyPath - used when creation fails.

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -104,7 +104,7 @@ public:
     /* O(n) */
     InstancePtr getInstanceById(QString id) const;
     /* O(n) */
-    InstancePtr getInstanceByManagedName(QString managed_name) const;
+    InstancePtr getInstanceByManagedName(const QString& managed_name) const;
     QModelIndex getInstanceIndexById(const QString &id) const;
     QStringList getGroups();
     bool isGroupCollapsed(const QString &groupName);
@@ -133,7 +133,7 @@ public:
      * should_override is used when another similar instance already exists, and we want to override it
      * - for instance, when updating it.
      */
-    bool commitStagedInstance(QString keyPath, const InstanceName& instanceName, QString groupName, bool should_override);
+    bool commitStagedInstance(const QString& keyPath, const InstanceName& instanceName, const QString& groupName, bool should_override);
 
     /**
      * Destroy a previously created staging area given by @keyPath - used when creation fails.

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -101,7 +101,10 @@ public:
     InstListError loadList();
     void saveNow();
 
+    /* O(n) */
     InstancePtr getInstanceById(QString id) const;
+    /* O(n) */
+    InstancePtr getInstanceByManagedName(QString managed_name) const;
     QModelIndex getInstanceIndexById(const QString &id) const;
     QStringList getGroups();
     bool isGroupCollapsed(const QString &groupName);
@@ -127,8 +130,10 @@ public:
     /**
      * Commit the staging area given by @keyPath to the provider - used when creation succeeds.
      * Used by instance manipulation tasks.
+     * should_override is used when another similar instance already exists, and we want to override it
+     * - for instance, when updating it.
      */
-    bool commitStagedInstance(const QString & keyPath, const QString& instanceName, const QString & groupName);
+    bool commitStagedInstance(const QString & keyPath, const QString& instanceName, const QString & groupName, bool should_override);
 
     /**
      * Destroy a previously created staging area given by @keyPath - used when creation fails.

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -1,9 +1,34 @@
 #include "InstanceTask.h"
 
-InstanceTask::InstanceTask()
+QString InstanceName::name() const
 {
+    if (!m_modified_name.isEmpty())
+        return modifiedName();
+    return QString("%1 %2").arg(m_original_name, m_original_version);
 }
 
-InstanceTask::~InstanceTask()
+QString InstanceName::originalName() const
 {
+    return m_original_name;
 }
+
+QString InstanceName::modifiedName() const
+{
+    if (!m_modified_name.isEmpty())
+        return m_modified_name;
+    return m_original_name;
+}
+
+QString InstanceName::version() const
+{
+    return m_original_version;
+}
+
+void InstanceName::setName(InstanceName& other)
+{
+   m_original_name = other.m_original_name; 
+   m_original_version = other.m_original_version; 
+   m_modified_name = other.m_modified_name;
+}
+
+InstanceTask::InstanceTask() : Task(), InstanceName() {}

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -1,5 +1,23 @@
 #include "InstanceTask.h"
 
+#include "ui/dialogs/CustomMessageBox.h"
+
+InstanceNameChange askForChangingInstanceName(QWidget* parent, QString old_name, QString new_name)
+{
+    auto dialog =
+        CustomMessageBox::selectable(parent, QObject::tr("Change instance name"),
+                                     QObject::tr("The instance's name seems to include the old version. Would you like to update it?\n\n"
+                                                 "Old name: %1\n"
+                                                 "New name: %2")
+                                         .arg(old_name, new_name),
+                                     QMessageBox::Question, QMessageBox::No | QMessageBox::Yes);
+    auto result = dialog->exec();
+
+    if (result == QMessageBox::Yes)
+        return InstanceNameChange::ShouldChange;
+    return InstanceNameChange::ShouldKeep;
+}
+
 QString InstanceName::name() const
 {
     if (!m_modified_name.isEmpty())
@@ -26,9 +44,9 @@ QString InstanceName::version() const
 
 void InstanceName::setName(InstanceName& other)
 {
-   m_original_name = other.m_original_name; 
-   m_original_version = other.m_original_version; 
-   m_modified_name = other.m_modified_name;
+    m_original_name = other.m_original_name;
+    m_original_version = other.m_original_version;
+    m_modified_name = other.m_modified_name;
 }
 
 InstanceTask::InstanceTask() : Task(), InstanceName() {}

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -2,7 +2,7 @@
 
 #include "ui/dialogs/CustomMessageBox.h"
 
-InstanceNameChange askForChangingInstanceName(QWidget* parent, QString old_name, QString new_name)
+InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& old_name, const QString& new_name)
 {
     auto dialog =
         CustomMessageBox::selectable(parent, QObject::tr("Change instance name"),

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -5,7 +5,7 @@
 
 /* Helpers */
 enum class InstanceNameChange { ShouldChange, ShouldKeep };
-[[nodiscard]] InstanceNameChange askForChangingInstanceName(QWidget* parent, QString old_name, QString new_name);
+[[nodiscard]] InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& old_name, const QString& new_name);
 
 struct InstanceName {
    public:

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -3,6 +3,10 @@
 #include "settings/SettingsObject.h"
 #include "tasks/Task.h"
 
+/* Helpers */
+enum class InstanceNameChange { ShouldChange, ShouldKeep };
+[[nodiscard]] InstanceNameChange askForChangingInstanceName(QWidget* parent, QString old_name, QString new_name);
+
 struct InstanceName {
    public:
     InstanceName() = default;

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -43,10 +43,17 @@ public:
         return m_instGroup;
     }
 
+    bool shouldOverride() const { return m_override_existing; }
+
+protected:
+    void setOverride(bool override) { m_override_existing = override; }
+
 protected: /* data */
     SettingsObjectPtr m_globalSettings;
     QString m_instName;
     QString m_instIcon;
     QString m_instGroup;
     QString m_stagingPath;
+
+    bool m_override_existing = false;
 };

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -1,56 +1,50 @@
 #pragma once
 
-#include "tasks/Task.h"
 #include "settings/SettingsObject.h"
+#include "tasks/Task.h"
 
-class InstanceTask : public Task
-{
+struct InstanceName {
+   public:
+    InstanceName() = default;
+    InstanceName(QString name, QString version) : m_original_name(std::move(name)), m_original_version(std::move(version)) {}
+
+    [[nodiscard]] QString modifiedName() const;
+    [[nodiscard]] QString originalName() const;
+    [[nodiscard]] QString name() const;
+    [[nodiscard]] QString version() const;
+
+    void setName(QString name) { m_modified_name = name; }
+    void setName(InstanceName& other);
+
+   protected:
+    QString m_original_name;
+    QString m_original_version;
+
+    QString m_modified_name;
+};
+
+class InstanceTask : public Task, public InstanceName {
     Q_OBJECT
-public:
-    explicit InstanceTask();
-    virtual ~InstanceTask();
+   public:
+    InstanceTask();
+    ~InstanceTask() override = default;
 
-    void setParentSettings(SettingsObjectPtr settings)
-    {
-        m_globalSettings = settings;
-    }
+    void setParentSettings(SettingsObjectPtr settings) { m_globalSettings = settings; }
 
-    void setStagingPath(const QString &stagingPath)
-    {
-        m_stagingPath = stagingPath;
-    }
+    void setStagingPath(const QString& stagingPath) { m_stagingPath = stagingPath; }
 
-    void setName(const QString &name)
-    {
-        m_instName = name;
-    }
-    QString name() const
-    {
-        return m_instName;
-    }
+    void setIcon(const QString& icon) { m_instIcon = icon; }
 
-    void setIcon(const QString &icon)
-    {
-        m_instIcon = icon;
-    }
-
-    void setGroup(const QString &group)
-    {
-        m_instGroup = group;
-    }
-    QString group() const
-    {
-        return m_instGroup;
-    }
+    void setGroup(const QString& group) { m_instGroup = group; }
+    QString group() const { return m_instGroup; }
 
     bool shouldOverride() const { return m_override_existing; }
 
-protected:
+   protected:
     void setOverride(bool override) { m_override_existing = override; }
 
-protected: /* data */
+   protected: /* data */
     SettingsObjectPtr m_globalSettings;
-    QString m_instName;
     QString m_instIcon;
     QString m_instGroup;
     QString m_stagingPath;

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -1,0 +1,32 @@
+#include "VanillaInstanceCreationTask.h"
+
+#include "FileSystem.h"
+#include "settings/INISettingsObject.h"
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+
+VanillaCreationTask::VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version)
+    : InstanceCreationTask(), m_version(version), m_using_loader(true), m_loader(loader), m_loader_version(loader_version)
+{}
+
+bool VanillaCreationTask::createInstance()
+{
+    setStatus(tr("Creating instance from version %1").arg(m_version->name()));
+
+    auto instance_settings = std::make_shared<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
+    instance_settings->suspendSave();
+    {
+        MinecraftInstance inst(m_globalSettings, instance_settings, m_stagingPath);
+        auto components = inst.getPackProfile();
+        components->buildingFromScratch();
+        components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
+        if(m_using_loader)
+            components->setComponentVersion(m_loader, m_loader_version->descriptor());
+
+        inst.setName(m_instName);
+        inst.setIconKey(m_instIcon);
+    }
+    instance_settings->resumeSave();
+
+    return true;
+}

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -1,12 +1,14 @@
 #include "VanillaInstanceCreationTask.h"
 
+#include <utility>
+
 #include "FileSystem.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "settings/INISettingsObject.h"
 
 VanillaCreationTask::VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version)
-    : InstanceCreationTask(), m_version(version), m_using_loader(true), m_loader(loader), m_loader_version(loader_version)
+    : InstanceCreationTask(), m_version(std::move(version)), m_using_loader(true), m_loader(std::move(loader)), m_loader_version(std::move(loader_version))
 {}
 
 bool VanillaCreationTask::createInstance()

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -1,9 +1,9 @@
 #include "VanillaInstanceCreationTask.h"
 
 #include "FileSystem.h"
-#include "settings/INISettingsObject.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
+#include "settings/INISettingsObject.h"
 
 VanillaCreationTask::VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version)
     : InstanceCreationTask(), m_version(version), m_using_loader(true), m_loader(loader), m_loader_version(loader_version)
@@ -23,7 +23,7 @@ bool VanillaCreationTask::createInstance()
         if(m_using_loader)
             components->setComponentVersion(m_loader, m_loader_version->descriptor());
 
-        inst.setName(m_instName);
+        inst.setName(name());
         inst.setIconKey(m_instIcon);
     }
     instance_settings->resumeSave();

--- a/launcher/minecraft/VanillaInstanceCreationTask.h
+++ b/launcher/minecraft/VanillaInstanceCreationTask.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "InstanceCreationTask.h"
+
+class VanillaCreationTask final : public InstanceCreationTask {
+    Q_OBJECT
+   public:
+    VanillaCreationTask(BaseVersionPtr version) : InstanceCreationTask(), m_version(version) {}
+    VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version);
+
+    bool createInstance() override;
+
+   private:
+    // Version to update to / create of the instance.
+    BaseVersionPtr m_version;
+
+    bool m_using_loader = false;
+    QString m_loader;
+    BaseVersionPtr m_loader_version;
+};

--- a/launcher/minecraft/VanillaInstanceCreationTask.h
+++ b/launcher/minecraft/VanillaInstanceCreationTask.h
@@ -2,10 +2,12 @@
 
 #include "InstanceCreationTask.h"
 
+#include <utility>
+
 class VanillaCreationTask final : public InstanceCreationTask {
     Q_OBJECT
    public:
-    VanillaCreationTask(BaseVersionPtr version) : InstanceCreationTask(), m_version(version) {}
+    VanillaCreationTask(BaseVersionPtr version) : InstanceCreationTask(), m_version(std::move(version)) {}
     VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version);
 
     bool createInstance() override;

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -90,6 +90,7 @@ void PackInstallTask::executeTask()
 
     QObject::connect(netJob, &NetJob::succeeded, this, &PackInstallTask::onDownloadSucceeded);
     QObject::connect(netJob, &NetJob::failed, this, &PackInstallTask::onDownloadFailed);
+    QObject::connect(netJob, &NetJob::aborted, this, &PackInstallTask::onDownloadAborted);
 }
 
 void PackInstallTask::onDownloadSucceeded()
@@ -167,6 +168,12 @@ void PackInstallTask::onDownloadFailed(QString reason)
     qDebug() << "PackInstallTask::onDownloadFailed: " << QThread::currentThreadId();
     jobPtr.reset();
     emitFailed(reason);
+}
+
+void PackInstallTask::onDownloadAborted()
+{
+    jobPtr.reset();
+    emitAborted();
 }
 
 void PackInstallTask::deleteExistingFiles()
@@ -675,6 +682,11 @@ void PackInstallTask::installConfigs()
         abortable = true;
         setProgress(current, total);
     });
+    connect(jobPtr.get(), &NetJob::aborted, [&]{
+        abortable = false;
+        jobPtr.reset();
+        emitAborted();
+    });
 
     jobPtr->start();
 }
@@ -830,6 +842,12 @@ void PackInstallTask::downloadMods()
     {
         abortable = true;
         setProgress(current, total);
+    });
+    connect(jobPtr.get(), &NetJob::aborted, [&]
+    {
+        abortable = false;
+        jobPtr.reset();
+        emitAborted();
     });
 
     jobPtr->start();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -1005,7 +1005,7 @@ void PackInstallTask::install()
 
     components->saveNow();
 
-    instance.setName(m_instName);
+    instance.setName(name());
     instance.setIconKey(m_instIcon);
     instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
     instanceSettings->resumeSave();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -93,6 +93,7 @@ protected:
 private slots:
     void onDownloadSucceeded();
     void onDownloadFailed(QString reason);
+    void onDownloadAborted();
 
     void onModsDownloaded();
     void onModsExtracted();

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -184,7 +184,7 @@ auto FlameAPI::getProjects(QStringList addonIds, QByteArray* response) const -> 
     return netJob;
 }
 
-auto FlameAPI::getFiles(QStringList fileIds, QByteArray* response) const -> NetJob*
+auto FlameAPI::getFiles(const QStringList& fileIds, QByteArray* response) const -> NetJob*
 {
     auto* netJob = new NetJob(QString("Flame::GetFiles"), APPLICATION->network());
 

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -183,3 +183,26 @@ auto FlameAPI::getProjects(QStringList addonIds, QByteArray* response) const -> 
 
     return netJob;
 }
+
+auto FlameAPI::getFiles(QStringList fileIds, QByteArray* response) const -> NetJob*
+{
+    auto* netJob = new NetJob(QString("Flame::GetFiles"), APPLICATION->network());
+
+    QJsonObject body_obj;
+    QJsonArray files_arr;
+    for (auto& fileId : fileIds) {
+        files_arr.append(fileId);
+    }
+
+    body_obj["fileIds"] = files_arr;
+
+    QJsonDocument body(body_obj);
+    auto body_raw = body.toJson();
+
+    netJob->addNetAction(Net::Upload::makeByteArray(QString("https://api.curseforge.com/v1/mods/files"), response, body_raw));
+
+    QObject::connect(netJob, &NetJob::finished, [response, netJob] { delete response; netJob->deleteLater(); });
+    QObject::connect(netJob, &NetJob::failed, [body_raw] { qDebug() << body_raw; });
+
+    return netJob;
+}

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -12,7 +12,7 @@ class FlameAPI : public NetworkModAPI {
     auto getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::IndexedVersion;
 
     auto getProjects(QStringList addonIds, QByteArray* response) const -> NetJob* override;
-    auto getFiles(QStringList fileIds, QByteArray* response) const -> NetJob*;
+    auto getFiles(const QStringList& fileIds, QByteArray* response) const -> NetJob*;
 
    private:
     inline auto getSortFieldInt(QString sortString) const -> int

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -12,6 +12,7 @@ class FlameAPI : public NetworkModAPI {
     auto getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::IndexedVersion;
 
     auto getProjects(QStringList addonIds, QByteArray* response) const -> NetJob* override;
+    auto getFiles(QStringList fileIds, QByteArray* response) const -> NetJob*;
 
    private:
     inline auto getSortFieldInt(QString sortString) const -> int

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -66,16 +66,25 @@ bool FlameCreationTask::updateInstance()
     auto version_id = inst->getManagedPackVersionName();
     auto version_str = !version_id.isEmpty() ? tr(" (version %1)").arg(version_id) : "";
 
-    auto info = CustomMessageBox::selectable(m_parent, tr("Similar modpack was found!"),
-                                             tr("One or more of your instances are from this same modpack%1. Do you want to create a "
-                                                "separate instance, or update the existing one?")
-                                                 .arg(version_str),
-                                             QMessageBox::Information, QMessageBox::Ok | QMessageBox::Abort);
+    auto info = CustomMessageBox::selectable(
+        m_parent, tr("Similar modpack was found!"),
+        tr("One or more of your instances are from this same modpack%1. Do you want to create a "
+           "separate instance, or update the existing one?\n\nNOTE: Make sure you made a backup of your important instance data before "
+           "updating, as worlds can be corrupted and some configuration may be lost (due to pack overrides).")
+            .arg(version_str), QMessageBox::Information, QMessageBox::Ok | QMessageBox::Reset | QMessageBox::Abort);
     info->setButtonText(QMessageBox::Ok, tr("Update existing instance"));
     info->setButtonText(QMessageBox::Abort, tr("Create new instance"));
+    info->setButtonText(QMessageBox::Reset, tr("Cancel"));
 
-    if (info->exec() && info->clickedButton() == info->button(QMessageBox::Abort))
+    info->exec();
+
+    if (info->clickedButton() == info->button(QMessageBox::Abort))
         return false;
+
+    if (info->clickedButton() == info->button(QMessageBox::Reset)) {
+        m_abort = true;
+        return false;
+    }
 
     QDir old_inst_dir(inst->instanceRoot());
 

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -5,6 +5,7 @@
 
 #include "Application.h"
 #include "FileSystem.h"
+#include "InstanceList.h"
 #include "Json.h"
 
 #include "minecraft/MinecraftInstance.h"
@@ -288,7 +289,8 @@ bool FlameCreationTask::createInstance()
         FS::deletePath(jarmodsPath);
     }
 
-    instance.setName(m_instName);
+    instance.setManagedPack("flame", {}, m_pack.name, {}, m_pack.version);
+    instance.setName(name());
 
     m_mod_id_resolver = new Flame::FileResolvingTask(APPLICATION->network(), m_pack);
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::succeeded, this, [this, &loop] { idResolverSucceeded(loop); });

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -195,6 +195,17 @@ bool FlameCreationTask::updateInstance()
         loop.exec();
 
         m_process_update_file_info_job = nullptr;
+    } else {
+        // We don't have an old index file, so we may duplicate stuff!
+        auto dialog = CustomMessageBox::selectable(m_parent,
+                tr("No index file."),
+                tr("We couldn't find a suitable index file for the older version. This may cause some of the files to be duplicated. Do you want to continue?"),
+                QMessageBox::Warning, QMessageBox::Ok | QMessageBox::Cancel);
+
+        if (dialog->exec() == QDialog::DialogCode::Rejected) {
+            m_abort = true;
+            return false;
+        }
     }
 
     setOverride(true);

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -126,7 +126,7 @@ bool FlameCreationTask::updateInstance()
         // TODO: Currently 'overrides' will always override the stuff on update. How do we preserve unchanged overrides?
         // FIXME: We may want to do something about disabled mods.
         auto old_overrides = Override::readOverrides("overrides", old_index_folder);
-        for (auto entry : old_overrides) {
+        for (const auto& entry : old_overrides) {
             if (entry.isEmpty())
                 continue;
             qDebug() << "Scheduling" << entry << "for removal";
@@ -320,7 +320,7 @@ bool FlameCreationTask::createInstance()
         qDebug() << "Found jarmods:";
         QDir jarmodsDir(jarmodsPath);
         QStringList jarMods;
-        for (auto info : jarmodsDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files)) {
+        for (const auto& info : jarmodsDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files)) {
             qDebug() << info.fileName();
             jarMods.push_back(info.absoluteFilePath());
         }

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -338,7 +338,7 @@ bool FlameCreationTask::createInstance()
     bool did_succeed = getError().isEmpty();
 
     if (m_instance && did_succeed) {
-        setAbortStatus(false);
+        setAbortable(false);
         auto inst = m_instance.value();
 
         inst->copyManagedPack(instance);

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -186,6 +186,8 @@ bool FlameCreationTask::updateInstance()
     setOverride(true);
     qDebug() << "Will override instance!";
 
+    m_instance = inst;
+
     // We let it go through the createInstance() stage, just with a couple modifications for updating
     return false;
 }
@@ -318,6 +320,13 @@ bool FlameCreationTask::createInstance()
     m_mod_id_resolver->start();
 
     loop.exec();
+
+    if (m_instance) {
+        auto inst = m_instance.value();
+
+        inst->copyManagedPack(instance);
+        inst->setName(instance.name());
+    }
 
     return getError().isEmpty();
 }

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -27,6 +27,9 @@ static const FlameAPI api;
 
 bool FlameCreationTask::abort()
 {
+    if (!canAbort())
+        return false;
+
     if (m_process_update_file_info_job)
         m_process_update_file_info_job->abort();
     if (m_files_job)
@@ -34,7 +37,7 @@ bool FlameCreationTask::abort()
     if (m_mod_id_resolver)
         m_mod_id_resolver->abort();
 
-    return true;
+    return Task::abort();
 }
 
 bool FlameCreationTask::updateInstance()

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -1,0 +1,284 @@
+#include "FlameInstanceCreationTask.h"
+
+#include "modplatform/flame/PackManifest.h"
+
+#include "Application.h"
+#include "FileSystem.h"
+#include "Json.h"
+
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+
+#include "settings/INISettingsObject.h"
+
+#include "ui/dialogs/BlockedModsDialog.h"
+
+bool FlameCreationTask::abort()
+{
+    if (m_files_job)
+        m_files_job->abort();
+    if (m_mod_id_resolver)
+        m_mod_id_resolver->abort();
+
+    return true;
+}
+
+const static QMap<QString, QString> forgemap = { { "1.2.5", "3.4.9.171" },
+                                                 { "1.4.2", "6.0.1.355" },
+                                                 { "1.4.7", "6.6.2.534" },
+                                                 { "1.5.2", "7.8.1.737" } };
+
+bool FlameCreationTask::createInstance()
+{
+    QEventLoop loop;
+
+    Flame::Manifest pack;
+    try {
+        QString configPath = FS::PathCombine(m_stagingPath, "manifest.json");
+        Flame::loadManifest(pack, configPath);
+        QFile::remove(configPath);
+    } catch (const JSONValidationError& e) {
+        setError(tr("Could not understand pack manifest:\n") + e.cause());
+        return false;
+    }
+
+    if (!pack.overrides.isEmpty()) {
+        QString overridePath = FS::PathCombine(m_stagingPath, pack.overrides);
+        if (QFile::exists(overridePath)) {
+            QString mcPath = FS::PathCombine(m_stagingPath, "minecraft");
+            if (!QFile::rename(overridePath, mcPath)) {
+                setError(tr("Could not rename the overrides folder:\n") + pack.overrides);
+                return false;
+            }
+        } else {
+            logWarning(
+                tr("The specified overrides folder (%1) is missing. Maybe the modpack was already used before?").arg(pack.overrides));
+        }
+    }
+
+    QString forgeVersion;
+    QString fabricVersion;
+    // TODO: is Quilt relevant here?
+    for (auto& loader : pack.minecraft.modLoaders) {
+        auto id = loader.id;
+        if (id.startsWith("forge-")) {
+            id.remove("forge-");
+            forgeVersion = id;
+            continue;
+        }
+        if (id.startsWith("fabric-")) {
+            id.remove("fabric-");
+            fabricVersion = id;
+            continue;
+        }
+        logWarning(tr("Unknown mod loader in manifest: %1").arg(id));
+    }
+
+    QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
+    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
+    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    auto mcVersion = pack.minecraft.version;
+
+    // Hack to correct some 'special sauce'...
+    if (mcVersion.endsWith('.')) {
+        mcVersion.remove(QRegularExpression("[.]+$"));
+        logWarning(tr("Mysterious trailing dots removed from Minecraft version while importing pack."));
+    }
+
+    auto components = instance.getPackProfile();
+    components->buildingFromScratch();
+    components->setComponentVersion("net.minecraft", mcVersion, true);
+    if (!forgeVersion.isEmpty()) {
+        // FIXME: dirty, nasty, hack. Proper solution requires dependency resolution and knowledge of the metadata.
+        if (forgeVersion == "recommended") {
+            if (forgemap.contains(mcVersion)) {
+                forgeVersion = forgemap[mcVersion];
+            } else {
+                logWarning(tr("Could not map recommended Forge version for Minecraft %1").arg(mcVersion));
+            }
+        }
+        components->setComponentVersion("net.minecraftforge", forgeVersion);
+    }
+    if (!fabricVersion.isEmpty())
+        components->setComponentVersion("net.fabricmc.fabric-loader", fabricVersion);
+
+    if (m_instIcon != "default") {
+        instance.setIconKey(m_instIcon);
+    } else {
+        if (pack.name.contains("Direwolf20")) {
+            instance.setIconKey("steve");
+        } else if (pack.name.contains("FTB") || pack.name.contains("Feed The Beast")) {
+            instance.setIconKey("ftb_logo");
+        } else {
+            instance.setIconKey("flame");
+        }
+    }
+
+    QString jarmodsPath = FS::PathCombine(m_stagingPath, "minecraft", "jarmods");
+    QFileInfo jarmodsInfo(jarmodsPath);
+    if (jarmodsInfo.isDir()) {
+        // install all the jar mods
+        qDebug() << "Found jarmods:";
+        QDir jarmodsDir(jarmodsPath);
+        QStringList jarMods;
+        for (auto info : jarmodsDir.entryInfoList(QDir::NoDotAndDotDot | QDir::Files)) {
+            qDebug() << info.fileName();
+            jarMods.push_back(info.absoluteFilePath());
+        }
+        auto profile = instance.getPackProfile();
+        profile->installJarMods(jarMods);
+        // nuke the original files
+        FS::deletePath(jarmodsPath);
+    }
+
+    instance.setName(m_instName);
+
+    m_mod_id_resolver = new Flame::FileResolvingTask(APPLICATION->network(), pack);
+    connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::succeeded, this, [this, &loop]{
+            idResolverSucceeded(loop);
+    });
+    connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::failed, [&](QString reason) {
+        m_mod_id_resolver.reset();
+        setError(tr("Unable to resolve mod IDs:\n") + reason);
+    });
+    connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::progress, this, &FlameCreationTask::setProgress);
+    connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::status, this, &FlameCreationTask::setStatus);
+
+    m_mod_id_resolver->start();
+
+    loop.exec();
+
+    return getError().isEmpty();
+}
+
+void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
+{
+    auto results = m_mod_id_resolver->getResults();
+    // first check for blocked mods
+    QString text;
+    QList<QUrl> urls;
+    auto anyBlocked = false;
+    for (const auto& result : results.files.values()) {
+        if (!result.resolved || result.url.isEmpty()) {
+            text += QString("%1: <a href='%2'>%2</a><br/>").arg(result.fileName, result.websiteUrl);
+            urls.append(QUrl(result.websiteUrl));
+            anyBlocked = true;
+        }
+    }
+    if (anyBlocked) {
+        qWarning() << "Blocked mods found, displaying mod list";
+
+        auto message_dialog = new BlockedModsDialog(m_parent, tr("Blocked mods found"),
+                                                   tr("The following mods were blocked on third party launchers.<br/>"
+                                                      "You will need to manually download them and add them to the modpack"),
+                                                   text,
+                                                   urls);
+        message_dialog->setModal(true);
+
+        if (message_dialog->exec()) {
+            m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());
+            for (const auto& result : m_mod_id_resolver->getResults().files) {
+                QString filename = result.fileName;
+                if (!result.required) {
+                    filename += ".disabled";
+                }
+
+                auto relpath = FS::PathCombine("minecraft", result.targetFolder, filename);
+                auto path = FS::PathCombine(m_stagingPath, relpath);
+
+                switch (result.type) {
+                    case Flame::File::Type::Folder: {
+                        logWarning(tr("This 'Folder' may need extracting: %1").arg(relpath));
+                        // fall-through intentional, we treat these as plain old mods and dump them wherever.
+                    }
+                    case Flame::File::Type::SingleFile:
+                    case Flame::File::Type::Mod: {
+                        if (!result.url.isEmpty()) {
+                            qDebug() << "Will download" << result.url << "to" << path;
+                            auto dl = Net::Download::makeFile(result.url, path);
+                            m_files_job->addNetAction(dl);
+                        }
+                        break;
+                    }
+                    case Flame::File::Type::Modpack:
+                        logWarning(tr("Nesting modpacks in modpacks is not implemented, nothing was downloaded: %1").arg(relpath));
+                        break;
+                    case Flame::File::Type::Cmod2:
+                    case Flame::File::Type::Ctoc:
+                    case Flame::File::Type::Unknown:
+                        logWarning(tr("Unrecognized/unhandled PackageType for: %1").arg(relpath));
+                        break;
+                }
+            }
+
+            m_mod_id_resolver.reset();
+            connect(m_files_job.get(), &NetJob::succeeded, this, [&]() {
+                m_files_job.reset();
+                emitSucceeded();
+            });
+            connect(m_files_job.get(), &NetJob::failed, [&](QString reason) {
+                m_files_job.reset();
+                setError(reason);
+            });
+            connect(m_files_job.get(), &NetJob::progress, [&](qint64 current, qint64 total) { setProgress(current, total); });
+            connect(m_files_job.get(), &NetJob::finished, &loop, &QEventLoop::quit);
+
+            setStatus(tr("Downloading mods..."));
+            m_files_job->start();
+        } else {
+            m_mod_id_resolver.reset();
+            setError("Canceled");
+        }
+    } else {
+        // TODO extract to function ?
+        m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());
+        for (const auto& result : m_mod_id_resolver->getResults().files) {
+            QString filename = result.fileName;
+            if (!result.required) {
+                filename += ".disabled";
+            }
+
+            auto relpath = FS::PathCombine("minecraft", result.targetFolder, filename);
+            auto path = FS::PathCombine(m_stagingPath, relpath);
+
+            switch (result.type) {
+                case Flame::File::Type::Folder: {
+                    logWarning(tr("This 'Folder' may need extracting: %1").arg(relpath));
+                    // fall-through intentional, we treat these as plain old mods and dump them wherever.
+                }
+                case Flame::File::Type::SingleFile:
+                case Flame::File::Type::Mod: {
+                    if (!result.url.isEmpty()) {
+                        qDebug() << "Will download" << result.url << "to" << path;
+                        auto dl = Net::Download::makeFile(result.url, path);
+                        m_files_job->addNetAction(dl);
+                    }
+                    break;
+                }
+                case Flame::File::Type::Modpack:
+                    logWarning(tr("Nesting modpacks in modpacks is not implemented, nothing was downloaded: %1").arg(relpath));
+                    break;
+                case Flame::File::Type::Cmod2:
+                case Flame::File::Type::Ctoc:
+                case Flame::File::Type::Unknown:
+                    logWarning(tr("Unrecognized/unhandled PackageType for: %1").arg(relpath));
+                    break;
+            }
+        }
+
+        m_mod_id_resolver.reset();
+        connect(m_files_job.get(), &NetJob::succeeded, this, [&]() {
+            m_files_job.reset();
+            emitSucceeded();
+        });
+        connect(m_files_job.get(), &NetJob::failed, [&](QString reason) {
+            m_files_job.reset();
+            setError(reason);
+        });
+        connect(m_files_job.get(), &NetJob::progress, [&](qint64 current, qint64 total) { setProgress(current, total); });
+        connect(m_files_job.get(), &NetJob::finished, &loop, &QEventLoop::quit);
+
+        setStatus(tr("Downloading mods..."));
+        m_files_job->start();
+    }
+}

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -30,6 +30,7 @@ bool FlameCreationTask::abort()
     if (!canAbort())
         return false;
 
+    m_abort = true;
     if (m_process_update_file_info_job)
         m_process_update_file_info_job->abort();
     if (m_files_job)

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -15,8 +15,8 @@
 
 #include "settings/INISettingsObject.h"
 
-#include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/BlockedModsDialog.h"
+#include "ui/dialogs/CustomMessageBox.h"
 
 const static QMap<QString, QString> forgemap = { { "1.2.5", "3.4.9.171" },
                                                  { "1.4.2", "6.0.1.355" },
@@ -348,12 +348,20 @@ bool FlameCreationTask::createInstance()
 
     bool did_succeed = getError().isEmpty();
 
+    // Update information of the already installed instance, if any.
     if (m_instance && did_succeed) {
         setAbortable(false);
         auto inst = m_instance.value();
 
+        // Only change the name if it didn't use a custom name, so that the previous custom name
+        // is preserved, but if we're using the original one, we update the version string.
+        // NOTE: This needs to come before the copyManagedPack call!
+        if (inst->name().contains(inst->getManagedPackVersionName())) {
+            if (askForChangingInstanceName(m_parent, inst->name(), instance.name()) == InstanceNameChange::ShouldChange)
+                inst->setName(instance.name());
+        }
+
         inst->copyManagedPack(instance);
-        inst->setName(instance.name());
     }
 
     return did_succeed;

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -19,6 +19,7 @@ class FlameCreationTask final : public InstanceCreationTask {
 
     bool abort() override;
 
+    bool updateInstance() override;
     bool createInstance() override;
 
    private slots:
@@ -29,5 +30,9 @@ class FlameCreationTask final : public InstanceCreationTask {
     QWidget* m_parent = nullptr;
 
     shared_qobject_ptr<Flame::FileResolvingTask> m_mod_id_resolver;
-    NetJob::Ptr m_files_job;
+    Flame::Manifest m_pack;
+
+    // Handle to allow aborting
+    NetJob* m_process_update_file_info_job = nullptr;
+    NetJob::Ptr m_files_job = nullptr;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -2,6 +2,10 @@
 
 #include "InstanceCreationTask.h"
 
+#include <optional>
+
+#include "minecraft/MinecraftInstance.h"
+
 #include "modplatform/flame/FileResolvingTask.h"
 
 #include "net/NetJob.h"
@@ -35,4 +39,6 @@ class FlameCreationTask final : public InstanceCreationTask {
     // Handle to allow aborting
     NetJob* m_process_update_file_info_job = nullptr;
     NetJob::Ptr m_files_job = nullptr;
+
+    std::optional<InstancePtr> m_instance;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -14,7 +14,7 @@ class FlameCreationTask final : public InstanceCreationTask {
     Q_OBJECT
 
    public:
-    FlameCreationTask(QString staging_path, SettingsObjectPtr global_settings, QWidget* parent)
+    FlameCreationTask(const QString& staging_path, SettingsObjectPtr global_settings, QWidget* parent)
         : InstanceCreationTask(), m_parent(parent)
     {
         setStagingPath(staging_path);

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -23,6 +23,7 @@ class FlameCreationTask final : public InstanceCreationTask {
 
    private slots:
     void idResolverSucceeded(QEventLoop&);
+    void setupDownloadJob(QEventLoop&);
 
    private:
     QWidget* m_parent = nullptr;

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "InstanceCreationTask.h"
+
+#include "modplatform/flame/FileResolvingTask.h"
+
+#include "net/NetJob.h"
+
+class FlameCreationTask final : public InstanceCreationTask {
+    Q_OBJECT
+
+   public:
+    FlameCreationTask(QString staging_path, SettingsObjectPtr global_settings, QWidget* parent)
+        : InstanceCreationTask(), m_parent(parent)
+    {
+        setStagingPath(staging_path);
+        setParentSettings(global_settings);
+    }
+
+    bool abort() override;
+
+    bool createInstance() override;
+
+   private slots:
+    void idResolverSucceeded(QEventLoop&);
+
+   private:
+    QWidget* m_parent = nullptr;
+
+    shared_qobject_ptr<Flame::FileResolvingTask> m_mod_id_resolver;
+    NetJob::Ptr m_files_job;
+};

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -29,21 +29,29 @@ static void loadMinecraftV1(Flame::Minecraft& m, QJsonObject& minecraft)
     }
 }
 
-static void loadManifestV1(Flame::Manifest& m, QJsonObject& manifest)
+static void loadManifestV1(Flame::Manifest& pack, QJsonObject& manifest)
 {
     auto mc = Json::requireObject(manifest, "minecraft");
-    loadMinecraftV1(m.minecraft, mc);
-    m.name = Json::ensureString(manifest, QString("name"), "Unnamed");
-    m.version = Json::ensureString(manifest, QString("version"), QString());
-    m.author = Json::ensureString(manifest, QString("author"), "Anonymous");
+
+    loadMinecraftV1(pack.minecraft, mc);
+
+    pack.name = Json::ensureString(manifest, QString("name"), "Unnamed");
+    pack.version = Json::ensureString(manifest, QString("version"), QString());
+    pack.author = Json::ensureString(manifest, QString("author"), "Anonymous");
+
     auto arr = Json::ensureArray(manifest, "files", QJsonArray());
-    for (QJsonValueRef item : arr) {
+    for (auto item : arr) {
         auto obj = Json::requireObject(item);
+
         Flame::File file;
         loadFileV1(file, obj);
-        m.files.insert(file.fileId,file);
+
+        pack.files.insert(file.fileId,file);
     }
-    m.overrides = Json::ensureString(manifest, "overrides", "overrides");
+
+    pack.overrides = Json::ensureString(manifest, "overrides", "overrides");
+
+    pack.is_loaded = true;
 }
 
 void Flame::loadManifest(Flame::Manifest& m, const QString& filepath)

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -61,7 +61,7 @@ void Flame::loadManifest(Flame::Manifest& m, const QString& filepath)
     loadManifestV1(m, obj);
 }
 
-bool Flame::File::parseFromObject(const QJsonObject& obj)
+bool Flame::File::parseFromObject(const QJsonObject& obj,  bool throw_on_blocked)
 {
     fileName = Json::requireString(obj, "fileName");
     // This is a piece of a Flame project JSON pulled out into the file metadata (here) for convenience
@@ -91,7 +91,7 @@ bool Flame::File::parseFromObject(const QJsonObject& obj)
     // may throw, if the project is blocked
     QString rawUrl = Json::ensureString(obj, "downloadUrl");
     url = QUrl(rawUrl, QUrl::TolerantMode);
-    if (!url.isValid()) {
+    if (!url.isValid() && throw_on_blocked) {
         throw JSONValidationError(QString("Invalid URL: %1").arg(rawUrl));
     }
 

--- a/launcher/modplatform/flame/PackManifest.h
+++ b/launcher/modplatform/flame/PackManifest.h
@@ -35,11 +35,11 @@
 
 #pragma once
 
-#include <QString>
-#include <QVector>
-#include <QMap>
-#include <QUrl>
 #include <QJsonObject>
+#include <QMap>
+#include <QString>
+#include <QUrl>
+#include <QVector>
 
 namespace Flame
 {
@@ -97,6 +97,8 @@ struct Manifest
     //File id -> File
     QMap<int,Flame::File> files;
     QString overrides;
+
+    bool is_loaded = false;
 };
 
 void loadManifest(Flame::Manifest & m, const QString &filepath);

--- a/launcher/modplatform/flame/PackManifest.h
+++ b/launcher/modplatform/flame/PackManifest.h
@@ -46,7 +46,7 @@ namespace Flame
 struct File
 {
     // NOTE: throws JSONValidationError
-    bool parseFromObject(const QJsonObject& object);
+    bool parseFromObject(const QJsonObject& object, bool throw_on_blocked = true);
 
     int projectId = 0;
     int fileId = 0;

--- a/launcher/modplatform/helpers/OverrideUtils.cpp
+++ b/launcher/modplatform/helpers/OverrideUtils.cpp
@@ -6,7 +6,7 @@
 
 namespace Override {
 
-void createOverrides(QString name, QString parent_folder, QString override_path)
+void createOverrides(const QString& name, const QString& parent_folder, const QString& override_path)
 {
     QString file_path(FS::PathCombine(parent_folder, name + ".txt"));
     if (QFile::exists(file_path))
@@ -33,7 +33,7 @@ void createOverrides(QString name, QString parent_folder, QString override_path)
     file.close();
 }
 
-QStringList readOverrides(QString name, QString parent_folder)
+QStringList readOverrides(const QString& name, const QString& parent_folder)
 {
     QString file_path(FS::PathCombine(parent_folder, name + ".txt"));
 

--- a/launcher/modplatform/helpers/OverrideUtils.cpp
+++ b/launcher/modplatform/helpers/OverrideUtils.cpp
@@ -1,0 +1,59 @@
+#include "OverrideUtils.h"
+
+#include <QDirIterator>
+
+#include "FileSystem.h"
+
+namespace Override {
+
+void createOverrides(QString name, QString parent_folder, QString override_path)
+{
+    QString file_path(FS::PathCombine(parent_folder, name + ".txt"));
+    if (QFile::exists(file_path))
+        QFile::remove(file_path);
+
+    FS::ensureFilePathExists(file_path);
+
+    QFile file(file_path);
+    file.open(QFile::WriteOnly);
+
+    QDirIterator override_iterator(override_path, QDirIterator::Subdirectories);
+    while (override_iterator.hasNext()) {
+        auto override_file_path = override_iterator.next();
+        QFileInfo info(override_file_path);
+        if (info.isFile()) {
+            // Absolute path with temp directory -> relative path
+            override_file_path = override_file_path.split(name).last().remove(0, 1);
+
+            file.write(override_file_path.toUtf8());
+            file.write("\n");
+        }
+    }
+
+    file.close();
+}
+
+QStringList readOverrides(QString name, QString parent_folder)
+{
+    QString file_path(FS::PathCombine(parent_folder, name + ".txt"));
+
+    QFile file(file_path);
+    if (!file.exists())
+        return {};
+
+    QStringList previous_overrides;
+
+    file.open(QFile::ReadOnly);
+
+    QString entry;
+    do {
+        entry = file.readLine();
+        previous_overrides.append(entry.trimmed());
+    } while (!entry.isEmpty());
+
+    file.close();
+
+    return previous_overrides;
+}
+
+}  // namespace Override

--- a/launcher/modplatform/helpers/OverrideUtils.h
+++ b/launcher/modplatform/helpers/OverrideUtils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+
+namespace Override {
+
+/** This creates a file in `parent_folder` that holds information about which
+ *  overrides are in `override_path`.
+ *
+ *  If there's already an existing such file, it will be ovewritten.
+ */
+void createOverrides(QString name, QString parent_folder, QString override_path);
+
+/** This reads an existing overrides archive, returning a list of overrides.
+ *
+ *  If there's no such file in `parent_folder`, it will return an empty list.
+ */
+QStringList readOverrides(QString name, QString parent_folder);
+
+}  // namespace Override

--- a/launcher/modplatform/helpers/OverrideUtils.h
+++ b/launcher/modplatform/helpers/OverrideUtils.h
@@ -9,12 +9,12 @@ namespace Override {
  *
  *  If there's already an existing such file, it will be ovewritten.
  */
-void createOverrides(QString name, QString parent_folder, QString override_path);
+void createOverrides(const QString& name, const QString& parent_folder, const QString& override_path);
 
 /** This reads an existing overrides archive, returning a list of overrides.
  *
  *  If there's no such file in `parent_folder`, it will return an empty list.
  */
-QStringList readOverrides(QString name, QString parent_folder);
+QStringList readOverrides(const QString& name, const QString& parent_folder);
 
 }  // namespace Override

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.h
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.h
@@ -33,10 +33,12 @@ private:
 protected slots:
     void fileDownloadFinished();
     void fileDownloadFailed(QString reason);
+    void fileDownloadAborted();
 
 signals:
     void finished(ModpackList publicPacks, ModpackList thirdPartyPacks);
     void failed(QString reason);
+    void aborted();
 
     void privateFileDownloadFinished(Modpack modpack);
     void privateFileDownloadFailed(QString reason, QString packCode);

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -228,7 +228,7 @@ void PackInstallTask::install()
 
     progress(4, 4);
 
-    instance.setName(m_instName);
+    instance.setName(name());
     if(m_instIcon == "default")
     {
         m_instIcon = "ftb_logo";

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -86,6 +86,7 @@ void PackInstallTask::downloadPack()
     connect(netJobContainer.get(), &NetJob::succeeded, this, &PackInstallTask::onDownloadSucceeded);
     connect(netJobContainer.get(), &NetJob::failed, this, &PackInstallTask::onDownloadFailed);
     connect(netJobContainer.get(), &NetJob::progress, this, &PackInstallTask::onDownloadProgress);
+    connect(netJobContainer.get(), &NetJob::aborted, this, &PackInstallTask::onDownloadAborted);
     netJobContainer->start();
 
     progress(1, 4);
@@ -108,6 +109,11 @@ void PackInstallTask::onDownloadProgress(qint64 current, qint64 total)
     abortable = true;
     progress(current, total * 4);
     setStatus(tr("Downloading zip for %1 (%2%)").arg(m_pack.name).arg(current / 10));
+}
+
+void PackInstallTask::onDownloadAborted()
+{
+    emitAborted();
 }
 
 void PackInstallTask::unzip()

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.h
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.h
@@ -38,6 +38,7 @@ private slots:
     void onDownloadSucceeded();
     void onDownloadFailed(QString reason);
     void onDownloadProgress(qint64 current, qint64 total);
+    void onDownloadAborted();
 
     void onUnzipFinished();
     void onUnzipCanceled();

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -65,9 +65,8 @@ bool PackInstallTask::abort()
     if (m_mod_id_resolver_task)
         aborted &= m_mod_id_resolver_task->abort();
 
-    // FIXME: This should be 'emitAborted()', but InstanceStaging doesn't connect to the abort signal yet...
     if (aborted)
-        emitFailed(tr("Aborted"));
+        emitAborted();
 
     return aborted;
 }

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -335,7 +335,7 @@ void PackInstallTask::install()
 
     components->saveNow();
 
-    instance.setName(m_instName);
+    instance.setName(name());
     instance.setIconKey(m_instIcon);
     instance.setManagedPack("modpacksch", QString::number(m_pack.id), m_pack.name, QString::number(m_version.id), m_version.name);
     instanceSettings->resumeSave();

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -262,12 +262,20 @@ bool ModrinthCreationTask::createInstance()
 
     loop.exec();
 
+    // Update information of the already installed instance, if any.
     if (m_instance && ended_well) {
         setAbortable(false);
         auto inst = m_instance.value();
 
+        // Only change the name if it didn't use a custom name, so that the previous custom name
+        // is preserved, but if we're using the original one, we update the version string.
+        // NOTE: This needs to come before the copyManagedPack call!
+        if (inst->name().contains(inst->getManagedPackVersionName())) {
+            if (askForChangingInstanceName(m_parent, inst->name(), instance.name()) == InstanceNameChange::ShouldChange)
+                inst->setName(instance.name());
+        }
+
         inst->copyManagedPack(instance);
-        inst->setName(instance.name());
     }
 
     return ended_well;

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -19,9 +19,12 @@
 
 bool ModrinthCreationTask::abort()
 {
+    if (!canAbort())
+        return false;
+
     if (m_files_job)
         return m_files_job->abort();
-    return true;
+    return Task::abort();
 }
 
 bool ModrinthCreationTask::updateInstance()

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -8,8 +8,6 @@
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 
-#include "modplatform/ModIndex.h"
-
 #include "net/ChecksumValidator.h"
 
 #include "settings/INISettingsObject.h"
@@ -30,11 +28,10 @@ bool ModrinthCreationTask::updateInstance()
     auto instance_list = APPLICATION->instances();
 
     // FIXME: How to handle situations when there's more than one install already for a given modpack?
-    // Based on the way we create the instance name (name + " " + version). Is there a better way?
-    auto inst = instance_list->getInstanceByManagedName(m_instName.section(' ', 0, -2));
+    auto inst = instance_list->getInstanceByManagedName(originalName());
 
     if (!inst) {
-        inst = instance_list->getInstanceById(m_instName);
+        inst = instance_list->getInstanceById(originalName());
 
         if (!inst)
             return false;
@@ -163,8 +160,9 @@ bool ModrinthCreationTask::createInstance()
     } else {
         instance.setIconKey("modrinth");
     }
-    instance.setName(m_instName);
+
     instance.setManagedPack("modrinth", getManagedPackID(), m_managed_name, m_managed_id, {});
+    instance.setName(name());
     instance.saveNow();
 
     m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -135,6 +135,17 @@ bool ModrinthCreationTask::updateInstance()
             qDebug() << "Scheduling" << entry << "for removal";
             m_files_to_remove.append(old_minecraft_dir.absoluteFilePath(entry));
         }
+    } else {
+        // We don't have an old index file, so we may duplicate stuff!
+        auto dialog = CustomMessageBox::selectable(m_parent,
+                tr("No index file."),
+                tr("We couldn't find a suitable index file for the older version. This may cause some of the files to be duplicated. Do you want to continue?"),
+                QMessageBox::Warning, QMessageBox::Ok | QMessageBox::Cancel);
+
+        if (dialog->exec() == QDialog::DialogCode::Rejected) {
+            m_abort = true;
+            return false;
+        }
     }
 
 

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -238,11 +238,12 @@ bool ModrinthCreationTask::createInstance()
         if (!file.downloads.empty()) {
             // FIXME: This really needs to be put into a ConcurrentTask of
             // MultipleOptionsTask's , once those exist :)
-            connect(dl.get(), &NetAction::failed, [this, &file, path, dl] {
-                auto dl = Net::Download::makeFile(file.downloads.dequeue(), path);
-                dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
-                m_files_job->addNetAction(dl);
-                dl->succeeded();
+            auto param = dl.toWeakRef();
+            connect(dl.get(), &NetAction::failed, [this, &file, path, param] {
+                auto ndl = Net::Download::makeFile(file.downloads.dequeue(), path);
+                ndl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
+                m_files_job->addNetAction(ndl);
+                if (auto shared = param.lock()) shared->succeeded();
             });
         }
     }

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -121,7 +121,7 @@ bool ModrinthCreationTask::updateInstance()
         // TODO: Currently 'overrides' will always override the stuff on update. How do we preserve unchanged overrides?
         // FIXME: We may want to do something about disabled mods.
         auto old_overrides = Override::readOverrides("overrides", old_index_folder);
-        for (auto entry : old_overrides) {
+        for (const auto& entry : old_overrides) {
             if (entry.isEmpty())
                 continue;
             qDebug() << "Scheduling" << entry << "for removal";
@@ -129,7 +129,7 @@ bool ModrinthCreationTask::updateInstance()
         }
 
         auto old_client_overrides = Override::readOverrides("client-overrides", old_index_folder);
-        for (auto entry : old_overrides) {
+        for (const auto& entry : old_overrides) {
             if (entry.isEmpty())
                 continue;
             qDebug() << "Scheduling" << entry << "for removal";
@@ -235,7 +235,7 @@ bool ModrinthCreationTask::createInstance()
         dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
         m_files_job->addNetAction(dl);
 
-        if (file.downloads.size() > 0) {
+        if (!file.downloads.empty()) {
             // FIXME: This really needs to be put into a ConcurrentTask of
             // MultipleOptionsTask's , once those exist :)
             connect(dl.get(), &NetAction::failed, [this, &file, path, dl] {
@@ -281,7 +281,7 @@ bool ModrinthCreationTask::createInstance()
     return ended_well;
 }
 
-bool ModrinthCreationTask::parseManifest(QString index_path, std::vector<Modrinth::File>& files, bool set_managed_info, bool show_optional_dialog)
+bool ModrinthCreationTask::parseManifest(const QString& index_path, std::vector<Modrinth::File>& files, bool set_managed_info, bool show_optional_dialog)
 {
     try {
         auto doc = Json::requireDocument(index_path);
@@ -300,7 +300,7 @@ bool ModrinthCreationTask::parseManifest(QString index_path, std::vector<Modrint
 
             auto jsonFiles = Json::requireIsArrayOf<QJsonObject>(obj, "files", "modrinth.index.json");
             bool had_optional = false;
-            for (auto modInfo : jsonFiles) {
+            for (const auto& modInfo : jsonFiles) {
                 Modrinth::File file;
                 file.path = Json::requireString(modInfo, "path");
 

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -22,8 +22,9 @@ bool ModrinthCreationTask::abort()
     if (!canAbort())
         return false;
 
+    m_abort = true;
     if (m_files_job)
-        return m_files_job->abort();
+        m_files_job->abort();
     return Task::abort();
 }
 

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -252,7 +252,7 @@ bool ModrinthCreationTask::createInstance()
     loop.exec();
 
     if (m_instance && ended_well) {
-        setAbortStatus(false);
+        setAbortable(false);
         auto inst = m_instance.value();
 
         inst->copyManagedPack(instance);

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -1,0 +1,225 @@
+#include "ModrinthInstanceCreationTask.h"
+
+#include "Application.h"
+#include "FileSystem.h"
+#include "Json.h"
+
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+
+#include "net/NetJob.h"
+#include "net/ChecksumValidator.h"
+
+#include "settings/INISettingsObject.h"
+
+#include "ui/dialogs/CustomMessageBox.h"
+
+bool ModrinthCreationTask::createInstance()
+{
+    QEventLoop loop;
+
+    if (m_files.empty() && !parseManifest())
+        return false;
+
+    auto mcPath = FS::PathCombine(m_stagingPath, ".minecraft");
+
+    auto override_path = FS::PathCombine(m_stagingPath, "overrides");
+    if (QFile::exists(override_path)) {
+        if (!QFile::rename(override_path, mcPath)) {
+            setError(tr("Could not rename the overrides folder:\n") + "overrides");
+            return false;
+        }
+    }
+
+    // Do client overrides
+    auto client_override_path = FS::PathCombine(m_stagingPath, "client-overrides");
+    if (QFile::exists(client_override_path)) {
+        if (!FS::overrideFolder(mcPath, client_override_path)) {
+            setError(tr("Could not rename the client overrides folder:\n") + "client overrides");
+            return false;
+        }
+    }
+
+    QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
+    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
+    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    auto components = instance.getPackProfile();
+    components->buildingFromScratch();
+    components->setComponentVersion("net.minecraft", minecraftVersion, true);
+
+    if (!fabricVersion.isEmpty())
+        components->setComponentVersion("net.fabricmc.fabric-loader", fabricVersion);
+    if (!quiltVersion.isEmpty())
+        components->setComponentVersion("org.quiltmc.quilt-loader", quiltVersion);
+    if (!forgeVersion.isEmpty())
+        components->setComponentVersion("net.minecraftforge", forgeVersion);
+    if (m_instIcon != "default") {
+        instance.setIconKey(m_instIcon);
+    } else {
+        instance.setIconKey("modrinth");
+    }
+    instance.setName(m_instName);
+    instance.setManagedPack("modrinth", getManagedPackID(), m_managed_name, m_managed_id, {});
+    instance.saveNow();
+
+    m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());
+
+    for (auto file : m_files) {
+        auto path = FS::PathCombine(m_stagingPath, ".minecraft", file.path);
+        qDebug() << "Will try to download" << file.downloads.front() << "to" << path;
+        auto dl = Net::Download::makeFile(file.downloads.dequeue(), path);
+        dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
+        m_files_job->addNetAction(dl);
+
+        if (file.downloads.size() > 0) {
+            // FIXME: This really needs to be put into a ConcurrentTask of
+            // MultipleOptionsTask's , once those exist :)
+            connect(dl.get(), &NetAction::failed, [this, &file, path, dl] {
+                auto dl = Net::Download::makeFile(file.downloads.dequeue(), path);
+                dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
+                m_files_job->addNetAction(dl);
+                dl->succeeded();
+            });
+        }
+    }
+
+    bool ended_well = false;
+
+    connect(m_files_job.get(), &NetJob::succeeded, this, [&]() { ended_well = true; });
+    connect(m_files_job.get(), &NetJob::failed, [&](const QString& reason) {
+        ended_well = false;
+        setError(reason);
+    });
+    connect(m_files_job.get(), &NetJob::finished, &loop, &QEventLoop::quit);
+    connect(m_files_job.get(), &NetJob::progress, [&](qint64 current, qint64 total) { setProgress(current, total); });
+
+    setStatus(tr("Downloading mods..."));
+    m_files_job->start();
+
+    loop.exec();
+
+    return ended_well;
+}
+
+bool ModrinthCreationTask::parseManifest()
+{
+    try {
+        QString indexPath = FS::PathCombine(m_stagingPath, "modrinth.index.json");
+        auto doc = Json::requireDocument(indexPath);
+        auto obj = Json::requireObject(doc, "modrinth.index.json");
+        int formatVersion = Json::requireInteger(obj, "formatVersion", "modrinth.index.json");
+        if (formatVersion == 1) {
+            auto game = Json::requireString(obj, "game", "modrinth.index.json");
+            if (game != "minecraft") {
+                throw JSONValidationError("Unknown game: " + game);
+            }
+
+            m_managed_version_id = Json::ensureString(obj, "versionId", "Managed ID");
+            m_managed_name = Json::ensureString(obj, "name", "Managed Name");
+
+            auto jsonFiles = Json::requireIsArrayOf<QJsonObject>(obj, "files", "modrinth.index.json");
+            bool had_optional = false;
+            for (auto modInfo : jsonFiles) {
+                Modrinth::File file;
+                file.path = Json::requireString(modInfo, "path");
+
+                auto env = Json::ensureObject(modInfo, "env");
+                // 'env' field is optional
+                if (!env.isEmpty()) {
+                    QString support = Json::ensureString(env, "client", "unsupported");
+                    if (support == "unsupported") {
+                        continue;
+                    } else if (support == "optional") {
+                        // TODO: Make a review dialog for choosing which ones the user wants!
+                        if (!had_optional) {
+                            had_optional = true;
+                            auto info = CustomMessageBox::selectable(
+                                m_parent, tr("Optional mod detected!"),
+                                tr("One or more mods from this modpack are optional. They will be downloaded, but disabled by default!"),
+                                QMessageBox::Information);
+                            info->exec();
+                        }
+
+                        if (file.path.endsWith(".jar"))
+                            file.path += ".disabled";
+                    }
+                }
+
+                QJsonObject hashes = Json::requireObject(modInfo, "hashes");
+                QString hash;
+                QCryptographicHash::Algorithm hashAlgorithm;
+                hash = Json::ensureString(hashes, "sha1");
+                hashAlgorithm = QCryptographicHash::Sha1;
+                if (hash.isEmpty()) {
+                    hash = Json::ensureString(hashes, "sha512");
+                    hashAlgorithm = QCryptographicHash::Sha512;
+                    if (hash.isEmpty()) {
+                        hash = Json::ensureString(hashes, "sha256");
+                        hashAlgorithm = QCryptographicHash::Sha256;
+                        if (hash.isEmpty()) {
+                            throw JSONValidationError("No hash found for: " + file.path);
+                        }
+                    }
+                }
+                file.hash = QByteArray::fromHex(hash.toLatin1());
+                file.hashAlgorithm = hashAlgorithm;
+
+                // Do not use requireUrl, which uses StrictMode, instead use QUrl's default TolerantMode
+                // (as Modrinth seems to incorrectly handle spaces)
+
+                auto download_arr = Json::ensureArray(modInfo, "downloads");
+                for (auto download : download_arr) {
+                    qWarning() << download.toString();
+                    bool is_last = download.toString() == download_arr.last().toString();
+
+                    auto download_url = QUrl(download.toString());
+
+                    if (!download_url.isValid()) {
+                        qDebug()
+                            << QString("Download URL (%1) for %2 is not a correctly formatted URL").arg(download_url.toString(), file.path);
+                        if (is_last && file.downloads.isEmpty())
+                            throw JSONValidationError(tr("Download URL for %1 is not a correctly formatted URL").arg(file.path));
+                    } else {
+                        file.downloads.push_back(download_url);
+                    }
+                }
+
+                m_files.push_back(file);
+            }
+
+            auto dependencies = Json::requireObject(obj, "dependencies", "modrinth.index.json");
+            for (auto it = dependencies.begin(), end = dependencies.end(); it != end; ++it) {
+                QString name = it.key();
+                if (name == "minecraft") {
+                    minecraftVersion = Json::requireString(*it, "Minecraft version");
+                } else if (name == "fabric-loader") {
+                    fabricVersion = Json::requireString(*it, "Fabric Loader version");
+                } else if (name == "quilt-loader") {
+                    quiltVersion = Json::requireString(*it, "Quilt Loader version");
+                } else if (name == "forge") {
+                    forgeVersion = Json::requireString(*it, "Forge version");
+                } else {
+                    throw JSONValidationError("Unknown dependency type: " + name);
+                }
+            }
+        } else {
+            throw JSONValidationError(QStringLiteral("Unknown format version: %s").arg(formatVersion));
+        }
+        QFile::remove(indexPath);
+    } catch (const JSONValidationError& e) {
+        setError(tr("Could not understand pack index:\n") + e.cause());
+        return false;
+    }
+
+    return true;
+}
+
+QString ModrinthCreationTask::getManagedPackID() const
+{
+    if (!m_source_url.isEmpty()) {
+        QRegularExpression regex(R"(data\/(.*)\/versions)");
+        return regex.match(m_source_url).captured(0);
+    }
+
+    return {};
+}

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "InstanceCreationTask.h"
+
+#include "modplatform/modrinth/ModrinthPackManifest.h"
+
+#include "net/NetJob.h"
+
+class ModrinthCreationTask final : public InstanceCreationTask {
+    Q_OBJECT
+
+   public:
+    ModrinthCreationTask(QString staging_path, SettingsObjectPtr global_settings, QWidget* parent, QString source_url = {})
+        : InstanceCreationTask(), m_parent(parent)
+    {
+        setStagingPath(staging_path);
+        setParentSettings(global_settings);
+    }
+
+    bool abort() override;
+    bool canAbort() const override { return true; }
+
+    bool updateInstance() override;
+    bool createInstance() override;
+
+   private:
+    bool parseManifest();
+    QString getManagedPackID() const;
+
+   private:
+    QWidget* m_parent = nullptr;
+
+    QString minecraftVersion, fabricVersion, quiltVersion, forgeVersion;
+    QString m_managed_id, m_managed_version_id, m_managed_name;
+    QString m_source_url;
+
+    std::vector<Modrinth::File> m_files;
+    NetJob::Ptr m_files_job;
+};

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -27,7 +27,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     bool createInstance() override;
 
    private:
-    bool parseManifest(QString, std::vector<Modrinth::File>&, bool set_managed_info = true);
+    bool parseManifest(QString, std::vector<Modrinth::File>&, bool set_managed_info = true, bool show_optional_dialog = true);
     QString getManagedPackID() const;
 
    private:

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -27,7 +27,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     bool createInstance() override;
 
    private:
-    bool parseManifest(QString, std::vector<Modrinth::File>&, bool set_managed_info = true, bool show_optional_dialog = true);
+    bool parseManifest(const QString&, std::vector<Modrinth::File>&, bool set_managed_info = true, bool show_optional_dialog = true);
     QString getManagedPackID() const;
 
    private:

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -24,7 +24,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     bool createInstance() override;
 
    private:
-    bool parseManifest();
+    bool parseManifest(QString, std::vector<Modrinth::File>&);
     QString getManagedPackID() const;
 
    private:

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -22,7 +22,6 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     }
 
     bool abort() override;
-    bool canAbort() const override { return true; }
 
     bool updateInstance() override;
     bool createInstance() override;

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -2,6 +2,10 @@
 
 #include "InstanceCreationTask.h"
 
+#include <optional>
+
+#include "minecraft/MinecraftInstance.h"
+
 #include "modplatform/modrinth/ModrinthPackManifest.h"
 
 #include "net/NetJob.h"
@@ -11,7 +15,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
 
    public:
     ModrinthCreationTask(QString staging_path, SettingsObjectPtr global_settings, QWidget* parent, QString source_url = {})
-        : InstanceCreationTask(), m_parent(parent)
+        : InstanceCreationTask(), m_parent(parent), m_source_url(std::move(source_url))
     {
         setStagingPath(staging_path);
         setParentSettings(global_settings);
@@ -24,7 +28,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     bool createInstance() override;
 
    private:
-    bool parseManifest(QString, std::vector<Modrinth::File>&);
+    bool parseManifest(QString, std::vector<Modrinth::File>&, bool set_managed_info = true);
     QString getManagedPackID() const;
 
    private:
@@ -36,4 +40,6 @@ class ModrinthCreationTask final : public InstanceCreationTask {
 
     std::vector<Modrinth::File> m_files;
     NetJob::Ptr m_files_job;
+
+    std::optional<InstancePtr> m_instance;
 };

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
@@ -133,7 +133,7 @@ void Technic::SingleZipPackInstallTask::extractFinished()
     shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &Technic::SingleZipPackInstallTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &Technic::SingleZipPackInstallTask::emitFailed);
-    packProcessor->run(m_globalSettings, m_instName, m_instIcon, m_stagingPath, m_minecraftVersion);
+    packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath, m_minecraftVersion);
 }
 
 void Technic::SingleZipPackInstallTask::extractAborted()

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -77,6 +77,7 @@ void Technic::SolderPackInstallTask::executeTask()
     auto job = m_filesNetJob.get();
     connect(job, &NetJob::succeeded, this, &Technic::SolderPackInstallTask::fileListSucceeded);
     connect(job, &NetJob::failed, this, &Technic::SolderPackInstallTask::downloadFailed);
+    connect(job, &NetJob::aborted, this, &Technic::SolderPackInstallTask::downloadAborted);
     m_filesNetJob->start();
 }
 
@@ -127,6 +128,7 @@ void Technic::SolderPackInstallTask::fileListSucceeded()
     connect(m_filesNetJob.get(), &NetJob::succeeded, this, &Technic::SolderPackInstallTask::downloadSucceeded);
     connect(m_filesNetJob.get(), &NetJob::progress, this, &Technic::SolderPackInstallTask::downloadProgressChanged);
     connect(m_filesNetJob.get(), &NetJob::failed, this, &Technic::SolderPackInstallTask::downloadFailed);
+    connect(m_filesNetJob.get(), &NetJob::aborted, this, &Technic::SolderPackInstallTask::downloadAborted);
     m_filesNetJob->start();
 }
 
@@ -169,6 +171,12 @@ void Technic::SolderPackInstallTask::downloadProgressChanged(qint64 current, qin
 {
     m_abortable = true;
     setProgress(current / 2, total);
+}
+
+void Technic::SolderPackInstallTask::downloadAborted()
+{
+    emitAborted();
+    m_filesNetJob.reset();
 }
 
 void Technic::SolderPackInstallTask::extractFinished()

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -214,7 +214,7 @@ void Technic::SolderPackInstallTask::extractFinished()
     shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &Technic::SolderPackInstallTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &Technic::SolderPackInstallTask::emitFailed);
-    packProcessor->run(m_globalSettings, m_instName, m_instIcon, m_stagingPath, m_minecraftVersion, true);
+    packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath, m_minecraftVersion, true);
 }
 
 void Technic::SolderPackInstallTask::extractAborted()

--- a/launcher/modplatform/technic/SolderPackInstallTask.h
+++ b/launcher/modplatform/technic/SolderPackInstallTask.h
@@ -61,6 +61,7 @@ namespace Technic
         void downloadSucceeded();
         void downloadFailed(QString reason);
         void downloadProgressChanged(qint64 current, qint64 total);
+        void downloadAborted();
         void extractFinished();
         void extractAborted();
 

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -68,7 +68,7 @@ class Task : public QObject, public QRunnable {
 
     virtual QStringList warnings() const;
 
-    virtual bool canAbort() const { return false; }
+    virtual bool canAbort() const { return m_can_abort; }
 
     auto getState() const -> State { return m_state; }
 
@@ -96,12 +96,18 @@ class Task : public QObject, public QRunnable {
     void status(QString status);
     void stepStatus(QString status);
 
+    /** Emitted when the canAbort() status has changed.
+     */
+    void abortStatusChanged(bool can_abort);
+
    public slots:
     // QRunnable's interface
     void run() override { start(); }
 
     virtual void start();
     virtual bool abort() { if(canAbort()) emitAborted(); return canAbort(); };
+
+    void setAbortStatus(bool can_abort) { m_can_abort = can_abort; emit abortStatusChanged(can_abort); }
 
    protected:
     virtual void executeTask() = 0;
@@ -125,4 +131,8 @@ class Task : public QObject, public QRunnable {
 
     // TODO: Nuke in favor of QLoggingCategory
     bool m_show_debug = true;
+
+   private:
+    // Change using setAbortStatus
+    bool m_can_abort = false;
 };

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -107,7 +107,7 @@ class Task : public QObject, public QRunnable {
     virtual void start();
     virtual bool abort() { if(canAbort()) emitAborted(); return canAbort(); };
 
-    void setAbortStatus(bool can_abort) { m_can_abort = can_abort; emit abortStatusChanged(can_abort); }
+    void setAbortable(bool can_abort) { m_can_abort = can_abort; emit abortStatusChanged(can_abort); }
 
    protected:
     virtual void executeTask() = 0;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1656,6 +1656,10 @@ void MainWindow::runModalTask(Task *task)
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
             }
         });
+    connect(task, &Task::aborted, [this]
+        {
+            CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)->show();
+        });
     ProgressDialog loadDialog(this);
     loadDialog.setSkipButton(true, tr("Abort"));
     loadDialog.execWithTask(task);

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -177,13 +177,30 @@ NewInstanceDialog::~NewInstanceDialog()
     delete ui;
 }
 
-void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task)
+void NewInstanceDialog::setSuggestedPack(QString name, InstanceTask* task)
 {
     creationTask.reset(task);
-    ui->instNameTextBox->setPlaceholderText(name);
 
-    if(!task)
-    {
+    ui->instNameTextBox->setPlaceholderText(name);
+    importVersion.clear();
+
+    if (!task) {
+        ui->iconButton->setIcon(APPLICATION->icons()->getIcon("default"));
+        importIcon = false;
+    }
+
+    auto allowOK = task && !instName().isEmpty();
+    m_buttons->button(QDialogButtonBox::Ok)->setEnabled(allowOK);
+}
+
+void NewInstanceDialog::setSuggestedPack(QString name, QString version, InstanceTask* task)
+{
+    creationTask.reset(task);
+
+    ui->instNameTextBox->setPlaceholderText(name);
+    importVersion = version;
+
+    if (!task) {
         ui->iconButton->setIcon(APPLICATION->icons()->getIcon("default"));
         importIcon = false;
     }
@@ -214,7 +231,11 @@ InstanceTask * NewInstanceDialog::extractTask()
 {
     InstanceTask * extracted = creationTask.get();
     creationTask.release();
-    extracted->setName(instName());
+
+    InstanceName inst_name(ui->instNameTextBox->placeholderText().trimmed(), importVersion);
+    inst_name.setName(ui->instNameTextBox->text().trimmed());
+    extracted->setName(inst_name);
+
     extracted->setGroup(instGroup());
     extracted->setIcon(iconKey());
     return extracted;

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -51,6 +51,7 @@
 #include <QFileDialog>
 #include <QValidator>
 #include <QDialogButtonBox>
+#include <utility>
 
 #include "ui/widgets/PageContainer.h"
 #include "ui/pages/modplatform/VanillaPage.h"
@@ -177,7 +178,7 @@ NewInstanceDialog::~NewInstanceDialog()
     delete ui;
 }
 
-void NewInstanceDialog::setSuggestedPack(QString name, InstanceTask* task)
+void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task)
 {
     creationTask.reset(task);
 
@@ -193,12 +194,12 @@ void NewInstanceDialog::setSuggestedPack(QString name, InstanceTask* task)
     m_buttons->button(QDialogButtonBox::Ok)->setEnabled(allowOK);
 }
 
-void NewInstanceDialog::setSuggestedPack(QString name, QString version, InstanceTask* task)
+void NewInstanceDialog::setSuggestedPack(const QString& name, QString version, InstanceTask* task)
 {
     creationTask.reset(task);
 
     ui->instNameTextBox->setPlaceholderText(name);
-    importVersion = version;
+    importVersion = std::move(version);
 
     if (!task) {
         ui->iconButton->setIcon(APPLICATION->icons()->getIcon("default"));

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -60,8 +60,8 @@ public:
 
     void updateDialogState();
 
-    void setSuggestedPack(QString name = QString(), InstanceTask * task = nullptr);
-    void setSuggestedPack(QString name, QString version, InstanceTask * task = nullptr);
+    void setSuggestedPack(const QString& name = QString(), InstanceTask * task = nullptr);
+    void setSuggestedPack(const QString& name, QString version, InstanceTask * task = nullptr);
     void setSuggestedIconFromFile(const QString &path, const QString &name);
     void setSuggestedIcon(const QString &key);
 

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -37,7 +37,6 @@
 
 #include <QDialog>
 
-#include "BaseVersion.h"
 #include "ui/pages/BasePageProvider.h"
 #include "InstanceTask.h"
 
@@ -61,7 +60,8 @@ public:
 
     void updateDialogState();
 
-    void setSuggestedPack(const QString & name = QString(), InstanceTask * task = nullptr);
+    void setSuggestedPack(QString name = QString(), InstanceTask * task = nullptr);
+    void setSuggestedPack(QString name, QString version, InstanceTask * task = nullptr);
     void setSuggestedIconFromFile(const QString &path, const QString &name);
     void setSuggestedIcon(const QString &key);
 
@@ -94,6 +94,8 @@ private:
     bool importIcon = false;
     QString importIconPath;
     QString importIconName;
+
+    QString importVersion;
 
     void importIconNow();
 };

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -43,8 +43,7 @@ void ProgressDialog::setSkipButton(bool present, QString label)
 void ProgressDialog::on_skipButton_clicked(bool checked)
 {
     Q_UNUSED(checked);
-    if (task->abort())
-        QDialog::reject();
+    task->abort();
 }
 
 ProgressDialog::~ProgressDialog()
@@ -81,7 +80,7 @@ int ProgressDialog::execWithTask(Task* task)
     connect(task, &Task::stepStatus, this, &ProgressDialog::changeStatus);
     connect(task, &Task::progress, this, &ProgressDialog::changeProgress);
 
-    connect(task, &Task::aborted, [this] { onTaskFailed(tr("Aborted by user")); });
+    connect(task, &Task::aborted, [this] { QDialog::reject(); });
 
     m_is_multi_step = task->isMultiStep();
     if (!m_is_multi_step) {

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -81,6 +81,7 @@ int ProgressDialog::execWithTask(Task* task)
     connect(task, &Task::progress, this, &ProgressDialog::changeProgress);
 
     connect(task, &Task::aborted, [this] { QDialog::reject(); });
+    connect(task, &Task::abortStatusChanged, ui->skipButton, &QPushButton::setEnabled);
 
     m_is_multi_step = task->isMultiStep();
     if (!m_is_multi_step) {

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -39,12 +39,12 @@
 #include <QTabBar>
 
 #include "Application.h"
+#include "Filter.h"
+#include "Version.h"
 #include "meta/Index.h"
 #include "meta/VersionList.h"
+#include "minecraft/VanillaInstanceCreationTask.h"
 #include "ui/dialogs/NewInstanceDialog.h"
-#include "Filter.h"
-#include "InstanceCreationTask.h"
-#include "Version.h"
 
 VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     : QWidget(parent), dialog(dialog), ui(new Ui::VanillaPage)
@@ -217,11 +217,11 @@ void VanillaPage::suggestCurrent()
 
     // There isn't a selected version if the version list is empty
     if(ui->loaderVersionList->selectedVersion() == nullptr)
-        dialog->setSuggestedPack(m_selectedVersion->descriptor(), new InstanceCreationTask(m_selectedVersion));
+        dialog->setSuggestedPack(m_selectedVersion->descriptor(), new VanillaCreationTask(m_selectedVersion));
     else
     {
         dialog->setSuggestedPack(m_selectedVersion->descriptor(),
-                                 new InstanceCreationTask(m_selectedVersion, m_selectedLoader,
+                                 new VanillaCreationTask(m_selectedVersion, m_selectedLoader,
                                                           m_selectedLoaderVersion));
     }
     dialog->setSuggestedIcon("default");

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -117,7 +117,7 @@ void AtlPage::suggestCurrent()
     }
 
     auto uiSupport = new AtlUserInteractionSupportImpl(this);
-    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ATLauncher::PackInstallTask(uiSupport, selected.name, selectedVersion));
+    dialog->setSuggestedPack(selected.name, selectedVersion, new ATLauncher::PackInstallTask(uiSupport, selected.name, selectedVersion));
 
     auto editedLogoName = selected.safeName;
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/images/%1.png").arg(selected.safeName.toLower());

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -127,7 +127,7 @@ void FtbPage::suggestCurrent()
         return;
     }
 
-    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ModpacksCH::PackInstallTask(selected, selectedVersion, this));
+    dialog->setSuggestedPack(selected.name, selectedVersion, new ModpacksCH::PackInstallTask(selected, selectedVersion, this));
     for(auto art : selected.art) {
         if(art.type == "square") {
             QString editedLogoName;

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -176,7 +176,7 @@ void Page::suggestCurrent()
         return;
     }
 
-    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new PackInstallTask(APPLICATION->network(), selected, selectedVersion));
+    dialog->setSuggestedPack(selected.name, selectedVersion, new PackInstallTask(APPLICATION->network(), selected, selectedVersion));
     QString editedLogoName;
     if(selected.logo.toLower().startsWith("ftb"))
     {

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -146,6 +146,7 @@ void Page::openedImpl()
     {
         connect(ftbFetchTask.get(), &PackFetchTask::finished, this, &Page::ftbPackDataDownloadSuccessfully);
         connect(ftbFetchTask.get(), &PackFetchTask::failed, this, &Page::ftbPackDataDownloadFailed);
+        connect(ftbFetchTask.get(), &PackFetchTask::aborted, this, &Page::ftbPackDataDownloadAborted);
 
         connect(ftbFetchTask.get(), &PackFetchTask::privateFileDownloadFinished, this, &Page::ftbPrivatePackDataDownloadSuccessfully);
         connect(ftbFetchTask.get(), &PackFetchTask::privateFileDownloadFailed, this, &Page::ftbPrivatePackDataDownloadFailed);
@@ -220,7 +221,12 @@ void Page::ftbPackDataDownloadSuccessfully(ModpackList publicPacks, ModpackList 
 
 void Page::ftbPackDataDownloadFailed(QString reason)
 {
-    //TODO: Display the error
+    CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
+}
+
+void Page::ftbPackDataDownloadAborted()
+{
+    CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)->show();
 }
 
 void Page::ftbPrivatePackDataDownloadSuccessfully(Modpack pack)

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.h
@@ -95,6 +95,7 @@ private:
 private slots:
     void ftbPackDataDownloadSuccessfully(ModpackList publicPacks, ModpackList thirdPartyPacks);
     void ftbPackDataDownloadFailed(QString reason);
+    void ftbPackDataDownloadAborted();
 
     void ftbPrivatePackDataDownloadSuccessfully(Modpack pack);
     void ftbPrivatePackDataDownloadFailed(QString reason, QString packCode);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -294,7 +294,7 @@ void ModrinthPage::suggestCurrent()
 
     for (auto& ver : current.versions) {
         if (ver.id == selectedVersion) {
-            dialog->setSuggestedPack(current.name + " " + ver.version, new InstanceImportTask(ver.download_url, this));
+            dialog->setSuggestedPack(current.name, ver.version, new InstanceImportTask(ver.download_url, this));
             auto iconName = current.iconName;
             m_model->getLogo(iconName, current.iconUrl.toString(),
                              [this, iconName](QString logo) { dialog->setSuggestedIconFromFile(logo, iconName); });

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -271,11 +271,11 @@ void TechnicPage::selectVersion() {
 
     if (!current.isSolder)
     {
-        dialog->setSuggestedPack(current.name + " " + selectedVersion, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name, selectedVersion, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
     }
     else
     {
-        dialog->setSuggestedPack(current.name + " " + selectedVersion, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url, current.slug, selectedVersion, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name, selectedVersion, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url, current.slug, selectedVersion, current.minecraftVersion));
     }
 }
 


### PR DESCRIPTION
This adds mostly refactor changes to how instances are created and imported, with the main purpose of laying the groundwork needed for a more user-friendly (and better) modpack updating schema. What it does is:
- Add ability to override an instance's contents when trying to create a new instance, for instance, to apply a version diff to it with the latest files
- Change the Instance ID naming slightly to make it easier to find similar instances (Note: While no instance will be lost / corrupted with this changes, it makes the current updating algorithm unable to find those old instances, unless you explicitly reinstall that modpack version from the modpack downloader). 
- Refactor instance imports into a suitable abstraction that can either update an existing instance, or create a new one entirely.

The idea is that, having this system in place, adding a nice UI with version selection, changelog and whatnot should be fairly straightforward, since we would be able to just, from the specified version, use the proper API to download the pack manifest / index / etc., and just pass it on to this system to handle it.

~TODO~:
- [x] Refactor existing _mrpack_ code
- [x] Add update capability to _mrpack_ instances
- [x] Refactor existing CF code
- [x] Add update capability to CF instances
- [x] ~Look into other providers, and try to fit them into this abstraction - Since they do things a little differently, porting them to this new architecture is not as straightforward, but if we do, the idea described previously would automatically work for them as well!~ those will be left to another PR down the line, since the changes here are already quite big! :o

feedback is always welcome!