### PR TITLE
Make Coremods / Mods seperation more clear

### DIFF
--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -112,10 +112,6 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
     }
 }
 
-CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent)
-    : ModFolderPage(inst, mods, parent)
-{}
-
 void ModFolderPage::runningStateChanged(bool running)
 {
     ExternalResourcesPage::runningStateChanged(running);
@@ -126,27 +122,6 @@ void ModFolderPage::runningStateChanged(bool running)
 bool ModFolderPage::shouldDisplay() const
 {
     return true;
-}
-
-bool CoreModFolderPage::shouldDisplay() const
-{
-    if (ModFolderPage::shouldDisplay()) {
-        auto inst = dynamic_cast<MinecraftInstance*>(m_instance);
-        if (!inst)
-            return true;
-
-        auto version = inst->getPackProfile();
-
-        if (!version)
-            return true;
-        if (!version->getComponent("net.minecraftforge"))
-            return false;
-        if (!version->getComponent("net.minecraft"))
-            return false;
-        if (version->getComponent("net.minecraft")->getReleaseDateTime() < g_VersionFilterData.legacyCutoffDate)
-            return true;
-    }
-    return false;
 }
 
 void ModFolderPage::installMods()
@@ -251,4 +226,29 @@ void ModFolderPage::updateMods()
 
         m_model->update();
     }
+}
+
+CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent)
+    : ModFolderPage(inst, mods, parent)
+{}
+
+bool CoreModFolderPage::shouldDisplay() const
+{
+    if (ModFolderPage::shouldDisplay()) {
+        auto inst = dynamic_cast<MinecraftInstance*>(m_instance);
+        if (!inst)
+            return true;
+
+        auto version = inst->getPackProfile();
+
+        if (!version)
+            return true;
+        if (!version->getComponent("net.minecraftforge"))
+            return false;
+        if (!version->getComponent("net.minecraft"))
+            return false;
+        if (version->getComponent("net.minecraft")->getReleaseDateTime() < g_VersionFilterData.legacyCutoffDate)
+            return true;
+    }
+    return false;
 }

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -64,5 +64,11 @@ class CoreModFolderPage : public ModFolderPage {
    public:
     explicit CoreModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent = 0);
     virtual ~CoreModFolderPage() = default;
-    virtual bool shouldDisplay() const;
+
+    virtual QString displayName() const override { return tr("Core mods"); }
+    virtual QIcon icon() const override { return APPLICATION->getThemedIcon("coremods"); }
+    virtual QString id() const override { return "coremods"; }
+    virtual QString helpPage() const override { return "Core-mods"; }
+
+    virtual bool shouldDisplay() const override;
 };


### PR DESCRIPTION
This changes the name and id of the Coremods page to make it distinct from the Mods page.

Not sure if there was an issue about this somewhere, but it has been reported multiple times in our support channels.