### PR TITLE
Use QSharedPointer instead of own impl. for shared_qobject_ptr

### DIFF
--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -1,91 +1,48 @@
 #pragma once
 
+#include <QObject>
+#include <QSharedPointer>
 #include <functional>
 #include <memory>
-#include <QObject>
 
-namespace details
+namespace details {
+[[maybe_unused]] static void do_delete_later(QObject* obj)
 {
-struct DeleteQObjectLater
-{
-    void operator()(QObject *obj) const
-    {
+    if (obj)
         obj->deleteLater();
-    }
-};
 }
+struct DeleteQObjectLater {
+    void operator()(QObject* obj) const { do_delete_later(obj); }
+};
+
+}  // namespace details
+
 /**
  * A unique pointer class with unique pointer semantics intended for derivates of QObject
  * Calls deleteLater() instead of destroying the contained object immediately
  */
-template<typename T> using unique_qobject_ptr = std::unique_ptr<T, details::DeleteQObjectLater>;
+template <typename T>
+using unique_qobject_ptr = std::unique_ptr<T, details::DeleteQObjectLater>;
 
 /**
  * A shared pointer class with shared pointer semantics intended for derivates of QObject
  * Calls deleteLater() instead of destroying the contained object immediately
  */
 template <typename T>
-class shared_qobject_ptr
-{
-public:
-    shared_qobject_ptr(){}
-    shared_qobject_ptr(T * wrap)
-    {
-        reset(wrap);
-    }
-    shared_qobject_ptr(const shared_qobject_ptr<T>& other)
-    {
-        m_ptr = other.m_ptr;
-    }
-    template<typename Derived>
-    shared_qobject_ptr(const shared_qobject_ptr<Derived> &other)
-    {
-        m_ptr = other.unwrap();
-    }
+class shared_qobject_ptr : public QSharedPointer<T> {
+   public:
+    constexpr shared_qobject_ptr() : QSharedPointer<T>() {}
+    constexpr shared_qobject_ptr(T* ptr) : QSharedPointer<T>(ptr, details::do_delete_later) {}
+    constexpr shared_qobject_ptr(std::nullptr_t null_ptr) : QSharedPointer<T>(null_ptr, details::do_delete_later) {}
 
-public:
-    void reset(T * wrap)
-    {
-        using namespace std::placeholders;
-        m_ptr.reset(wrap, std::bind(&QObject::deleteLater, _1));
-    }
-    void reset(const shared_qobject_ptr<T> &other)
-    {
-        m_ptr = other.m_ptr;
-    }
-    void reset()
-    {
-        m_ptr.reset();
-    }
-    T * get() const
-    {
-        return m_ptr.get();
-    }
-    T * operator->() const
-    {
-        return m_ptr.get();
-    }
-    T & operator*() const
-    {
-        return *m_ptr.get();
-    }
-    operator bool() const
-    {
-        return m_ptr.get() != nullptr;
-    }
-    const std::shared_ptr <T> unwrap() const
-    {
-        return m_ptr;
-    }
-    template<typename U>
-    bool operator==(const shared_qobject_ptr<U>& other) const {
-        return m_ptr == other.m_ptr;
-    }
-    template<typename U>
-    bool operator!=(const shared_qobject_ptr<U>& other) const {
-        return m_ptr != other.m_ptr;
-    }
+    template <typename Derived>
+    constexpr shared_qobject_ptr(const shared_qobject_ptr<Derived>& other) : QSharedPointer<T>(other)
+    {}
 
-private:
-    std::shared_ptr <T> m_ptr;
+    void reset() { QSharedPointer<T>::reset(); }
+    void reset(const shared_qobject_ptr<T>& other)
+    {
+        shared_qobject_ptr<T> t(other);
+        this->swap(t);
+    }
 };

--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -2,27 +2,16 @@
 
 #include <QObject>
 #include <QSharedPointer>
+
 #include <functional>
 #include <memory>
-
-namespace details {
-[[maybe_unused]] static void do_delete_later(QObject* obj)
-{
-    if (obj)
-        obj->deleteLater();
-}
-struct DeleteQObjectLater {
-    void operator()(QObject* obj) const { do_delete_later(obj); }
-};
-
-}  // namespace details
 
 /**
  * A unique pointer class with unique pointer semantics intended for derivates of QObject
  * Calls deleteLater() instead of destroying the contained object immediately
  */
 template <typename T>
-using unique_qobject_ptr = std::unique_ptr<T, details::DeleteQObjectLater>;
+using unique_qobject_ptr = QScopedPointer<T, QScopedPointerDeleteLater>;
 
 /**
  * A shared pointer class with shared pointer semantics intended for derivates of QObject
@@ -32,8 +21,8 @@ template <typename T>
 class shared_qobject_ptr : public QSharedPointer<T> {
    public:
     constexpr shared_qobject_ptr() : QSharedPointer<T>() {}
-    constexpr shared_qobject_ptr(T* ptr) : QSharedPointer<T>(ptr, details::do_delete_later) {}
-    constexpr shared_qobject_ptr(std::nullptr_t null_ptr) : QSharedPointer<T>(null_ptr, details::do_delete_later) {}
+    constexpr shared_qobject_ptr(T* ptr) : QSharedPointer<T>(ptr, &QObject::deleteLater) {}
+    constexpr shared_qobject_ptr(std::nullptr_t null_ptr) : QSharedPointer<T>(null_ptr, &QObject::deleteLater) {}
 
     template <typename Derived>
     constexpr shared_qobject_ptr(const shared_qobject_ptr<Derived>& other) : QSharedPointer<T>(other)

--- a/launcher/minecraft/MinecraftUpdate.cpp
+++ b/launcher/minecraft/MinecraftUpdate.cpp
@@ -43,7 +43,7 @@ void MinecraftUpdate::executeTask()
     m_tasks.clear();
     // create folders
     {
-        m_tasks.append(std::make_shared<FoldersTask>(m_inst));
+        m_tasks.append(new FoldersTask(m_inst));
     }
 
     // add metadata update task if necessary
@@ -53,23 +53,23 @@ void MinecraftUpdate::executeTask()
         auto task = components->getCurrentTask();
         if(task)
         {
-            m_tasks.append(task.unwrap());
+            m_tasks.append(task);
         }
     }
 
     // libraries download
     {
-        m_tasks.append(std::make_shared<LibrariesTask>(m_inst));
+        m_tasks.append(new LibrariesTask(m_inst));
     }
 
     // FML libraries download and copy into the instance
     {
-        m_tasks.append(std::make_shared<FMLLibrariesTask>(m_inst));
+        m_tasks.append(new FMLLibrariesTask(m_inst));
     }
 
     // assets update
     {
-        m_tasks.append(std::make_shared<AssetUpdateTask>(m_inst));
+        m_tasks.append(new AssetUpdateTask(m_inst));
     }
 
     if(!m_preFailure.isEmpty())

--- a/launcher/minecraft/MinecraftUpdate.h
+++ b/launcher/minecraft/MinecraftUpdate.h
@@ -50,7 +50,7 @@ private:
 
 private:
     MinecraftInstance *m_inst = nullptr;
-    QList<std::shared_ptr<Task>> m_tasks;
+    QList<Task::Ptr> m_tasks;
     QString m_preFailure;
     int m_currentTask = -1;
     bool m_abort = false;

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -238,7 +238,7 @@ void MinecraftAccount::authFailed(QString reason)
 }
 
 bool MinecraftAccount::isActive() const {
-    return m_currentTask;
+    return !m_currentTask.isNull();
 }
 
 bool MinecraftAccount::shouldRefresh() const {

--- a/launcher/ui/dialogs/LoginDialog.cpp
+++ b/launcher/ui/dialogs/LoginDialog.cpp
@@ -115,5 +115,5 @@ MinecraftAccountPtr LoginDialog::newAccount(QWidget *parent, QString msg)
     {
         return dlg.m_account;
     }
-    return 0;
+    return nullptr;
 }

--- a/launcher/ui/dialogs/MSALoginDialog.cpp
+++ b/launcher/ui/dialogs/MSALoginDialog.cpp
@@ -169,5 +169,5 @@ MinecraftAccountPtr MSALoginDialog::newAccount(QWidget *parent, QString msg)
     {
         return dlg.m_account;
     }
-    return 0;
+    return nullptr;
 }

--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -103,5 +103,5 @@ MinecraftAccountPtr OfflineLoginDialog::newAccount(QWidget *parent, QString msg)
     {
         return dlg.m_account;
     }
-    return 0;
+    return nullptr;
 }


### PR DESCRIPTION
This also fixes the annoying `QCoreApplication::postEvent: Unexpected null receiver` warning that spams the logs sometimes.
CC @Scrumplex 