### PR TITLE
Only remove orphaned metadata once on mod page opening

### DIFF
--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -63,6 +63,9 @@ void ModFolderModel::startWatching()
     if(is_watching)
         return;
 
+    // Remove orphaned metadata next time
+    m_first_folder_load = true;
+
     update();
 
     // Watch the mods folder
@@ -113,7 +116,8 @@ bool ModFolderModel::update()
     }
 
     auto index_dir = indexDir();
-    auto task = new ModFolderLoadTask(dir(), index_dir, m_is_indexed);
+    auto task = new ModFolderLoadTask(dir(), index_dir, m_is_indexed, m_first_folder_load);
+    m_first_folder_load = false;
 
     m_update = task->result();
 

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -172,6 +172,7 @@ protected:
     bool interaction_disabled = false;
     QDir m_dir;
     bool m_is_indexed;
+    bool m_first_folder_load = true;
     QMap<QString, int> modsIndex;
     QMap<int, LocalModParseTask::ResultPtr> activeTickets;
     int nextResolutionTicket = 0;

--- a/launcher/minecraft/mod/tasks/ModFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ModFolderLoadTask.h
@@ -56,7 +56,7 @@ public:
     }
 
 public:
-    ModFolderLoadTask(QDir& mods_dir, QDir& index_dir, bool is_indexed);
+    ModFolderLoadTask(QDir& mods_dir, QDir& index_dir, bool is_indexed, bool clean_orphan = false);
     void run();
 signals:
     void succeeded();
@@ -67,5 +67,6 @@ private:
 private:
     QDir& m_mods_dir, m_index_dir;
     bool m_is_indexed;
+    bool m_clean_orphan;
     ResultPtr m_result;
 };


### PR DESCRIPTION
In #1017, i accidentally introduced a bug in which the metadata for a given mod is deleted when you update it to a newer version. This shouldn't happen, since when updating the metadata is updated, so having to generate it again is a waste of effort.

So, this makes it so that orphaned metadata is only checked for on the first time the load task is ran (i.e. when opening the mods page).

sorry for dum dum :sob: 