### PR TITLE
Fix variable substitution in pre launch/post exit hooks

### DIFF
--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -282,35 +282,22 @@ void LaunchTask::emitFailed(QString reason)
     Task::emitFailed(reason);
 }
 
-void LaunchTask::substituteVariables(const QStringList &args) const
+void LaunchTask::substituteVariables(QStringList &args) const
 {
-    auto variables = m_instance->getVariables();
-    auto envVariables = QProcessEnvironment::systemEnvironment();
+    auto env = m_instance->createEnvironment();
 
-    for (auto arg : args) {
-        for (auto key : variables)
-        {
-            arg.replace("$" + key, variables.value(key));
-        }
-        for (auto env : envVariables.keys())
-        {
-            arg.replace("$" + env, envVariables.value(env));
-        }
+    for (auto key : env.keys())
+    {
+        args.replaceInStrings("$" + key, env.value(key));
     }
 }
 
-QString LaunchTask::substituteVariables(const QString &cmd) const
+void LaunchTask::substituteVariables(QString &cmd) const
 {
-    QString out = cmd;
-    auto variables = m_instance->getVariables();
-    for (auto it = variables.begin(); it != variables.end(); ++it)
+    auto env = m_instance->createEnvironment();
+
+    for (auto key : env.keys())
     {
-        out.replace("$" + it.key(), it.value());
+        cmd.replace("$" + key, env.value(key));
     }
-    auto env = QProcessEnvironment::systemEnvironment();
-    for (auto var : env.keys())
-    {
-        out.replace("$" + var, env.value(var));
-    }
-    return out;
 }

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -105,8 +105,8 @@ public: /* methods */
     shared_qobject_ptr<LogModel> getLogModel();
 
 public:
-    void substituteVariables(const QStringList &args) const;
-    QString substituteVariables(const QString &cmd) const;
+    void substituteVariables(QStringList &args) const;
+    void substituteVariables(QString &cmd) const;
     QString censorPrivateInfo(QString in);
 
 protected: /* methods */

--- a/launcher/launch/steps/PostLaunchCommand.cpp
+++ b/launcher/launch/steps/PostLaunchCommand.cpp
@@ -56,9 +56,10 @@ void PostLaunchCommand::executeTask()
     const QString program = args.takeFirst();
     m_process.start(program, args);
 #else
-    QString postlaunch_cmd = m_parent->substituteVariables(m_command);
-    emit logLine(tr("Running Post-Launch command: %1").arg(postlaunch_cmd), MessageLevel::Launcher);
-    m_process.start(postlaunch_cmd);
+    m_parent->substituteVariables(m_command);
+
+    emit logLine(tr("Running Post-Launch command: %1").arg(m_command), MessageLevel::Launcher);
+    m_process.start(m_command);
 #endif
 }
 

--- a/launcher/launch/steps/PreLaunchCommand.cpp
+++ b/launcher/launch/steps/PreLaunchCommand.cpp
@@ -56,9 +56,10 @@ void PreLaunchCommand::executeTask()
     const QString program = args.takeFirst();
     m_process.start(program, args);
 #else
-    QString prelaunch_cmd = m_parent->substituteVariables(m_command);
-    emit logLine(tr("Running Pre-Launch command: %1").arg(prelaunch_cmd), MessageLevel::Launcher);
-    m_process.start(prelaunch_cmd);
+    m_parent->substituteVariables(m_command);
+
+    emit logLine(tr("Running Pre-Launch command: %1").arg(m_command), MessageLevel::Launcher);
+    m_process.start(m_command);
 #endif
 }
 


### PR DESCRIPTION
Closes #960

Rewrote that part of the code to make it easier overall. It will now take the `QProcessEnvironment` that will be generated for launching the processes.
Apart from that, strings will now actually be substituted. Some idiot put `const` there and only replaced the values in a copy of the args list.