### PR TITLE
Fix some icon cache problems

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -864,6 +864,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         m_metacache->addBase("ModpacksCHPacks", QDir("cache/ModpacksCHPacks").absolutePath());
         m_metacache->addBase("TechnicPacks", QDir("cache/TechnicPacks").absolutePath());
         m_metacache->addBase("FlamePacks", QDir("cache/FlamePacks").absolutePath());
+        m_metacache->addBase("FlameMods", QDir("cache/FlameMods").absolutePath());
         m_metacache->addBase("ModrinthPacks", QDir("cache/ModrinthPacks").absolutePath());
         m_metacache->addBase("root", QDir::currentPath());
         m_metacache->addBase("translations", QDir("translations").absolutePath());

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -44,11 +44,6 @@
 
 #include <QDebug>
 
-/** Maximum time to hold a cache entry
- *  = 1 week in milliseconds
- */
-#define TIME_TO_EXPIRE 1*7*24*60*60*1000
-
 auto MetaEntry::getFullPath() -> QString
 {
     // FIXME: make local?
@@ -127,9 +122,8 @@ auto HttpMetaCache::resolveEntry(QString base, QString resource_path, QString ex
     }
 
     // Get rid of old entries, to prevent cache problems
-    auto current_time = QDateTime::currentMSecsSinceEpoch();
-    auto remote_time = QDateTime::fromString(entry->remote_changed_timestamp).toMSecsSinceEpoch();
-    if (current_time - remote_time < TIME_TO_EXPIRE) {
+    auto current_time = QDateTime::currentSecsSinceEpoch();
+    if (entry->isExpired(current_time - ( file_last_changed / 1000 ))) {
         qWarning() << "Removing cache entry because of old age!";
         selected_base.entry_list.remove(resource_path);
         return staleEntry(base, resource_path);
@@ -235,6 +229,8 @@ void HttpMetaCache::Load()
         foo->etag = Json::ensureString(element_obj, "etag");
         foo->local_changed_timestamp = Json::ensureDouble(element_obj, "last_changed_timestamp");
         foo->remote_changed_timestamp = Json::ensureString(element_obj, "remote_changed_timestamp");
+        foo->current_age = Json::ensureDouble(element_obj, "current_age");
+        foo->max_age = Json::ensureDouble(element_obj, "max_age");
         // presumed innocent until closer examination
         foo->stale = false;
 
@@ -275,6 +271,8 @@ void HttpMetaCache::SaveNow()
             entryObj.insert("last_changed_timestamp", QJsonValue(double(entry->local_changed_timestamp)));
             if (!entry->remote_changed_timestamp.isEmpty())
                 entryObj.insert("remote_changed_timestamp", QJsonValue(entry->remote_changed_timestamp));
+            entryObj.insert("current_age", QJsonValue(double(entry->current_age)));
+            entryObj.insert("max_age", QJsonValue(double(entry->max_age)));
             entriesArr.append(entryObj);
         }
     }

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -64,6 +64,14 @@ class MetaEntry {
     auto getMD5Sum() -> QString { return md5sum; }
     void setMD5Sum(QString md5sum) { this->md5sum = md5sum; }
 
+    auto getCurrentAge() -> qint64 { return current_age; }
+    void setCurrentAge(qint64 age) { current_age = age; }
+
+    auto getMaximumAge() -> qint64 { return max_age; }
+    void setMaximumAge(qint64 age) { max_age = age; }
+
+    bool isExpired(qint64 offset) { return current_age >= max_age - offset; };
+
    protected:
     QString baseId;
     QString basePath;
@@ -72,6 +80,8 @@ class MetaEntry {
     QString etag;
     qint64 local_changed_timestamp = 0;
     QString remote_changed_timestamp;  // QString for now, RFC 2822 encoded time
+    qint64 current_age = 0;
+    qint64 max_age = 0;
     bool stale = true;
 };
 


### PR DESCRIPTION
(or at least try to)

This fixes a cache problem, that as far as my understanding goes, happens because:
1. Modrinth doesn't have an 'icon_name' field in their API responses, so we use the project ID as the entry name in the logo metacache.
2. Because the project ID remains the same the icon is updated, the change in icon is not reflected in the cache entry name.
3. This way, we never invalidate the cache because we didn't have any reasons to.

This creates stale entries over time, that are not marked as such, and so the correct, updated icon is not reflected in our UI. This problem is avoided in the Flame code by using the provided icon name field in their API, so that the meta entry name changes when the icon updates. But we shouldn't really rely on the 3rd-party behavior for that kind of thing in general, it's too flimsy a system IMO.

Thus, this creates a time limit to how much a cache entry can exist before it's marked as stale. When that time expires, the icon is re-fetched (possibly at a minimal cost because of the ETag headers in the request), and so we avoid having such outdated icons. The time limit for a resource to live in the cache is set to 1 week, which I think is a reasonable time, but idk.

Lastly, this adds a missing cache entry to FlameMods, so that we correctly cache CF mod icons.