### PR TITLE
Hide the entire performance tab on the instance settings in non-Linux OSes

### DIFF
--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -349,7 +349,7 @@ void InstanceSettingsPage::loadSettings()
     ui->useDiscreteGpuCheck->setChecked(m_settings->get("UseDiscreteGpu").toBool());
 
     #if !defined(Q_OS_LINUX)
-    ui->perfomanceGroupBox->setVisible(false);
+    ui->settingsTabs->setTabVisible(ui->settingsTabs->indexOf(ui->performancePage), false);
     #endif
 
     // Miscellanous


### PR DESCRIPTION
We were just hiding the group box, not the tab itself, causing a weird issue.