### PR TITLE
fix: Make world safety nag popup title text match the action

### DIFF
--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -211,7 +211,7 @@ void WorldListPage::on_actionDatapacks_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion("Open World Datapacks Folder"))
+    if(!worldSafetyNagQuestion(tr("Open World Datapacks Folder")))
         return;
 
     auto fullPath = m_worlds->data(index, WorldList::FolderRole).toString();
@@ -269,7 +269,7 @@ void WorldListPage::on_actionMCEdit_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion("Open World in MCEdit"))
+    if(!worldSafetyNagQuestion(tr("Open World in MCEdit")))
         return;
 
     auto fullPath = m_worlds->data(index, WorldList::FolderRole).toString();
@@ -377,7 +377,7 @@ bool WorldListPage::worldSafetyNagQuestion(const QString &actionType)
 {
     if(!isWorldSafe(getSelectedWorld()))
     {
-        auto result = QMessageBox::question(this, tr("%1").arg(actionType), tr("Changing a world while Minecraft is running is potentially unsafe.\nDo you wish to proceed?"));
+        auto result = QMessageBox::question(this, actionType, tr("Changing a world while Minecraft is running is potentially unsafe.\nDo you wish to proceed?"));
         if(result == QMessageBox::No)
         {
             return false;
@@ -395,7 +395,7 @@ void WorldListPage::on_actionCopy_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion("Copy World"))
+    if(!worldSafetyNagQuestion(tr("Copy World")))
         return;
 
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
@@ -417,7 +417,7 @@ void WorldListPage::on_actionRename_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion("Rename World"))
+    if(!worldSafetyNagQuestion(tr("Rename World")))
         return;
 
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -211,7 +211,7 @@ void WorldListPage::on_actionDatapacks_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion())
+    if(!worldSafetyNagQuestion("Open World Datapacks Folder"))
         return;
 
     auto fullPath = m_worlds->data(index, WorldList::FolderRole).toString();
@@ -269,7 +269,7 @@ void WorldListPage::on_actionMCEdit_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion())
+    if(!worldSafetyNagQuestion("Open World in MCEdit"))
         return;
 
     auto fullPath = m_worlds->data(index, WorldList::FolderRole).toString();
@@ -373,11 +373,11 @@ bool WorldListPage::isWorldSafe(QModelIndex)
     return !m_inst->isRunning();
 }
 
-bool WorldListPage::worldSafetyNagQuestion()
+bool WorldListPage::worldSafetyNagQuestion(const QString &actionType)
 {
     if(!isWorldSafe(getSelectedWorld()))
     {
-        auto result = QMessageBox::question(this, tr("Copy World"), tr("Changing a world while Minecraft is running is potentially unsafe.\nDo you wish to proceed?"));
+        auto result = QMessageBox::question(this, tr("%1").arg(actionType), tr("Changing a world while Minecraft is running is potentially unsafe.\nDo you wish to proceed?"));
         if(result == QMessageBox::No)
         {
             return false;
@@ -395,7 +395,7 @@ void WorldListPage::on_actionCopy_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion())
+    if(!worldSafetyNagQuestion("Copy World"))
         return;
 
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
@@ -417,7 +417,7 @@ void WorldListPage::on_actionRename_triggered()
         return;
     }
 
-    if(!worldSafetyNagQuestion())
+    if(!worldSafetyNagQuestion("Rename World"))
         return;
 
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -93,7 +93,7 @@ protected:
 private:
     QModelIndex getSelectedWorld();
     bool isWorldSafe(QModelIndex index);
-    bool worldSafetyNagQuestion();
+    bool worldSafetyNagQuestion(const QString &actionType);
     void mceditError();
 
 private:


### PR DESCRIPTION
Make world safety nag title text match the action being performed instead of always saying 'Copy World' regardless of the button.

Before: (after clicking Datapacks)
![image](https://user-images.githubusercontent.com/25965766/183761031-29eec643-f03c-45c3-a3da-77b4ed9967c7.png)

Before: (after clicking Datapacks)
![image](https://user-images.githubusercontent.com/25965766/183761071-900d5977-7982-4466-99b0-343f3ec6796d.png)

This is my first PR here; pretty sure I followed all of the required process steps. Please let me know if there's anything you need me to change.