### PR TITLE
Revert "fix(nix): add stdenv.cc.cc.lib to GAME_LIBRARY_PATH"

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,7 +34,6 @@ let
     libXxf86vm
     libpulseaudio
     libGL
-    stdenv.cc.cc.lib
   ];
 
   # This variable will be passed to Minecraft by PolyMC


### PR DESCRIPTION
Reverts PolyMC/PolyMC#904

CC @virchau13 
This seems to cause issues with some environments?

e.g. `nix run github:PolyMC/PolyMC/ba9164022d489be54bccf2d1a2cb56a0123ebc25#polymc` will cause the game to crash on launch, with the following errors for me:

```
/usr/bin/env: /nix/store/8dn12i3d7harw8g7dzk6dy7c5diz5ibp-gcc-11.3.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /usr/lib/libMangoHud.so)
/usr/bin/env: /nix/store/8dn12i3d7harw8g7dzk6dy7c5diz5ibp-gcc-11.3.0-lib/lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /usr/lib/libspdlog.so.1)
```
I don't really know enough about Nix to figure this out. If anyone has a better idea than just reverting the PR, feel free to comment