### PR TITLE
Some more UI / UX improvements to the mod downloader!

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -680,6 +680,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
         m_settings->registerSetting("UpdateDialogGeometry", "");
 
+        m_settings->registerSetting("ModDownloadGeometry", "");
+
         // HACK: This code feels so stupid is there a less stupid way of doing this?
         {
             m_settings->registerSetting("PastebinURL", "");

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -884,6 +884,8 @@ SET(LAUNCHER_SOURCES
     ui/widgets/PageContainer.cpp
     ui/widgets/PageContainer.h
     ui/widgets/PageContainer_p.h
+    ui/widgets/ProjectItem.h
+    ui/widgets/ProjectItem.cpp
     ui/widgets/VersionListView.cpp
     ui/widgets/VersionListView.h
     ui/widgets/VersionSelectWidget.cpp

--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -73,7 +73,7 @@ class ModAPI {
     };
 
     virtual void searchMods(CallerType* caller, SearchArgs&& args) const = 0;
-    virtual void getModInfo(CallerType* caller, ModPlatform::IndexedPack& pack) = 0;
+    virtual void getModInfo(ModPlatform::IndexedPack& pack, std::function<void(QJsonDocument&, ModPlatform::IndexedPack&)> callback) = 0;
 
     virtual auto getProject(QString addonId, QByteArray* response) const -> NetJob* = 0;
     virtual auto getProjects(QStringList addonIds, QByteArray* response) const -> NetJob* = 0;

--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -85,7 +85,7 @@ class ModAPI {
         ModLoaderTypes loaders;
     };
 
-    virtual void getVersions(CallerType* caller, VersionSearchArgs&& args) const = 0;
+    virtual void getVersions(VersionSearchArgs&& args, std::function<void(QJsonDocument&, QString)> callback) const = 0;
 
     static auto getModLoaderString(ModLoaderType type) -> const QString {
         switch (type) {

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -73,6 +73,8 @@ struct ExtraPackData {
     QString sourceUrl;
     QString wikiUrl;
     QString discordUrl;
+
+    QString body;
 };
 
 struct IndexedPack {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -7,6 +7,7 @@ class FlameAPI : public NetworkModAPI {
    public:
     auto matchFingerprints(const QList<uint>& fingerprints, QByteArray* response) -> NetJob::Ptr;
     auto getModFileChangelog(int modId, int fileId) -> QString;
+    auto getModDescription(int modId) -> QString;
 
     auto getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::IndexedVersion;
 

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -4,10 +4,9 @@
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "modplatform/flame/FlameAPI.h"
-#include "net/NetJob.h"
 
-static ModPlatform::ProviderCapabilities ProviderCaps;
 static FlameAPI api;
+static ModPlatform::ProviderCapabilities ProviderCaps;
 
 void FlameMod::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 {
@@ -49,6 +48,8 @@ void FlameMod::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& ob
     pack.extraData.wikiUrl = Json::ensureString(links_obj, "wikiUrl");
     if(pack.extraData.wikiUrl.endsWith('/'))
         pack.extraData.wikiUrl.chop(1);
+
+    pack.extraData.body  = api.getModDescription(pack.addonId.toInt());
 
     pack.extraDataLoaded = true;
 }

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -30,10 +30,11 @@ void FlameMod::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
         pack.authors.append(packAuthor);
     }
 
-    loadExtraPackData(pack, obj);
+    pack.extraDataLoaded = false;
+    loadURLs(pack, obj);
 }
 
-void FlameMod::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& obj)
+void FlameMod::loadURLs(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 {
     auto links_obj = Json::ensureObject(obj, "links");
 
@@ -49,9 +50,16 @@ void FlameMod::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& ob
     if(pack.extraData.wikiUrl.endsWith('/'))
         pack.extraData.wikiUrl.chop(1);
 
+    if (!pack.extraData.body.isEmpty())
+        pack.extraDataLoaded = true;
+}
+
+void FlameMod::loadBody(ModPlatform::IndexedPack& pack, QJsonObject& obj)
+{
     pack.extraData.body  = api.getModDescription(pack.addonId.toInt());
 
-    pack.extraDataLoaded = true;
+    if (!pack.extraData.issuesUrl.isEmpty() || !pack.extraData.sourceUrl.isEmpty() || !pack.extraData.wikiUrl.isEmpty())
+        pack.extraDataLoaded = true;
 }
 
 static QString enumToString(int hash_algorithm)

--- a/launcher/modplatform/flame/FlameModIndex.h
+++ b/launcher/modplatform/flame/FlameModIndex.h
@@ -12,7 +12,8 @@
 namespace FlameMod {
 
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
-void loadExtraPackData(ModPlatform::IndexedPack& m, QJsonObject& obj);
+void loadURLs(ModPlatform::IndexedPack& m, QJsonObject& obj);
+void loadBody(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                              QJsonArray& arr,
                              const shared_qobject_ptr<QNetworkAccessManager>& network,

--- a/launcher/modplatform/helpers/NetworkModAPI.cpp
+++ b/launcher/modplatform/helpers/NetworkModAPI.cpp
@@ -52,27 +52,27 @@ void NetworkModAPI::getModInfo(ModPlatform::IndexedPack& pack, std::function<voi
     job->start();
 }
 
-void NetworkModAPI::getVersions(CallerType* caller, VersionSearchArgs&& args) const
+void NetworkModAPI::getVersions(VersionSearchArgs&& args, std::function<void(QJsonDocument&, QString)> callback) const
 {
-    auto netJob = new NetJob(QString("%1::ModVersions(%2)").arg(caller->debugName()).arg(args.addonId), APPLICATION->network());
+    auto netJob = new NetJob(QString("ModVersions(%2)").arg(args.addonId), APPLICATION->network());
     auto response = new QByteArray();
 
     netJob->addNetAction(Net::Download::makeByteArray(getVersionsURL(args), response));
 
-    QObject::connect(netJob, &NetJob::succeeded, caller, [response, caller, args] {
+    QObject::connect(netJob, &NetJob::succeeded, [response, callback, args] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from " << caller->debugName() << " at " << parse_error.offset
+            qWarning() << "Error while parsing JSON response for getting versions at " << parse_error.offset
                        << " reason: " << parse_error.errorString();
             qWarning() << *response;
             return;
         }
 
-        caller->versionRequestSucceeded(doc, args.addonId);
+        callback(doc, args.addonId);
     });
 
-    QObject::connect(netJob, &NetJob::finished, caller, [response, netJob] {
+    QObject::connect(netJob, &NetJob::finished, [response, netJob] {
         netJob->deleteLater();
         delete response;
     });

--- a/launcher/modplatform/helpers/NetworkModAPI.h
+++ b/launcher/modplatform/helpers/NetworkModAPI.h
@@ -6,7 +6,7 @@ class NetworkModAPI : public ModAPI {
    public:
     void searchMods(CallerType* caller, SearchArgs&& args) const override;
     void getModInfo(ModPlatform::IndexedPack& pack, std::function<void(QJsonDocument&, ModPlatform::IndexedPack&)> callback) override;
-    void getVersions(CallerType* caller, VersionSearchArgs&& args) const override;
+    void getVersions(VersionSearchArgs&& args, std::function<void(QJsonDocument&, QString)> callback) const override;
 
     auto getProject(QString addonId, QByteArray* response) const -> NetJob* override;
 

--- a/launcher/modplatform/helpers/NetworkModAPI.h
+++ b/launcher/modplatform/helpers/NetworkModAPI.h
@@ -5,7 +5,7 @@
 class NetworkModAPI : public ModAPI {
    public:
     void searchMods(CallerType* caller, SearchArgs&& args) const override;
-    void getModInfo(CallerType* caller, ModPlatform::IndexedPack& pack) override;
+    void getModInfo(ModPlatform::IndexedPack& pack, std::function<void(QJsonDocument&, ModPlatform::IndexedPack&)> callback) override;
     void getVersions(CallerType* caller, VersionSearchArgs&& args) const override;
 
     auto getProject(QString addonId, QByteArray* response) const -> NetJob* override;

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -87,6 +87,8 @@ void Modrinth::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& ob
         pack.extraData.donate.append(donate);
     }
 
+    pack.extraData.body = Json::ensureString(obj, "body");
+
     pack.extraDataLoaded = true;
 }
 

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -64,6 +64,7 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods
     OkButton->setEnabled(false);
     OkButton->setDefault(true);
     OkButton->setAutoDefault(true);
+    OkButton->setText(tr("Review and confirm"));
     connect(OkButton, &QPushButton::clicked, this, &ModDownloadDialog::confirm);
 
     auto CancelButton = m_buttons->button(QDialogButtonBox::Cancel);

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -81,6 +81,8 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel>& mods
     QMetaObject::connectSlotsByName(this);
     setWindowModality(Qt::WindowModal);
     setWindowTitle(dialogTitle());
+
+    restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("ModDownloadGeometry").toByteArray()));
 }
 
 QString ModDownloadDialog::dialogTitle()
@@ -90,6 +92,7 @@ QString ModDownloadDialog::dialogTitle()
 
 void ModDownloadDialog::reject()
 {
+    APPLICATION->settings()->set("ModDownloadGeometry", saveGeometry().toBase64());
     QDialog::reject();
 }
 
@@ -116,6 +119,7 @@ void ModDownloadDialog::confirm()
 
 void ModDownloadDialog::accept()
 {
+    APPLICATION->settings()->set("ModDownloadGeometry", saveGeometry().toBase64());
     QDialog::accept();
 }
 

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -55,6 +55,8 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel>& mods
 
     m_container->addButtons(m_buttons);
 
+    connect(m_container, &PageContainer::selectedPageChanged, this, &ModDownloadDialog::selectedPageChanged);
+
     // Bonk Qt over its stupid head and make sure it understands which button is the default one...
     // See: https://stackoverflow.com/questions/24556831/qbuttonbox-set-default-button
     auto OkButton = m_buttons->button(QDialogButtonBox::Ok);
@@ -162,4 +164,22 @@ bool ModDownloadDialog::isModSelected(QString name) const
 const QList<ModDownloadTask*> ModDownloadDialog::getTasks()
 {
     return modTask.values();
+}
+
+void ModDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* selected)
+{
+    auto* prev_page = dynamic_cast<ModPage*>(previous);
+    if (!prev_page) {
+        qCritical() << "Page '" << previous->displayName() << "' in ModDownloadDialog is not a ModPage!";
+        return;
+    }
+
+    auto* selected_page = dynamic_cast<ModPage*>(selected);
+    if (!selected_page) {
+        qCritical() << "Page '" << selected->displayName() << "' in ModDownloadDialog is not a ModPage!";
+        return;
+    }
+
+    // Same effect as having a global search bar
+    selected_page->setSearchTerm(prev_page->getSearchTerm());
 }

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -78,7 +78,7 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods
 
     QMetaObject::connectSlotsByName(this);
     setWindowModality(Qt::WindowModal);
-    setWindowTitle("Download mods");
+    setWindowTitle(dialogTitle());
 }
 
 QString ModDownloadDialog::dialogTitle()

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -19,36 +19,33 @@
 #include "ModDownloadDialog.h"
 
 #include <BaseVersion.h>
-#include <icons/IconList.h>
 #include <InstanceList.h>
+#include <icons/IconList.h>
 
 #include "Application.h"
-#include "ProgressDialog.h"
 #include "ReviewMessageBox.h"
 
+#include <QDialogButtonBox>
 #include <QLayout>
 #include <QPushButton>
 #include <QValidator>
-#include <QDialogButtonBox>
 
-#include "ui/widgets/PageContainer.h"
-#include "ui/pages/modplatform/modrinth/ModrinthModPage.h"
 #include "ModDownloadTask.h"
+#include "ui/pages/modplatform/flame/FlameModPage.h"
+#include "ui/pages/modplatform/modrinth/ModrinthModPage.h"
+#include "ui/widgets/PageContainer.h"
 
-
-ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods, QWidget *parent,
-                                     BaseInstance *instance)
-    : QDialog(parent), mods(mods), m_instance(instance)
+ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel>& mods, QWidget* parent, BaseInstance* instance)
+    : QDialog(parent), mods(mods), m_verticalLayout(new QVBoxLayout(this)), m_instance(instance)
 {
     setObjectName(QStringLiteral("ModDownloadDialog"));
-
-    resize(std::max(0.5*parent->width(), 400.0), std::max(0.75*parent->height(), 400.0));
-
-    m_verticalLayout = new QVBoxLayout(this);
     m_verticalLayout->setObjectName(QStringLiteral("verticalLayout"));
 
+    resize(std::max(0.5 * parent->width(), 400.0), std::max(0.75 * parent->height(), 400.0));
+
     setWindowIcon(APPLICATION->getThemedIcon("new"));
-    // NOTE: m_buttons must be initialized before PageContainer, because it indirectly accesses m_buttons through setSuggestedPack! Do not move this below.
+    // NOTE: m_buttons must be initialized before PageContainer, because it indirectly accesses m_buttons through setSuggestedPack! Do not
+    // move this below.
     m_buttons = new QDialogButtonBox(QDialogButtonBox::Help | QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     m_container = new PageContainer(this);
@@ -65,6 +62,8 @@ ModDownloadDialog::ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods
     OkButton->setDefault(true);
     OkButton->setAutoDefault(true);
     OkButton->setText(tr("Review and confirm"));
+    OkButton->setShortcut(tr("Ctrl+Return"));
+    OkButton->setToolTip(tr("Opens a new popup to review your selected mods and confirm your selection. Shortcut: Ctrl+Return"));
     connect(OkButton, &QPushButton::clicked, this, &ModDownloadDialog::confirm);
 
     auto CancelButton = m_buttons->button(QDialogButtonBox::Cancel);
@@ -118,9 +117,9 @@ void ModDownloadDialog::accept()
     QDialog::accept();
 }
 
-QList<BasePage *> ModDownloadDialog::getPages()
+QList<BasePage*> ModDownloadDialog::getPages()
 {
-    QList<BasePage *> pages;
+    QList<BasePage*> pages;
 
     pages.append(new ModrinthModPage(this, m_instance));
     if (APPLICATION->currentCapabilities() & Application::SupportsFlame)
@@ -129,7 +128,7 @@ QList<BasePage *> ModDownloadDialog::getPages()
     return pages;
 }
 
-void ModDownloadDialog::addSelectedMod(const QString& name, ModDownloadTask* task)
+void ModDownloadDialog::addSelectedMod(QString name, ModDownloadTask* task)
 {
     removeSelectedMod(name);
     modTask.insert(name, task);
@@ -137,16 +136,16 @@ void ModDownloadDialog::addSelectedMod(const QString& name, ModDownloadTask* tas
     m_buttons->button(QDialogButtonBox::Ok)->setEnabled(!modTask.isEmpty());
 }
 
-void ModDownloadDialog::removeSelectedMod(const QString &name)
+void ModDownloadDialog::removeSelectedMod(QString name)
 {
-    if(modTask.contains(name))
+    if (modTask.contains(name))
         delete modTask.find(name).value();
     modTask.remove(name);
 
     m_buttons->button(QDialogButtonBox::Ok)->setEnabled(!modTask.isEmpty());
 }
 
-bool ModDownloadDialog::isModSelected(const QString &name, const QString& filename) const
+bool ModDownloadDialog::isModSelected(QString name, QString filename) const
 {
     // FIXME: Is there a way to check for versions without checking the filename
     //        as a heuristic, other than adding such info to ModDownloadTask itself?
@@ -154,16 +153,13 @@ bool ModDownloadDialog::isModSelected(const QString &name, const QString& filena
     return iter != modTask.end() && (iter.value()->getFilename() == filename);
 }
 
-bool ModDownloadDialog::isModSelected(const QString &name) const
+bool ModDownloadDialog::isModSelected(QString name) const
 {
     auto iter = modTask.find(name);
     return iter != modTask.end();
 }
 
-ModDownloadDialog::~ModDownloadDialog()
+const QList<ModDownloadTask*> ModDownloadDialog::getTasks()
 {
-}
-
-const QList<ModDownloadTask*> ModDownloadDialog::getTasks() {
     return modTask.values();
 }

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -34,7 +34,7 @@ class PageContainer;
 class QDialogButtonBox;
 class ModrinthModPage;
 
-class ModDownloadDialog : public QDialog, public BasePageProvider
+class ModDownloadDialog final : public QDialog, public BasePageProvider
 {
     Q_OBJECT
 
@@ -57,6 +57,9 @@ public slots:
     void confirm();
     void accept() override;
     void reject() override;
+
+private slots:
+    void selectedPageChanged(BasePage* previous, BasePage* selected);
 
 private:
     Ui::ModDownloadDialog *ui = nullptr;

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -21,11 +21,9 @@
 #include <QDialog>
 #include <QVBoxLayout>
 
-#include "BaseVersion.h"
-#include "ui/pages/BasePageProvider.h"
-#include "minecraft/mod/ModFolderModel.h"
 #include "ModDownloadTask.h"
-#include "ui/pages/modplatform/flame/FlameModPage.h"
+#include "minecraft/mod/ModFolderModel.h"
+#include "ui/pages/BasePageProvider.h"
 
 namespace Ui
 {
@@ -41,16 +39,16 @@ class ModDownloadDialog : public QDialog, public BasePageProvider
     Q_OBJECT
 
 public:
-    explicit ModDownloadDialog(const std::shared_ptr<ModFolderModel> &mods, QWidget *parent, BaseInstance *instance);
-    ~ModDownloadDialog();
+    explicit ModDownloadDialog(const std::shared_ptr<ModFolderModel>& mods, QWidget* parent, BaseInstance* instance);
+    ~ModDownloadDialog() override = default;
 
     QString dialogTitle() override;
-    QList<BasePage *> getPages() override;
+    QList<BasePage*> getPages() override;
 
-    void addSelectedMod(const QString & name = QString(), ModDownloadTask * task = nullptr);
-    void removeSelectedMod(const QString & name = QString());
-    bool isModSelected(const QString & name, const QString & filename) const;
-    bool isModSelected(const QString & name) const;
+    void addSelectedMod(QString name = QString(), ModDownloadTask* task = nullptr);
+    void removeSelectedMod(QString name = QString());
+    bool isModSelected(QString name, QString filename) const;
+    bool isModSelected(QString name) const;
 
     const QList<ModDownloadTask*> getTasks();
     const std::shared_ptr<ModFolderModel> &mods;

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -1,10 +1,15 @@
 #include "ReviewMessageBox.h"
 #include "ui_ReviewMessageBox.h"
 
+#include <QPushButton>
+
 ReviewMessageBox::ReviewMessageBox(QWidget* parent, QString const& title, QString const& icon)
     : QDialog(parent), ui(new Ui::ReviewMessageBox)
 {
     ui->setupUi(this);
+
+    auto back_button = ui->buttonBox->button(QDialogButtonBox::Cancel);
+    back_button->setText(tr("Back"));
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ReviewMessageBox::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ReviewMessageBox::reject);

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -6,6 +6,8 @@
 #include "minecraft/PackProfile.h"
 #include "ui/dialogs/ModDownloadDialog.h"
 
+#include "ui/widgets/ProjectItem.h"
+
 #include <QMessageBox>
 
 namespace ModPlatform {
@@ -39,9 +41,6 @@ auto ListModel::data(const QModelIndex& index, int role) const -> QVariant
 
     ModPlatform::IndexedPack pack = modpacks.at(pos);
     switch (role) {
-        case Qt::DisplayRole: {
-            return pack.name;
-        }
         case Qt::ToolTipRole: {
             if (pack.description.length() > 100) {
                 // some magic to prevent to long tooltips and replace html linebreaks
@@ -64,20 +63,20 @@ auto ListModel::data(const QModelIndex& index, int role) const -> QVariant
             ((ListModel*)this)->requestLogo(pack.logoName, pack.logoUrl);
             return icon;
         }
+        case Qt::SizeHintRole: 
+            return QSize(0, 58);
         case Qt::UserRole: {
             QVariant v;
             v.setValue(pack);
             return v;
         }
-        case Qt::FontRole: {
-            QFont font;
-            if (m_parent->getDialog()->isModSelected(pack.name)) {
-                font.setBold(true);
-                font.setUnderline(true);
-            }
-
-            return font;
-        }
+    // Custom data
+        case UserDataTypes::TITLE:
+            return pack.name;
+        case UserDataTypes::DESCRIPTION:
+            return pack.description;
+        case UserDataTypes::SELECTED:
+            return m_parent->getDialog()->isModSelected(pack.name);
         default:
             break;
     }

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -2,6 +2,7 @@
 
 #include "BuildConfig.h"
 #include "Json.h"
+#include "ModPage.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "ui/dialogs/ModDownloadDialog.h"

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -102,7 +102,8 @@ void ListModel::performPaginatedSearch()
 
 void ListModel::requestModInfo(ModPlatform::IndexedPack& current)
 {
-    m_parent->apiProvider()->getModInfo(this, current);
+    m_parent->apiProvider()->getModInfo(
+        current, [this](QJsonDocument& doc, ModPlatform::IndexedPack& pack) { infoRequestFinished(doc, pack); });
 }
 
 void ListModel::refresh()

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -100,7 +100,8 @@ void ListModel::requestModVersions(ModPlatform::IndexedPack const& current)
 {
     auto profile = (dynamic_cast<MinecraftInstance*>((dynamic_cast<ModPage*>(parent()))->m_instance))->getPackProfile();
 
-    m_parent->apiProvider()->getVersions(this, { current.addonId.toString(), getMineVersions(), profile->getModLoaders() });
+    m_parent->apiProvider()->getVersions({ current.addonId.toString(), getMineVersions(), profile->getModLoaders() },
+                                         [this, current](QJsonDocument& doc, QString addonId) { versionRequestSucceeded(doc, addonId); });
 }
 
 void ListModel::performPaginatedSearch()

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -28,6 +28,7 @@ class ListModel : public QAbstractListModel {
 
     /* Retrieve information from the model at a given index with the given role */
     auto data(const QModelIndex& index, int role) const -> QVariant override;
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override;
 
     inline void setActiveJob(NetJob::Ptr ptr) { jobPtr = ptr; }
     inline NetJob* activeJob() { return jobPtr.get(); }
@@ -36,7 +37,7 @@ class ListModel : public QAbstractListModel {
     void fetchMore(const QModelIndex& parent) override;
     void refresh();
     void searchWithTerm(const QString& term, const int sort, const bool filter_changed);
-    void requestModInfo(ModPlatform::IndexedPack& current);
+    void requestModInfo(ModPlatform::IndexedPack& current, QModelIndex index);
     void requestModVersions(const ModPlatform::IndexedPack& current);
 
     virtual void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) = 0;
@@ -51,7 +52,7 @@ class ListModel : public QAbstractListModel {
     void searchRequestFinished(QJsonDocument& doc);
     void searchRequestFailed(QString reason);
 
-    void infoRequestFinished(QJsonDocument& doc, ModPlatform::IndexedPack& pack);
+    void infoRequestFinished(QJsonDocument& doc, ModPlatform::IndexedPack& pack, const QModelIndex& index);
 
     void versionRequestSucceeded(QJsonDocument doc, QString addonId);
 

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -2,7 +2,6 @@
 
 #include <QAbstractListModel>
 
-#include "modplatform/ModAPI.h"
 #include "modplatform/ModIndex.h"
 #include "net/NetJob.h"
 

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -18,7 +18,7 @@ class ListModel : public QAbstractListModel {
 
    public:
     ListModel(ModPage* parent);
-    ~ListModel() override = default;
+    ~ListModel() override;
 
     inline auto rowCount(const QModelIndex& parent) const -> int override { return modpacks.size(); };
     inline auto columnCount(const QModelIndex& parent) const -> int override { return 1; };

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -30,6 +30,7 @@ class ListModel : public QAbstractListModel {
     auto data(const QModelIndex& index, int role) const -> QVariant override;
 
     inline void setActiveJob(NetJob::Ptr ptr) { jobPtr = ptr; }
+    inline NetJob* activeJob() { return jobPtr.get(); }
 
     /* Ask the API for more information */
     void fetchMore(const QModelIndex& parent) override;

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -38,7 +38,7 @@ class ListModel : public QAbstractListModel {
     void refresh();
     void searchWithTerm(const QString& term, const int sort, const bool filter_changed);
     void requestModInfo(ModPlatform::IndexedPack& current, QModelIndex index);
-    void requestModVersions(const ModPlatform::IndexedPack& current);
+    void requestModVersions(const ModPlatform::IndexedPack& current, QModelIndex index);
 
     virtual void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) = 0;
     virtual void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) {};
@@ -54,7 +54,7 @@ class ListModel : public QAbstractListModel {
 
     void infoRequestFinished(QJsonDocument& doc, ModPlatform::IndexedPack& pack, const QModelIndex& index);
 
-    void versionRequestSucceeded(QJsonDocument doc, QString addonId);
+    void versionRequestSucceeded(QJsonDocument doc, QString addonId, const QModelIndex& index);
 
    protected slots:
 

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -169,13 +169,13 @@ void ModPage::setSearchTerm(QString term)
     ui->searchEdit->setText(term);
 }
 
-void ModPage::onSelectionChanged(QModelIndex first, QModelIndex second)
+void ModPage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
 {
     ui->versionSelectionBox->clear();
 
-    if (!first.isValid()) { return; }
+    if (!curr.isValid()) { return; }
 
-    current = listModel->data(first, Qt::UserRole).value<ModPlatform::IndexedPack>();
+    current = listModel->data(curr, Qt::UserRole).value<ModPlatform::IndexedPack>();
 
     if (!current.versionsLoaded) {
         qDebug() << QString("Loading %1 mod versions").arg(debugName());
@@ -195,7 +195,8 @@ void ModPage::onSelectionChanged(QModelIndex first, QModelIndex second)
 
     if(!current.extraDataLoaded){
         qDebug() << QString("Loading %1 mod info").arg(debugName());
-        listModel->requestModInfo(current);
+
+        listModel->requestModInfo(current, curr);
     }
 
     updateUi();

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -43,6 +43,7 @@
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "ui/dialogs/ModDownloadDialog.h"
+#include "ui/widgets/ProjectItem.h"
 
 ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     : QWidget(dialog)
@@ -71,6 +72,8 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     connect(&filter_widget, &ModFilterWidget::filterUnchanged, this, [&]{
         ui->searchButton->setStyleSheet("text-decoration: none");
     });
+
+    ui->packView->setItemDelegate(new ProjectItemDelegate(this));
 }
 
 ModPage::~ModPage()

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -76,6 +76,7 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     });
 
     ui->packView->setItemDelegate(new ProjectItemDelegate(this));
+    ui->packView->installEventFilter(this);
 }
 
 ModPage::~ModPage()
@@ -98,6 +99,18 @@ auto ModPage::eventFilter(QObject* watched, QEvent* event) -> bool
         auto* keyEvent = dynamic_cast<QKeyEvent*>(event);
         if (keyEvent->key() == Qt::Key_Return) {
             triggerSearch();
+            keyEvent->accept();
+            return true;
+        }
+    } else if (watched == ui->packView && event->type() == QEvent::KeyPress) {
+        auto* keyEvent = dynamic_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Return) {
+            onModSelected();
+
+            // To have the 'select mod' button outlined instead of the 'review and confirm' one
+            ui->modSelectionButton->setFocus(Qt::FocusReason::ShortcutFocusReason);
+            ui->packView->setFocus(Qt::FocusReason::NoFocusReason);
+
             keyEvent->accept();
             return true;
         }
@@ -172,6 +185,9 @@ void ModPage::onVersionSelectionChanged(QString data)
 
 void ModPage::onModSelected()
 {
+    if (selectedVersion < 0)
+        return;
+
     auto& version = current.versions[selectedVersion];
     if (dialog->isModSelected(current.name, version.fileName)) {
         dialog->removeSelectedMod(current.name);

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -226,6 +226,9 @@ void ModPage::onModSelected()
     }
 
     updateSelectionButton();
+
+    /* Force redraw on the mods list when the selection changes */
+    ui->packView->adjustSize();
 }
 
 

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -56,8 +56,15 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     , api(api)
 {
     ui->setupUi(this);
+
     connect(ui->searchButton, &QPushButton::clicked, this, &ModPage::triggerSearch);
     connect(ui->modFilterButton, &QPushButton::clicked, this, &ModPage::filterMods);
+
+    m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
+    m_search_timer.setSingleShot(true);
+
+    connect(&m_search_timer, &QTimer::timeout, this, &ModPage::triggerSearch);
+
     ui->searchEdit->installEventFilter(this);
 
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -101,6 +108,11 @@ auto ModPage::eventFilter(QObject* watched, QEvent* event) -> bool
             triggerSearch();
             keyEvent->accept();
             return true;
+        } else {
+            if (m_search_timer.isActive())
+                m_search_timer.stop();
+
+            m_search_timer.start(350);
         }
     } else if (watched == ui->packView && event->type() == QEvent::KeyPress) {
         auto* keyEvent = dynamic_cast<QKeyEvent*>(event);

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -183,7 +183,7 @@ void ModPage::onSelectionChanged(QModelIndex curr, QModelIndex prev)
         ui->modSelectionButton->setText(tr("Loading versions..."));
         ui->modSelectionButton->setEnabled(false);
 
-        listModel->requestModVersions(current);
+        listModel->requestModVersions(current, curr);
     } else {
         for (int i = 0; i < current.versions.size(); i++) {
             ui->versionSelectionBox->addItem(current.versions[i].version, QVariant(i));

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -40,6 +40,8 @@
 #include <QKeyEvent>
 #include <memory>
 
+#include <HoeDown.h>
+
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "ui/dialogs/ModDownloadDialog.h"
@@ -288,5 +290,6 @@ void ModPage::updateUi()
 
     text += "<hr>";
 
-    ui->packDescription->setHtml(text + current.description);
+    HoeDown h;
+    ui->packDescription->setHtml(text + (current.extraData.body.isEmpty() ? current.description : h.process(current.extraData.body.toUtf8())));
 }

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -53,6 +53,7 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     , ui(new Ui::ModPage)
     , dialog(dialog)
     , filter_widget(static_cast<MinecraftInstance*>(instance)->getPackProfile()->getComponentVersion("net.minecraft"), this)
+    , m_fetch_progress(this, false)
     , api(api)
 {
     ui->setupUi(this);
@@ -70,7 +71,12 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance* instance, ModAPI* api)
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
-    ui->gridLayout_3->addWidget(&filter_widget, 0, 0, 1, ui->gridLayout_3->columnCount());
+    m_fetch_progress.hideIfInactive(true);
+    m_fetch_progress.setFixedHeight(24);
+    m_fetch_progress.progressFormat("");
+
+    ui->gridLayout_3->addWidget(&m_fetch_progress, 0, 0, 1, ui->gridLayout_3->columnCount());
+    ui->gridLayout_3->addWidget(&filter_widget, 1, 0, 1, ui->gridLayout_3->columnCount());
 
     filter_widget.setInstance(static_cast<MinecraftInstance*>(m_instance));
     m_filter = filter_widget.getFilter();
@@ -151,6 +157,7 @@ void ModPage::triggerSearch()
     }
 
     listModel->searchWithTerm(getSearchTerm(), ui->sortByBox->currentIndex(), changed);
+    m_fetch_progress.watch(listModel->activeJob());
 }
 
 QString ModPage::getSearchTerm() const

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -138,7 +138,16 @@ void ModPage::triggerSearch()
         updateSelectionButton();
     }
 
-    listModel->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex(), changed);
+    listModel->searchWithTerm(getSearchTerm(), ui->sortByBox->currentIndex(), changed);
+}
+
+QString ModPage::getSearchTerm() const
+{
+    return ui->searchEdit->text();
+}
+void ModPage::setSearchTerm(QString term)
+{
+    ui->searchEdit->setText(term);
 }
 
 void ModPage::onSelectionChanged(QModelIndex first, QModelIndex second)

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -81,4 +81,7 @@ class ModPage : public QWidget, public BasePage {
     std::unique_ptr<ModAPI> api;
 
     int selectedVersion = -1;
+
+    // Used to do instant searching with a delay to cache quick changes
+    QTimer m_search_timer;
 };

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -8,6 +8,7 @@
 #include "ui/pages/BasePage.h"
 #include "ui/pages/modplatform/ModModel.h"
 #include "ui/widgets/ModFilterWidget.h"
+#include "ui/widgets/ProgressWidget.h"
 
 class ModDownloadDialog;
 
@@ -74,6 +75,8 @@ class ModPage : public QWidget, public BasePage {
 
     ModFilterWidget filter_widget;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
+
+    ProgressWidget m_fetch_progress;
 
     ModPlatform::ListModel* listModel = nullptr;
     ModPlatform::IndexedPack current;

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -45,6 +45,11 @@ class ModPage : public QWidget, public BasePage {
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
     auto getDialog() const -> const ModDownloadDialog* { return dialog; }
 
+    /** Get the current term in the search bar. */
+    auto getSearchTerm() const -> QString;
+    /** Programatically set the term in the search bar. */
+    void setSearchTerm(QString);
+
     auto getCurrent() -> ModPlatform::IndexedPack& { return current; }
     void updateModVersions(int prev_count = -1);
 

--- a/launcher/ui/pages/modplatform/flame/FlameModModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModModel.cpp
@@ -12,6 +12,12 @@ void ListModel::loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj)
     FlameMod::loadIndexedPack(m, obj);
 }
 
+// We already deal with the URLs when initializing the pack, due to the API response's structure
+void ListModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj)
+{
+    FlameMod::loadBody(m, obj);
+}
+
 void ListModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
     FlameMod::loadIndexedPackVersions(m, arr, APPLICATION->network(), m_parent->m_instance);

--- a/launcher/ui/pages/modplatform/flame/FlameModModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModModel.h
@@ -13,6 +13,7 @@ class ListModel : public ModPlatform::ListModel {
 
    private:
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
+    void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr) override;
 
     auto documentToArray(QJsonDocument& obj) const -> QJsonArray override;

--- a/launcher/ui/widgets/Common.cpp
+++ b/launcher/ui/widgets/Common.cpp
@@ -1,27 +1,33 @@
 #include "Common.h"
 
 // Origin: Qt
-QStringList viewItemTextLayout(QTextLayout &textLayout, int lineWidth, qreal &height,
-                               qreal &widthUsed)
+// More specifically, this is a trimmed down version on the algorithm in:
+// https://code.woboq.org/qt5/qtbase/src/widgets/styles/qcommonstyle.cpp.html#846
+QList<std::pair<qreal, QString>> viewItemTextLayout(QTextLayout& textLayout, int lineWidth, qreal& height)
 {
-    QStringList lines;
+    QList<std::pair<qreal, QString>> lines;
     height = 0;
-    widthUsed = 0;
+
     textLayout.beginLayout();
+
     QString str = textLayout.text();
-    while (true)
-    {
+    while (true) {
         QTextLine line = textLayout.createLine();
+
         if (!line.isValid())
             break;
         if (line.textLength() == 0)
             break;
+
         line.setLineWidth(lineWidth);
         line.setPosition(QPointF(0, height));
+
         height += line.height();
-        lines.append(str.mid(line.textStart(), line.textLength()));
-        widthUsed = qMax(widthUsed, line.naturalTextWidth());
+
+        lines.append(std::make_pair(line.naturalTextWidth(), str.mid(line.textStart(), line.textLength())));
     }
+
     textLayout.endLayout();
+
     return lines;
 }

--- a/launcher/ui/widgets/Common.h
+++ b/launcher/ui/widgets/Common.h
@@ -1,6 +1,9 @@
 #pragma once
-#include <QStringList>
+
 #include <QTextLayout>
 
-QStringList viewItemTextLayout(QTextLayout &textLayout, int lineWidth, qreal &height,
-                        qreal &widthUsed);
+/** Cuts out the text in textLayout into smaller pieces, according to the lineWidth.
+ *  Returns a list of pairs, each containing the width of that line and that line's string, respectively.
+ *  The total height of those lines is set in the last argument, 'height'.
+ */
+QList<std::pair<qreal, QString>> viewItemTextLayout(QTextLayout& textLayout, int lineWidth, qreal& height);

--- a/launcher/ui/widgets/PageContainer.cpp
+++ b/launcher/ui/widgets/PageContainer.cpp
@@ -244,7 +244,14 @@ void PageContainer::help()
 
 void PageContainer::currentChanged(const QModelIndex &current)
 {
-    showPage(current.isValid() ? m_proxyModel->mapToSource(current).row() : -1);
+    int selected_index = current.isValid() ? m_proxyModel->mapToSource(current).row() : -1;
+
+    auto* selected = m_model->pages().at(selected_index);
+    auto* previous = m_currentPage;
+
+    emit selectedPageChanged(previous, selected);
+
+    showPage(selected_index);
 }
 
 bool PageContainer::prepareToClose()

--- a/launcher/ui/widgets/PageContainer.h
+++ b/launcher/ui/widgets/PageContainer.h
@@ -95,6 +95,10 @@ private:
 public slots:
     void help();
 
+signals:
+    /** Emitted when the currently selected page is changed */
+    void selectedPageChanged(BasePage* previous, BasePage* selected);
+
 private slots:
     void currentChanged(const QModelIndex &current);
     void showPage(int row);

--- a/launcher/ui/widgets/ProgressWidget.h
+++ b/launcher/ui/widgets/ProgressWidget.h
@@ -9,24 +9,48 @@ class Task;
 class QProgressBar;
 class QLabel;
 
-class ProgressWidget : public QWidget
-{
+class ProgressWidget : public QWidget {
     Q_OBJECT
-public:
-    explicit ProgressWidget(QWidget *parent = nullptr);
+   public:
+    explicit ProgressWidget(QWidget* parent = nullptr, bool show_label = true);
 
-public slots:
-    void start(std::shared_ptr<Task> task);
+    /** Whether to hide the widget automatically if it's watching no running task. */
+    void hideIfInactive(bool hide) { m_hide_if_inactive = hide; }
+
+    /** Reset the displayed progress to 0 */
+    void reset();
+
+    /** The text that shows up in the middle of the progress bar.
+     *  By default it's '%p%', with '%p' being the total progress in percentage.
+     */
+    void progressFormat(QString);
+
+   public slots:
+    /** Watch the progress of a task. */
+    void watch(Task* task);
+
+    /** Watch the progress of a task, and start it if needed */
+    void start(Task* task);
+
+    /** Blocking way of waiting for a task to finish. */
     bool exec(std::shared_ptr<Task> task);
 
-private slots:
+    /** Un-hide the widget if needed. */
+    void show();
+
+    /** Make the widget invisible. */
+    void hide();
+
+   private slots:
     void handleTaskFinish();
-    void handleTaskStatus(const QString &status);
+    void handleTaskStatus(const QString& status);
     void handleTaskProgress(qint64 current, qint64 total);
     void taskDestroyed();
 
-private:
-    QLabel *m_label;
-    QProgressBar *m_bar;
-    std::shared_ptr<Task> m_task;
+   private:
+    QLabel* m_label = nullptr;
+    QProgressBar* m_bar = nullptr;
+    Task* m_task = nullptr;
+
+    bool m_hide_if_inactive = false;
 };

--- a/launcher/ui/widgets/ProjectItem.cpp
+++ b/launcher/ui/widgets/ProjectItem.cpp
@@ -1,0 +1,78 @@
+#include "ProjectItem.h"
+
+#include "Common.h"
+
+#include <QIcon>
+#include <QPainter>
+
+ProjectItemDelegate::ProjectItemDelegate(QWidget* parent) : QStyledItemDelegate(parent) {}
+
+void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    painter->save();
+
+    QStyleOptionViewItem opt(option);
+    initStyleOption(&opt, index);
+
+    auto& rect = opt.rect;
+    auto icon_width = rect.height(), icon_height = rect.height();
+    auto remaining_width = rect.width() - icon_width;
+
+    if (opt.state & QStyle::State_Selected) {
+        painter->fillRect(rect, opt.palette.highlight());
+        painter->setPen(opt.palette.highlightedText().color());
+    } else if (opt.state & QStyle::State_MouseOver) {
+        painter->fillRect(rect, opt.palette.window());
+    }
+
+    {  // Icon painting
+        // Square-sized, occupying the left portion
+        opt.icon.paint(painter, rect.x(), rect.y(), icon_width, icon_height);
+    }
+
+    {  // Title painting
+        auto title = index.data(UserDataTypes::TITLE).toString();
+
+        painter->save();
+
+        auto font = opt.font;
+        if (index.data(UserDataTypes::SELECTED).toBool()) {
+            // Set nice font
+            font.setBold(true);
+            font.setUnderline(true);
+        }
+
+        font.setPointSize(font.pointSize() + 2);
+        painter->setFont(font);
+
+        // On the top, aligned to the left after the icon
+        painter->drawText(rect.x() + icon_width, rect.y() + QFontMetrics(font).height(), title);
+
+        painter->restore();
+    }
+
+    {  // Description painting
+        auto description = index.data(UserDataTypes::DESCRIPTION).toString();
+
+        QTextLayout text_layout(description, opt.font);
+
+        qreal height = 0;
+        auto cut_text = viewItemTextLayout(text_layout, remaining_width, height);
+
+        // Get first line unconditionally
+        description = cut_text.first().second;
+        // Get second line, elided if needed
+        if (cut_text.size() > 1) {
+            if (cut_text.size() > 2)
+                description += opt.fontMetrics.elidedText(cut_text.at(1).second, opt.textElideMode, cut_text.at(1).first);
+            else
+                description += cut_text.at(1).second;
+        }
+
+        // On the bottom, aligned to the left after the icon, and featuring at most two lines of text (with some margin space to spare)
+        painter->drawText(rect.x() + icon_width, rect.y() + rect.height() - 2.2 * opt.fontMetrics.height(), remaining_width,
+                          2 * opt.fontMetrics.height(), Qt::TextWordWrap, description);
+    }
+
+    painter->restore();
+}

--- a/launcher/ui/widgets/ProjectItem.h
+++ b/launcher/ui/widgets/ProjectItem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+
+/* Custom data types for our custom list models :) */
+enum UserDataTypes {
+    TITLE = 257,        // QString
+    DESCRIPTION = 258,  // QString
+    SELECTED = 259      // bool
+};
+
+/** This is an item delegate composed of:
+ *  - An Icon on the left
+ *  - A title
+ *  - A description
+ * */
+class ProjectItemDelegate final : public QStyledItemDelegate {
+    Q_OBJECT
+
+    public:
+        ProjectItemDelegate(QWidget* parent);
+
+        void paint(QPainter*, const QStyleOptionViewItem&, const QModelIndex&) const override;
+
+};


### PR DESCRIPTION
Closes #803, #908 and #937. 
Maybe closes #892 (i've implemented what was suggested in the comments, because it was relatively straight-forward. I don't know if we want to implement a specific page for combined search in both providers though)

This aims to improve the UI and tweak some of the UX in the mod downloader. What is done here:

- Show more information for mods, by using their entire description instead of just their summary. Done in c7a4020c2135cae7db4c0a9a99bd19f88ad1dd95, 749c9d9dd4b6d26b73088a5fae23248abf81b28f and a8997b2ea73349e92cb8d0c61243dd4415f7c0a1.

- In the mod list, show not only the icon and name of the mod, but also it's summary (previously in the right-side page). Done in 9ba3eb2349bdc654e5381ab2c3c6664c365dfa60.

- Allow selecting a mod with the 'Enter' key, and going to the review page with 'Ctrl+Enter'. Done in 5be771d7051309e513695d3ed70cd1d8c96924ee. Closes #803.

- Cache some info in the mod downloader to reduce bandwidth usage when browsing. Done in b3003d3de2591e345f39aa4c63dc4bd6fee8cb4d, a302aaf524eb5d6ae005629ff8cbd98866f83aad, c5f7c04314ca84873bce4020fe4673031b3fe597 and 659249d5528e5a0ea3fbedb9e776160b99727f3f.

- Preserve search terms between provider pages, so that it's easier to search for mods in both providers. Done in fd1e76d998a1c08c81729dd0af28a4f86b187210. #892 (?)

- Search using the search term automatically after some small delay (to catch quick changes when writing), and add a progress bar when the search is being done. Done in 2e1063547aa98fae6ae5d353626b1d6d2876634d and bdd915116db96170e045cf8d63a22bd96fab6307. Closes #908.

- Remember the mod downloader's window geometry, like with other modal dialogs. Done in fc6ae14c8d8b39a05baa9fae0451b8106aa8c61b. Closes #937.

- Fix a missing translation and change a bit some button wordings to better indicate what they do. Done in e419903921ce4da1d299e2079628d0e83b498990 and 2f2545962f81a7f848ab5c30ecccb1b7c74cbb25.

---

Comparison of looks:
Before:
![no info = sad](https://user-images.githubusercontent.com/9145768/179810150-9cf352d1-6965-4592-bc72-7a2a9a7e0b97.png)

After:
![lots of info!](https://user-images.githubusercontent.com/9145768/179813296-d837982f-c36d-416b-a6d0-41bf10c0398c.png)

---

also, since there's a lot of ui changes that may be more about personal preference than anything objective, feel free to give your opinions (especially the project item delegate, I intend on using it for modpacks too in the future, because it seems like a reasonable thing to do, so we may as well get it to a good state for everyone here!)

reviewers, please tell me if laying out the changes in the description like I did here helped anything! :)
