### PR TITLE
fix(nix): add stdenv.cc.cc.lib to GAME_LIBRARY_PATH

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,6 +34,7 @@ let
     libXxf86vm
     libpulseaudio
     libGL
+    stdenv.cc.cc.lib
   ];
 
   # This variable will be passed to Minecraft by PolyMC


### PR DESCRIPTION
Some mods (like DiscordRichPresence) require libstdc++. This commit adds `stdenv.cc.cc.lib` to `$GAME_LIBRARY_PATH` so that these mods function correctly.