### PR TITLE
Fix WinGet releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: vedantmgoyal2009/winget-releaser@latest
         with:
           identifier: PolyMC.PolyMC
-          installers-regex: '\.exe$'
+          installers-regex: 'PolyMC-Windows-Setup-.+\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
I assume it stopped working, because the latest WinGet manifest only has one installer, while our release tag has two `*.exe` files.

This should strictly match the non-Legacy installer instead.