### PR TITLE
fix(nix): only load stdenv.cc.cc.lib on NixOS

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -34,7 +34,6 @@ let
     libXxf86vm
     libpulseaudio
     libGL
-    stdenv.cc.cc.lib
   ];
 
   # This variable will be passed to Minecraft by PolyMC
@@ -68,10 +67,12 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals enableLTO [ "-DENABLE_LTO=on" ]
     ++ lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ];
 
+  # we have to check if the system is NixOS before adding stdenv.cc.cc.lib (#923)
   postInstall = ''
     # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
     wrapQtApp $out/bin/polymc \
-      --set GAME_LIBRARY_PATH ${gameLibraryPath} \
+      --run '[ -f /etc/NIXOS ] && export GAME_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib"' \
+      --prefix GAME_LIBRARY_PATH : ${gameLibraryPath} \
       --prefix POLYMC_JAVA_PATHS : ${javaPaths} \
       --prefix PATH : ${lib.makeBinPath [ xorg.xrandr ]}
   '';


### PR DESCRIPTION
On non-NixOS, launching any external process from Minecraft (e.g. clicking on links) will fail due to a conflict between the system libraries and the Nix `stdenv.cc.cc.lib` (#923, #928). This works around that issue by only loading `stdenv.cc.cc.lib` on NixOS.