### PR TITLE
Fix adding multiple accounts in Qt6

### DIFF
--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -77,10 +77,12 @@ public:
     {
         return m_ptr;
     }
-    bool operator==(const shared_qobject_ptr<T>& other) {
+    template<typename U>
+    bool operator==(const shared_qobject_ptr<U>& other) const {
         return m_ptr == other.m_ptr;
     }
-    bool operator!=(const shared_qobject_ptr<T>& other) {
+    template<typename U>
+    bool operator!=(const shared_qobject_ptr<U>& other) const {
         return m_ptr != other.m_ptr;
     }
 

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -109,8 +109,10 @@ QStringList AccountList::profileNames() const {
 
 void AccountList::addAccount(const MinecraftAccountPtr account)
 {
-    // NOTE: Do not allow adding something that's already there
-    if(m_accounts.contains(account)) {
+    // NOTE: Do not allow adding something that's already there. We shouldn't let it continue
+    // because of the signal / slot connections after this.
+    if (m_accounts.contains(account)) {
+        qDebug() << "Tried to add account that's already on the accounts list!";
         return;
     }
 
@@ -123,6 +125,8 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
     if(profileId.size()) {
         auto existingAccount = findAccountByProfileId(profileId);
         if(existingAccount != -1) {
+            qDebug() << "Replacing old account with a new one with the same profile ID!";
+
             MinecraftAccountPtr existingAccountPtr = m_accounts[existingAccount];
             m_accounts[existingAccount] = account;
             if(m_defaultAccount == existingAccountPtr) {
@@ -138,9 +142,12 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
 
     // if we don't have this profileId yet, add the account to the end
     int row = m_accounts.count();
+    qDebug() << "Inserting account at index" << row;
+
     beginInsertRows(QModelIndex(), row, row);
     m_accounts.append(account);
     endInsertRows();
+
     onListChanged();
 }
 


### PR DESCRIPTION
Fixes #946 (also, not noted on that issue, but offline accounts also couldn't be added anymore lol)

~For some reason, `m_accounts.contains(account)` seems to always return `true` in Qt6, even when `m_accounts` does not contain `account`. I don't know why, i've checked the pointers and they are in fact different. I suspect it has something to do with the memory layout changes in QList in Qt6, but i'm not really sure what's going on here. o.O~
Edit: the problem was found to be with the implicit `const` in `operator==()` in `shared_qobject_ptr`, that changed behavior in C++17, used by Qt6.

Anyway, this check seems kind of superfluous to the one just below, since if we have an account identical to another one already on the accounts list, it will by definition have the same `profileID`, and we'll just exchange account `x` with account `x`, so nothing changes. If that's not the case, let me know :c