### PR TITLE
Reduce code duplication in tasks, fix some bugs and add some tests

### DIFF
--- a/launcher/net/NetAction.h
+++ b/launcher/net/NetAction.h
@@ -54,6 +54,8 @@ class NetAction : public Task {
     QUrl url() { return m_url; }
     auto index() -> int { return m_index_within_job; }
 
+    void setNetwork(shared_qobject_ptr<QNetworkAccessManager> network) { m_network = network; }
+
    protected slots:
     virtual void downloadProgress(qint64 bytesReceived, qint64 bytesTotal) = 0;
     virtual void downloadError(QNetworkReply::NetworkError error) = 0;

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -71,7 +71,7 @@ void ConcurrentTask::startNext()
     if (m_aborted || m_doing.count() > m_total_max_size)
         return;
 
-    if (m_queue.isEmpty() && m_doing.isEmpty()) {
+    if (m_queue.isEmpty() && m_doing.isEmpty() && !wasSuccessful()) {
         emitSucceeded();
         return;
     }

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -37,7 +37,8 @@ void ConcurrentTask::executeTask()
 {
     m_total_size = m_queue.size();
 
-    for (int i = 0; i < m_total_max_size; i++) {
+    int num_starts = std::min(m_total_max_size, m_total_size);
+    for (int i = 0; i < num_starts; i++) {
         QMetaObject::invokeMethod(this, &ConcurrentTask::startNext, Qt::QueuedConnection);
     }
 }

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -132,11 +132,6 @@ void ConcurrentTask::subTaskStatus(const QString& msg)
 
 void ConcurrentTask::subTaskProgress(qint64 current, qint64 total)
 {
-    if (total == 0) {
-        setProgress(0, 100);
-        return;
-    }
-
     m_stepProgress = current;
     m_stepTotalProgress = total;
 }

--- a/launcher/tasks/ConcurrentTask.h
+++ b/launcher/tasks/ConcurrentTask.h
@@ -9,7 +9,9 @@ class ConcurrentTask : public Task {
     Q_OBJECT
 public:
     explicit ConcurrentTask(QObject* parent = nullptr, QString task_name = "", int max_concurrent = 6);
-    virtual ~ConcurrentTask();
+    ~ConcurrentTask() override;
+
+    bool canAbort() const override { return true; }
 
     inline auto isMultiStep() const -> bool override { return m_queue.size() > 1; };
     auto getStepProgress() const -> qint64 override;

--- a/launcher/tasks/MultipleOptionsTask.cpp
+++ b/launcher/tasks/MultipleOptionsTask.cpp
@@ -2,7 +2,7 @@
 
 #include <QDebug>
 
-MultipleOptionsTask::MultipleOptionsTask(QObject* parent, const QString& task_name) : ConcurrentTask(parent, task_name) {}
+MultipleOptionsTask::MultipleOptionsTask(QObject* parent, const QString& task_name) : SequentialTask(parent, task_name) {}
 
 void MultipleOptionsTask::startNext()
 {

--- a/launcher/tasks/MultipleOptionsTask.cpp
+++ b/launcher/tasks/MultipleOptionsTask.cpp
@@ -2,47 +2,26 @@
 
 #include <QDebug>
 
-MultipleOptionsTask::MultipleOptionsTask(QObject* parent, const QString& task_name) : SequentialTask(parent, task_name) {}
+MultipleOptionsTask::MultipleOptionsTask(QObject* parent, const QString& task_name) : ConcurrentTask(parent, task_name) {}
 
 void MultipleOptionsTask::startNext()
 {
-    Task* previous = nullptr;
-    if (m_currentIndex != -1) {
-        previous = m_queue[m_currentIndex].get();
-        disconnect(previous, 0, this, 0);
-    }
-
-    m_currentIndex++;
-    if ((previous && previous->wasSuccessful())) {
+    if (m_done.size() != m_failed.size()) {
         emitSucceeded();
         return;
     }
 
-    Task::Ptr next = m_queue[m_currentIndex];
-
-    connect(next.get(), &Task::failed, this, &MultipleOptionsTask::subTaskFailed);
-    connect(next.get(), &Task::succeeded, this, &MultipleOptionsTask::startNext);
-
-    connect(next.get(), &Task::status, this, &MultipleOptionsTask::subTaskStatus);
-    connect(next.get(), &Task::stepStatus, this, &MultipleOptionsTask::subTaskStatus);
-    
-    connect(next.get(), &Task::progress, this, &MultipleOptionsTask::subTaskProgress);
-
-    qDebug() << QString("Making attemp %1 out of %2").arg(m_currentIndex + 1).arg(m_queue.size());
-    setStatus(tr("Making attempt #%1 out of %2").arg(m_currentIndex + 1).arg(m_queue.size()));
-    setStepStatus(next->isMultiStep() ? next->getStepStatus() : next->getStatus());
-
-    next->start();
-}
-
-void MultipleOptionsTask::subTaskFailed(QString const& reason)
-{
-    qDebug() << QString("Failed attempt #%1 of %2. Reason: %3").arg(m_currentIndex + 1).arg(m_queue.size()).arg(reason);
-    if(m_currentIndex < m_queue.size() - 1) {
-        startNext();
+    if (m_queue.isEmpty()) {
+        emitFailed(tr("All attempts have failed!"));
+        qWarning() << "All attempts have failed!";
         return;
     }
 
-    qWarning() << QString("All attempts have failed!");
-    emitFailed();
+    ConcurrentTask::startNext();
+}
+
+void MultipleOptionsTask::updateState()
+{
+    setProgress(m_done.count(), m_total_size);
+    setStatus(tr("Attempting task %1 out of %2").arg(QString::number(m_doing.count() + m_done.count()), QString::number(m_total_size)));
 }

--- a/launcher/tasks/MultipleOptionsTask.h
+++ b/launcher/tasks/MultipleOptionsTask.h
@@ -1,19 +1,17 @@
 #pragma once
 
-#include "SequentialTask.h"
+#include "ConcurrentTask.h"
 
 /* This task type will attempt to do run each of it's subtasks in sequence,
  * until one of them succeeds. When that happens, the remaining tasks will not run.
  * */
-class MultipleOptionsTask : public SequentialTask
-{
+class MultipleOptionsTask : public ConcurrentTask {
     Q_OBJECT
-public:
-    explicit MultipleOptionsTask(QObject *parent = nullptr, const QString& task_name = "");
-    virtual ~MultipleOptionsTask() = default;
+   public:
+    explicit MultipleOptionsTask(QObject* parent = nullptr, const QString& task_name = "");
+    ~MultipleOptionsTask() override = default;
 
-private
-slots:
+   private slots:
     void startNext() override;
-    void subTaskFailed(const QString &msg) override;
+    void updateState() override;
 };

--- a/launcher/tasks/MultipleOptionsTask.h
+++ b/launcher/tasks/MultipleOptionsTask.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "ConcurrentTask.h"
+#include "SequentialTask.h"
 
 /* This task type will attempt to do run each of it's subtasks in sequence,
  * until one of them succeeds. When that happens, the remaining tasks will not run.
  * */
-class MultipleOptionsTask : public ConcurrentTask {
+class MultipleOptionsTask : public SequentialTask {
     Q_OBJECT
    public:
     explicit MultipleOptionsTask(QObject* parent = nullptr, const QString& task_name = "");

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -230,10 +230,11 @@ void ListModel::searchRequestFinished(QJsonDocument& doc)
 
 void ListModel::searchRequestFailed(QString reason)
 {
-    if (!jobPtr->first()->m_reply) {
+    auto failed_action = jobPtr->getFailedActions().at(0);
+    if (!failed_action->m_reply) {
         // Network error
         QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load mods."));
-    } else if (jobPtr->first()->m_reply && jobPtr->first()->m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 409) {
+    } else if (failed_action->m_reply && failed_action->m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 409) {
         // 409 Gone, notify user to update
         QMessageBox::critical(nullptr, tr("Error"),
                               //: %1 refers to the launcher itself

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -301,10 +301,11 @@ void ModpackListModel::searchRequestFinished(QJsonDocument& doc_all)
 
 void ModpackListModel::searchRequestFailed(QString reason)
 {
-    if (!jobPtr->first()->m_reply) {
+    auto failed_action = jobPtr->getFailedActions().at(0);
+    if (!failed_action->m_reply) {
         // Network error
         QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load modpacks."));
-    } else if (jobPtr->first()->m_reply && jobPtr->first()->m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 409) {
+    } else if (failed_action->m_reply && failed_action->m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() == 409) {
         // 409 Gone, notify user to update
         QMessageBox::critical(nullptr, tr("Error"),
                               //: %1 refers to the launcher itself


### PR DESCRIPTION
This fixes a couple issues with the current `ConcurrentTask`s, mostly to do with some visual glitches and a bit of unneeded log spam.

It also condenses `SequentialTask`, `MultipleOptionsTask` and `NetJob` by making them reuse the concurrent task's code.

Lastly, this adds a couple more tests to the tasks, related to their behavior when running. Tests are cool, and i'm tired of breaking things every time! :sob: 