### PR TITLE
fix(nix): add mangohud to GAME_LIBRARY_PATH

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
 , wrapQtAppsHook
 , xorg
 , libpulseaudio
+, mangohud
 , qtbase
 , quazip
 , libGL
@@ -38,7 +39,9 @@ let
   ];
 
   # This variable will be passed to Minecraft by PolyMC
-  gameLibraryPath = libpath + ":/run/opengl-driver/lib";
+  # MangoHUD needs to be handled specially because it
+  # puts library files in lib/mangohud/ rather than lib/
+  gameLibraryPath = libpath + ":${mangohud}/lib/mangohud:/run/opengl-driver/lib";
 
   javaPaths = lib.makeSearchPath "bin/java" ([ jdk jdk8 ] ++ extraJDKs);
 in


### PR DESCRIPTION
This fixes MangoHUD not showing up when running from Nix, resulting in a dependency error (#923) on non-NixOS systems running Nix and MangoHUD simply not working on NixOS.

CC @Scrumplex can you test this?