### PR TITLE
Hide performance tab on non-Linux OSes

### DIFF
--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -349,7 +349,7 @@ void InstanceSettingsPage::loadSettings()
     ui->useDiscreteGpuCheck->setChecked(m_settings->get("UseDiscreteGpu").toBool());
 
     #if !defined(Q_OS_LINUX)
-    ui->settingsTabs->setTabVisible(ui->settingsTabs->indexOf(ui->performancePage), false);
+    ui->settingsTabs->removeTab(ui->settingsTabs->indexOf(ui->performancePage));
     #endif
 
     // Miscellanous


### PR DESCRIPTION
Fixes the performance tab showing on non-Linux operating systems.

The original code used `setTabVisible`, which only hid the performance *page*, not the item in the tab bar.