### PR TITLE
Allow the cape to be changed without changing the skin

### DIFF
--- a/launcher/ui/dialogs/SkinUploadDialog.ui
+++ b/launcher/ui/dialogs/SkinUploadDialog.ui
@@ -21,7 +21,11 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QLineEdit" name="skinPathTextBox"/>
+       <widget class="QLineEdit" name="skinPathTextBox">
+        <property name="placeholderText">
+         <string>Leave empty to keep current skin</string>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QPushButton" name="skinBrowseBtn">


### PR DESCRIPTION
Fixes #368 by making skin uploads optional.

If the skin upload box is empty, skin uploading is skipped. I have also added a placeholder to the text box explaining this to users.

I'm not entirely convinced this is a worthwhile change, but it's here if you want it I guess.