### PR TITLE
chore: downgrade to Qt 6.3.0 on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
             macosx_deployment_target: 10.14
             qt_ver: 6
             qt_host: mac
-            qt_version: '6.3.1'
+            qt_version: '6.3.0'
             qt_modules: 'qt5compat qtimageformats'
             qt_path: /Users/runner/work/PolyMC/Qt
 


### PR DESCRIPTION
seems to fix some emoji-related issues

also fixes an issue i reported in #939 


also fixes an issue where the ⚠️ emoji didn't show in FO's description

before:
<img width="417" alt="before" src="https://user-images.githubusercontent.com/83089242/182345662-770618a8-3796-4808-9e1e-04c252ccd8c6.png">

after:
<img width="400" alt="after" src="https://user-images.githubusercontent.com/83089242/182345755-77001bdc-1764-4d20-ac37-c17f598f47b5.png">

