### PR TITLE
Fix filter in external resource pages not working

### DIFF
--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -32,13 +32,13 @@ class SortProxy : public QSortFilterProxyModel {
         
         const auto& mod = model->at(source_row);
 
-        if (mod.name().contains(filterRegularExpression()))
+        if (filterRegularExpression().match(mod.name()).hasMatch())
             return true;
-        if (mod.description().contains(filterRegularExpression()))
+        if (filterRegularExpression().match(mod.description()).hasMatch())
             return true;
         
         for (auto& author : mod.authors()) {
-            if (author.contains(filterRegularExpression())) {
+            if (filterRegularExpression().match(author).hasMatch()) {
                 return true;
             }
         }
@@ -182,7 +182,7 @@ void ExternalResourcesPage::retranslate()
 void ExternalResourcesPage::filterTextChanged(const QString& newContents)
 {
     m_viewFilter = newContents;
-    m_filterModel->setFilterFixedString(m_viewFilter);
+    m_filterModel->setFilterRegularExpression(m_viewFilter);
 }
 
 void ExternalResourcesPage::runningStateChanged(bool running)


### PR DESCRIPTION
For some reason, using `setFilterFixedString()` doesn't seem to update the QRegularExpression object with a new value, instead leaving it empty. It updates QRegExp just fine, so maybe that's an Qt bug? o.O

Anyway, using regex in the filter is kinda cool actually :D