### PR TITLE
Fix readability issue with placeholder text in the dark theme

### DIFF
--- a/launcher/ui/themes/DarkTheme.cpp
+++ b/launcher/ui/themes/DarkTheme.cpp
@@ -31,6 +31,7 @@ QPalette DarkTheme::colorScheme()
     darkPalette.setColor(QPalette::Link, QColor(42, 130, 218));
     darkPalette.setColor(QPalette::Highlight, QColor(42, 130, 218));
     darkPalette.setColor(QPalette::HighlightedText, Qt::black);
+    darkPalette.setColor(QPalette::PlaceholderText, Qt::darkGray);
     return fadeInactive(darkPalette, fadeAmount(),  fadeColor());
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9145768/179567749-c1f65b9d-139e-4a61-8716-1546f3b81bd6.png)

Now:
![image](https://user-images.githubusercontent.com/9145768/179568025-9e7f9fe8-2a06-4b71-9b08-c8dfa9abe365.png)
