### PR TITLE
fix(nix): prefix /lib:/usr/lib: to GAME_LIBRARY_PATH

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,7 +38,9 @@ let
   ];
 
   # This variable will be passed to Minecraft by PolyMC
-  gameLibraryPath = libpath + ":/run/opengl-driver/lib";
+  # We need to add /lib and /usr/lib to enable external processes
+  # on non-NixOS to work properly
+  gameLibraryPath = "/lib:/usr/lib:" + libpath + ":/run/opengl-driver/lib";
 
   javaPaths = lib.makeSearchPath "bin/java" ([ jdk jdk8 ] ++ extraJDKs);
 in


### PR DESCRIPTION
On non-NixOS, launching any external process from Minecraft (e.g. clicking on links) will fail due to a conflict between the system libraries and the Nix libraries (#923). This works around the issue by making the launched processes look for system libraries first.

CC @Scrumplex