### PR TITLE
Run markdownlint on the markdown files

### DIFF
--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -11,6 +11,7 @@ on:
       - '**.nix'
       - 'packages/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.markdownlint**'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -19,6 +20,7 @@ on:
       - '**.nix'
       - 'packages/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - '.markdownlint**'
   workflow_dispatch:
 
 jobs:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# MD013/line-length - Line length
+MD013: false
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  siblings-only: true
+
+# MD033/no-inline-html Inline HTML
+MD033: false
+
+# MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
+MD041: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+libraries/nbtplusplus
+libraries/quazip

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 # Contributor Covenant Code of Conduct
+
 This is a modified version of the Contributor Covenant.
 See commit history to see our changes.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -134,4 +134,3 @@ For answers to common questions about this code of conduct, see the FAQ at
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,31 +26,33 @@ Signed-off-by: Author name <Author email>
 
 By signing off your work, you agree to the terms below:
 
-    Developer's Certificate of Origin 1.1
+```
+Developer's Certificate of Origin 1.1
 
-    By making a contribution to this project, I certify that:
+By making a contribution to this project, I certify that:
 
-    (a) The contribution was created in whole or in part by me and I
-        have the right to submit it under the open source license
-        indicated in the file; or
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
 
-    (b) The contribution is based upon previous work that, to the best
-        of my knowledge, is covered under an appropriate open source
-        license and I have the right under that license to submit that
-        work with modifications, whether created in whole or in part
-        by me, under the same open source license (unless I am
-        permitted to submit under a different license), as indicated
-        in the file; or
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
 
-    (c) The contribution was provided directly to me by some other
-        person who certified (a), (b) or (c) and I have not modified
-        it.
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
 
-    (d) I understand and agree that this project and the contribution
-        are public and that a record of the contribution (including all
-        personal information I submit with it, including my sign-off) is
-        maintained indefinitely and may be redistributed consistent with
-        this project or the open source license(s) involved.
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
 
 These terms will be enforced once you create a pull request, and you will be informed automatically if any of your commits aren't signed-off by you.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,5 @@ These terms will be enforced once you create a pull request, and you will be inf
 
 As a bonus, you can also [cryptographically sign your commits][gh-signing-commits] and enable [vigilant mode][gh-vigilant-mode] on GitHub.
 
-
-
 [gh-signing-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
 [gh-vigilant-mode]: https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Try to follow the existing formatting.
 If there is no existing formatting, you may use `clang-format` with our included `.clang-format` configuration.
 
 In general, in order of importance:
+
 - Make sure your IDE is not messing up line endings or whitespace and avoid using linters.
 - Prefer readability over dogma.
 - Keep to the existing formatting.

--- a/COPYING.md
+++ b/COPYING.md
@@ -1,4 +1,4 @@
-# PolyMC
+## PolyMC
 
      PolyMC - Minecraft Launcher
      Copyright (C) 2021-2022 PolyMC Contributors
@@ -32,7 +32,7 @@
          See the License for the specific language governing permissions and
          limitations under the License.
 
-# MinGW runtime (Windows)
+## MinGW runtime (Windows)
 
     Copyright (c) 2012 MinGW.org project
 
@@ -54,14 +54,14 @@
     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
     DEALINGS IN THE SOFTWARE.
 
-# Qt 5/6
+## Qt 5/6
 
     Copyright (C) 2022 The Qt Company Ltd and other contributors.
     Contact: https://www.qt.io/licensing
 
     Licensed under LGPL v3
 
-# libnbt++
+## libnbt++
 
     libnbt++ - A library for the Minecraft Named Binary Tag format.
     Copyright (C) 2013, 2015  ljfa-ag
@@ -79,7 +79,7 @@
     You should have received a copy of the GNU Lesser General Public License
     along with libnbt++.  If not, see <http://www.gnu.org/licenses/>.
 
-# rainbow (KGuiAddons)
+## rainbow (KGuiAddons)
 
     Copyright (C) 2007 Matthew Woehlke <mw_triad@users.sourceforge.net>
     Copyright (C) 2007 Olaf Schmidt <ojschmidt@kde.org>
@@ -102,7 +102,7 @@
     the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
     Boston, MA 02110-1301, USA.
 
-# Hoedown
+## Hoedown
 
     Copyright (c) 2008, Natacha Porté
     Copyright (c) 2011, Vicent Martí
@@ -120,7 +120,7 @@
     ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# Batch icon set
+## Batch icon set
 
     You are free to use Batch (the "icon set") or any part thereof (the "icons")
     in any personal, open-source or commercial work without obligation of payment
@@ -136,7 +136,7 @@
     PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF THE USE OF THE ICONS,
     EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-# Material Design Icons
+## Material Design Icons
 
     Copyright (c) 2014, Austin Andrews (http://materialdesignicons.com/),
     with Reserved Font Name Material Design Icons.
@@ -147,7 +147,7 @@
     This license is copied below, and is also available with a FAQ at:
     http://scripts.sil.org/OFL
 
-# Quazip
+## Quazip
 
     Copyright (C) 2005-2021 Sergey A. Tachenov
 
@@ -171,7 +171,7 @@
 
     See COPYING file for the full LGPL text.
 
-# xz-minidec
+## xz-minidec
 
     XZ decompressor
 
@@ -181,7 +181,7 @@
     This file has been put into the public domain.
     You can do whatever you want with this file.
 
-# ColumnResizer
+## ColumnResizer
 
     Copyright (c) 2011-2016 Aurélien Gâteau and contributors.
 
@@ -217,7 +217,7 @@
     OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
     IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# launcher (`libraries/launcher`)
+## launcher (`libraries/launcher`)
 
      PolyMC - Minecraft Launcher
      Copyright (C) 2021-2022 PolyMC Contributors
@@ -268,7 +268,7 @@
          See the License for the specific language governing permissions and
          limitations under the License.
 
-# lionshead
+## lionshead
 
     Code has been taken from https://github.com/natefoo/lionshead and loosely
     translated to C++ laced with Qt.
@@ -295,7 +295,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-# tomlc99
+## tomlc99
 
     MIT License
 
@@ -320,7 +320,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 
-# O2 (Katabasis fork)
+## O2 (Katabasis fork)
 
     Copyright (c) 2012, Akos Polster
     All rights reserved.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ All launcher code is available under the GPL-3.0-only license.
 The logo and related assets are under the CC BY-SA 4.0 license.
 
 ## Sponsors
+
 Thank you to all our generous backers over at Open Collective! Support PolyMC by [becoming a backer](https://opencollective.com/polymc).
 
 [![OpenCollective Backers](https://opencollective.com/polymc/backers.svg?width=890&limit=1000)](https://opencollective.com/polymc#backers)

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ To modify download information or change packaging information send a pull reque
 ## Forking/Redistributing/Custom builds policy
 
 We don't care what you do with your fork/custom build as long as you follow the terms of the [license](LICENSE) (this is a legal responsibility), and if you made code changes rather than just packaging a custom build, please do the following as a basic courtesy:
+
 - Make it clear that your fork is not PolyMC and is not endorsed by or affiliated with the PolyMC project (<https://polymc.org>).
 - Go through [CMakeLists.txt](CMakeLists.txt) and change PolyMC's API keys to your own or set them to empty strings (`""`) to disable them (this way the program will still compile but the functionality requiring those keys will be disabled).
 
 If you have any questions or want any clarification on the above conditions please make an issue and ask us.
 
 Be aware that if you build this software without removing the provided API keys in [CMakeLists.txt](CMakeLists.txt) you are accepting the following terms and conditions:
+
 - [Microsoft Identity Platform Terms of Use](https://docs.microsoft.com/en-us/legal/microsoft-identity-platform/terms-of-use)
 - [CurseForge 3rd Party API Terms and Conditions](https://support.curseforge.com/en/support/solutions/articles/9000207405-curse-forge-3rd-party-api-terms-and-conditions)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to read about why this fork was created, check out [our FAQ page](ht
 # Installation
 
 - All downloads and instructions for PolyMC can be found [here](https://polymc.org/download/)
-- Last build status: https://github.com/PolyMC/PolyMC/actions
+- Last build status: <https://github.com/PolyMC/PolyMC/actions>
 
 ## Development Builds
 
@@ -59,7 +59,7 @@ If you want to build PolyMC yourself, check [Build Instructions](https://polymc.
 
 ## Translations
 
-The translation effort for PolyMC is hosted on [Weblate](https://hosted.weblate.org/projects/polymc/polymc/) and information about translating PolyMC is available at https://github.com/PolyMC/Translations
+The translation effort for PolyMC is hosted on [Weblate](https://hosted.weblate.org/projects/polymc/polymc/) and information about translating PolyMC is available at <https://github.com/PolyMC/Translations>
 
 ## Download information
 
@@ -68,7 +68,7 @@ To modify download information or change packaging information send a pull reque
 ## Forking/Redistributing/Custom builds policy
 
 We don't care what you do with your fork/custom build as long as you follow the terms of the [license](LICENSE) (this is a legal responsibility), and if you made code changes rather than just packaging a custom build, please do the following as a basic courtesy:
-- Make it clear that your fork is not PolyMC and is not endorsed by or affiliated with the PolyMC project (https://polymc.org).
+- Make it clear that your fork is not PolyMC and is not endorsed by or affiliated with the PolyMC project (<https://polymc.org>).
 - Go through [CMakeLists.txt](CMakeLists.txt) and change PolyMC's API keys to your own or set them to empty strings (`""`) to disable them (this way the program will still compile but the functionality requiring those keys will be disabled).
 
 If you have any questions or want any clarification on the above conditions please make an issue and ask us.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ If you want to read about why this fork was created, check out [our FAQ page](ht
 - All downloads and instructions for PolyMC can be found [here](https://polymc.org/download/)
 - Last build status: https://github.com/PolyMC/PolyMC/actions
 
-
 ## Development Builds
 
 There are per-commit development builds available [here](https://github.com/PolyMC/PolyMC/actions). These have debug information in the binaries, so their file sizes are relatively larger.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- <p align="center">
+<p align="center">
 <img src="./program_info/polymc-header-black.svg#gh-light-mode-only" alt="PolyMC logo" width="50%"/>
 <img src="./program_info/polymc-header.svg#gh-dark-mode-only" alt="PolyMC logo" width="50%"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ We don't care what you do with your fork/custom build as long as you follow the 
 If you have any questions or want any clarification on the above conditions please make an issue and ask us.
 
 Be aware that if you build this software without removing the provided API keys in [CMakeLists.txt](CMakeLists.txt) you are accepting the following terms and conditions:
- - [Microsoft Identity Platform Terms of Use](https://docs.microsoft.com/en-us/legal/microsoft-identity-platform/terms-of-use)
- - [CurseForge 3rd Party API Terms and Conditions](https://support.curseforge.com/en/support/solutions/articles/9000207405-curse-forge-3rd-party-api-terms-and-conditions)
+- [Microsoft Identity Platform Terms of Use](https://docs.microsoft.com/en-us/legal/microsoft-identity-platform/terms-of-use)
+- [CurseForge 3rd Party API Terms and Conditions](https://support.curseforge.com/en/support/solutions/articles/9000207405-curse-forge-3rd-party-api-terms-and-conditions)
 
 If you do not agree with these terms and conditions, then remove the associated API keys from the [CMakeLists.txt](CMakeLists.txt) file by setting them to an empty string (`""`).
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -3,6 +3,7 @@
 This folder has third-party or otherwise external libraries needed for other parts to work.
 
 ## classparser
+
 A simplistic parser for Java class files.
 
 This library has served as a base for some (much more full-featured and advanced) work under NDA for AVG. It, however, should NOT be confused with that work.
@@ -18,16 +19,19 @@ See [github repo](https://github.com/FeralInteractive/gamemode).
 BSD licensed
 
 ## hoedown
+
 Hoedown is a revived fork of Sundown, the Markdown parser based on the original code of the Upskirt library by Natacha Porté.
 
 See [github repo](https://github.com/hoedown/hoedown).
 
 ## javacheck
+
 Simple Java tool that prints the JVM details - version and platform bitness.
 
 Do what you want with it. It is so trivial that noone cares.
 
 ## Katabasis
+
 Oauth2 library customized for Microsoft authentication.
 
 This is a fork of the [O2 library](https://github.com/pipacs/o2).
@@ -35,6 +39,7 @@ This is a fork of the [O2 library](https://github.com/pipacs/o2).
 MIT licensed.
 
 ## launcher
+
 Java launcher part for Minecraft.
 
 It:
@@ -131,6 +136,7 @@ launcher onesix
 Available under `GPL-3.0-only` (with classpath exception), sublicensed from its original `Apache-2.0` codebase
 
 ## libnbtplusplus
+
 libnbt++ is a free C++ library for Minecraft's file format Named Binary Tag (NBT). It can read and write compressed and uncompressed NBT files and provides a code interface for working with NBT data.
 
 See [github repo](https://github.com/ljfa-ag/libnbtplusplus).
@@ -138,6 +144,7 @@ See [github repo](https://github.com/ljfa-ag/libnbtplusplus).
 Available either under LGPL version 3 or later.
 
 ## LocalPeer
+
 Library for making only one instance of the application run at all times.
 
 BSD licensed, derived from [QtSingleApplication](https://github.com/qtproject/qt-solutions/tree/master/qtsingleapplication).
@@ -157,6 +164,7 @@ A zip manipulation library, forked for MultiMC's use.
 LGPL 2.1
 
 ## rainbow
+
 Color functions extracted from [KGuiAddons](https://inqlude.org/libraries/kguiaddons.html). Used for adaptive text coloring.
 
 Available either under LGPL version 2.1 or later.

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -43,6 +43,7 @@ MIT licensed.
 Java launcher part for Minecraft.
 
 It:
+
 * Starts a process
 * Waits for a launch script on stdin
 * Consumes the launch script you feed it

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -57,6 +57,7 @@ A `legacy` and `onesix` launchers are available.
 * `onesix` can handle launching any Minecraft version, at the cost of some extra features `legacy` enables (custom window icon and title).
 
 Example (some parts have been censored):
+
 ```
 mod legacyjavafixer-1.0
 mainClass net.minecraft.launchwrapper.Launch

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -188,4 +188,3 @@ Licenced under the MIT licence.
 Tiny implementation of LZMA2 de/compression. This format is only used by Forge to save bandwidth.
 
 Public domain.
