### PR TITLE
Hide 'More news...' button if the news aren't loaded yet

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1465,6 +1465,7 @@ void MainWindow::updateNewsLabel()
     {
         newsLabel->setText(tr("Loading news..."));
         newsLabel->setEnabled(false);
+        ui->actionMoreNews->setVisible(false);
     }
     else
     {
@@ -1473,11 +1474,13 @@ void MainWindow::updateNewsLabel()
         {
             newsLabel->setText(entries[0]->title);
             newsLabel->setEnabled(true);
+            ui->actionMoreNews->setVisible(true);
         }
         else
         {
             newsLabel->setText(tr("No news available."));
             newsLabel->setEnabled(false);
+            ui->actionMoreNews->setVisible(false);
         }
     }
 }


### PR DESCRIPTION
Fixes #980

I haven't gotten around to implementing the 'Minecraft news' thingy yet, so here's just a simple fix for the crash to avoid blocking 1.4.2 ,_,