### PR TITLE
Install scdoc on GHA to build manpage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install ninja-build extra-cmake-modules
+          sudo apt-get -y install ninja-build extra-cmake-modules scdoc
 
       - name: Install Dependencies (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
Adds `scdoc` to GHA workflow so official Linux builds will have a manpage

Companion PR to #847