-

--- a/libraries/katabasis/README.md
+++ b/libraries/katabasis/README.md
@@ -8,9 +8,9 @@ It may be possible to backport some of the changes to O2 in the future, but for 
 
 Notes to contributors:
 
-   * Please follow the coding style of the existing source, where reasonable
-   * Code contributions are released under Simplified BSD License, as specified in LICENSE. Do not contribute if this license does not suit your code
-   * If you are interested in working on this, come to the PolyMC Discord server and talk first
+* Please follow the coding style of the existing source, where reasonable
+* Code contributions are released under Simplified BSD License, as specified in LICENSE. Do not contribute if this license does not suit your code
+* If you are interested in working on this, come to the PolyMC Discord server and talk first
 
 ## Installation
 

--- a/libraries/katabasis/acknowledgements.md
+++ b/libraries/katabasis/acknowledgements.md
@@ -1,4 +1,4 @@
-# O2 library by Akos Polster and contributors
+## O2 library by Akos Polster and contributors
 
 [The origin of this fork.](https://github.com/pipacs/o2)
 
@@ -26,7 +26,7 @@
 > OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 > OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# SimpleCrypt by Andre Somers
+## SimpleCrypt by Andre Somers
 
 Cryptographic methods for Qt.
 
@@ -56,7 +56,7 @@ Cryptographic methods for Qt.
 > (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 > SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Mandeep Sandhu <mandeepsandhu.chd@gmail.com>
+## Mandeep Sandhu <mandeepsandhu.chd@gmail.com>
 
 Configurable settings storage, Twitter XAuth specialization, new demos, cleanups.
 
@@ -67,42 +67,42 @@ Configurable settings storage, Twitter XAuth specialization, new demos, cleanups
 > Regards,
 > -mandeep"
 
-# Sergey Gavrushkin <https://github.com/ncux>
+## Sergey Gavrushkin <https://github.com/ncux>
 
 FreshBooks specialization
 
-# Theofilos Intzoglou <https://github.com/parapente>
+## Theofilos Intzoglou <https://github.com/parapente>
 
 Hubic specialization
 
-# Dimitar
+## Dimitar
 
 SurveyMonkey specialization
 
-# David Brooks <https://github.com/dbrnz>
+## David Brooks <https://github.com/dbrnz>
 
 CMake related fixes and improvements.
 
-# Lukas Vogel <https://github.com/lukedirtwalker>
+## Lukas Vogel <https://github.com/lukedirtwalker>
 
 Spotify support
 
-# Alan Garny <https://github.com/agarny>
+## Alan Garny <https://github.com/agarny>
 
 Windows DLL build support
 
-# MartinMikita <https://github.com/MartinMikita>
+## MartinMikita <https://github.com/MartinMikita>
 
 Bug fixes
 
-# Larry Shaffer <https://github.com/dakcarto>
+## Larry Shaffer <https://github.com/dakcarto>
 
 Versioning, shared lib, install target and header support
 
-# Gilmanov Ildar <https://github.com/gilmanov-ildar>
+## Gilmanov Ildar <https://github.com/gilmanov-ildar>
 
 Bug fixes, support for ```qml``` module
 
-# Fabian Vogt <https://github.com/Vogtinator>
+## Fabian Vogt <https://github.com/Vogtinator>
 
 Bug fixes, support for building without Qt keywords enabled

--- a/libraries/katabasis/acknowledgements.md
+++ b/libraries/katabasis/acknowledgements.md
@@ -32,10 +32,10 @@ Cryptographic methods for Qt.
 
 > Copyright (c) 2011, Andre Somers
 > All rights reserved.
-> 
+>
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions are met:
-> 
+>
 >    * Redistributions of source code must retain the above copyright
 >      notice, this list of conditions and the following disclaimer.
 >    * Redistributions in binary form must reproduce the above copyright
@@ -44,7 +44,7 @@ Cryptographic methods for Qt.
 >    * Neither the name of the Rathenau Instituut, Andre Somers nor the
 >      names of its contributors may be used to endorse or promote products
 >      derived from this software without specific prior written permission.
-> 
+>
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 > ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 > WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -61,9 +61,9 @@ Cryptographic methods for Qt.
 Configurable settings storage, Twitter XAuth specialization, new demos, cleanups.
 
 > "Hi Akos,
-> 
+>
 > I'm writing this mail to confirm that my contributions to the O2 library, available here https://github.com/pipacs/o2, can be freely distributed according to the project's license (as shown in the LICENSE file).
-> 
+>
 > Regards,
 > -mandeep"
 

--- a/libraries/katabasis/acknowledgements.md
+++ b/libraries/katabasis/acknowledgements.md
@@ -26,7 +26,6 @@
 > OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 > OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 # SimpleCrypt by Andre Somers
 
 Cryptographic methods for Qt.
@@ -107,4 +106,3 @@ Bug fixes, support for ```qml``` module
 # Fabian Vogt <https://github.com/Vogtinator>
 
 Bug fixes, support for building without Qt keywords enabled
-

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -10,7 +10,6 @@ If you are looking for a C++ library, you might try this wrapper: [https://githu
 [iarna/toml-spec-tests](https://github.com/iarna/toml-spec-tests).
 * Provides very simple and intuitive interface.
 
-
 ## Usage
 
 Please see the `toml.h` file for details. What follows is a simple example that
@@ -182,7 +181,6 @@ To test against the standard test set provided by BurntSushi/toml-test:
 % bash build.sh   # do this once
 % bash run.sh     # this will run the test suite
 ```
-
 
 To test against the standard test set provided by iarna/toml:
 

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -95,7 +95,7 @@ int main()
 }
 ```
 
-#### Accessing Table Content
+### Accessing Table Content
 
 TOML tables are dictionaries where lookups are done using string keys. In
 general, all access functions on tables are named `toml_*_in(...)`.
@@ -124,7 +124,7 @@ for (int i = 0; ; i++) {
 }
 ```
 
-#### Accessing Array Content
+### Accessing Array Content
 
 TOML arrays can be deref-ed using integer indices. In general, all access methods on arrays are named `toml_*_at()`.
 
@@ -146,7 +146,7 @@ toml_table_at(arr, idx);
 toml_array_at(arr, idx);
 ```
 
-#### toml_datum_t
+### toml_datum_t
 
 Some `toml_*_at` and `toml_*_in` functions return a toml_datum_t
 structure. The `ok` flag in the structure indicates if the function

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -17,8 +17,8 @@ parses this config file:
 
 ```toml
 [server]
-	host = "www.example.com"
-	port = [ 8080, 8181, 8282 ]
+    host = "www.example.com"
+    port = [ 8080, 8181, 8282 ]
 ```
 
 The steps for getting values from our file is usually :
@@ -158,8 +158,8 @@ For example:
 ```c
 toml_datum_t host = toml_string_in(tab, "host");
 if (host.ok) {
-	printf("host: %s\n", host.u.s);
-	free(host.u.s);   /* FREE applies to string and timestamp types only */
+    printf("host: %s\n", host.u.s);
+    free(host.u.s);   /* FREE applies to string and timestamp types only */
 }
 ```
 

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -163,7 +163,7 @@ if (host.ok) {
 }
 ```
 
-** IMPORTANT: if the accessed value is a string or a timestamp, you must call `free(datum.u.s)` or `free(datum.u.ts)` respectively after usage. **
+**IMPORTANT: if the accessed value is a string or a timestamp, you must call `free(datum.u.s)` or `free(datum.u.ts)` respectively after usage.**
 
 ## Building and installing
 

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -102,6 +102,7 @@ general, all access functions on tables are named `toml_*_in(...)`.
 
 In the normal case, you know the key and its content type, and retrievals can be done
 using one of these functions:
+
 ```c
 toml_string_in(tab, key);
 toml_bool_in(tab, key);
@@ -113,6 +114,7 @@ toml_array_in(tab, key);
 ```
 
 You can also interrogate the keys in a table using an integer index:
+
 ```c
 toml_table_t* tab = toml_parse_file(...);
 for (int i = 0; ; i++) {
@@ -127,11 +129,13 @@ for (int i = 0; ; i++) {
 TOML arrays can be deref-ed using integer indices. In general, all access methods on arrays are named `toml_*_at()`.
 
 To obtain the size of an array:
+
 ```c
 int size = toml_array_nelem(arr);
 ```
 
 To obtain the content of an array, use a valid index and call one of these functions:
+
 ```c
 toml_string_at(arr, idx);
 toml_bool_at(arr, idx);
@@ -150,6 +154,7 @@ call was successful. If so, you may proceed to read the value
 corresponding to the type of the content.
 
 For example:
+
 ```c
 toml_datum_t host = toml_string_in(tab, "host");
 if (host.ok) {

--- a/libraries/tomlc99/README.md
+++ b/libraries/tomlc99/README.md
@@ -150,7 +150,7 @@ call was successful. If so, you may proceed to read the value
 corresponding to the type of the content.
 
 For example:
-```
+```c
 toml_datum_t host = toml_string_in(tab, "host");
 if (host.ok) {
 	printf("host: %s\n", host.u.s);

--- a/nix/NIX.md
+++ b/nix/NIX.md
@@ -1,6 +1,7 @@
 # How to import
 
 To import with flakes use
+
 ```nix
 {
   inputs = {

--- a/nix/NIX.md
+++ b/nix/NIX.md
@@ -2,19 +2,21 @@
 
 To import with flakes use
 ```nix
-inputs = {
-  polymc.url = "github:PolyMC/PolyMC";
-};
+{
+  inputs = {
+    polymc.url = "github:PolyMC/PolyMC";
+  };
 
 ...
 
-nixpkgs.overlays = [ inputs.polymc.overlay ]; ## Within configuration.nix
-environment.systemPackages = with pkgs; [ polymc ]; ##
+  nixpkgs.overlays = [ inputs.polymc.overlay ]; ## Within configuration.nix
+  environment.systemPackages = with pkgs; [ polymc ]; ##
+}
 ```
 
 To import without flakes use channels:
 
-```
+```sh
 nix-channel --add https://github.com/PolyMC/PolyMC/archive/master.tar.gz polymc
 nix-channel --update polymc
 nix-env -iA polymc
@@ -22,10 +24,12 @@ nix-env -iA polymc
 
 or alternatively you can use
 
-```
-nixpkgs.overlays = [
-  (import (builtins.fetchTarball "https://github.com/PolyMC/PolyMC/archive/develop.tar.gz")).overlay
-];
+```nix
+{
+  nixpkgs.overlays = [
+    (import (builtins.fetchTarball "https://github.com/PolyMC/PolyMC/archive/develop.tar.gz")).overlay
+  ];
 
-environment.systemPackages = with pkgs; [ polymc ];
+  environment.systemPackages = with pkgs; [ polymc ];
+}
 ```

--- a/program_info/README.md
+++ b/program_info/README.md
@@ -1,6 +1,7 @@
 # PolyMC Program Info
 
 This is PolyMC's program info which contains information about:
+
 - Application name and logo (and branding in general)
 - Various URLs and API endpoints
 - Desktop file


### PR DESCRIPTION
One rule per commit

I've added the config to run it in the last commit. Let me know if it's unnecessary and I'll remove it.

There are still some suggestions that show when running `markdownlint .` These are edge cases and would ideally be ignored. I'd like help with ignoring them specifically without adding comments to the markdown files themselves.