### PR TITLE
check for java installs in PATH on windows

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -177,6 +177,12 @@ QStringList addJavasFromEnv(QList<QString> javas)
     QByteArray env = qgetenv("POLYMC_JAVA_PATHS");
 #if defined(Q_OS_WIN32)
     QList<QString> javaPaths = QString::fromLocal8Bit(env).replace("\\", "/").split(QLatin1String(";"));
+    
+    QByteArray envPath = qgetenv("PATH");
+    QList<QString> javaPathsfromPath = QString::fromLocal8Bit(envPath).replace("\\", "/").split(QLatin1String(";"));
+    for (QString string : javaPathsfromPath) {
+        javaPaths.append(string + "/javaw.exe");
+    }
 #else
     QList<QString> javaPaths = QString::fromLocal8Bit(env).split(QLatin1String(":"));
 #endif

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -174,17 +174,17 @@ JavaInstallPtr JavaUtils::GetDefaultJava()
 
 QStringList addJavasFromEnv(QList<QString> javas)
 {
-    QByteArray env = qgetenv("POLYMC_JAVA_PATHS");
+    auto env = qEnvironmentVariable("POLYMC_JAVA_PATHS");
 #if defined(Q_OS_WIN32)
-    QList<QString> javaPaths = QString::fromLocal8Bit(env).replace("\\", "/").split(QLatin1String(";"));
+    QList<QString> javaPaths = env.replace("\\", "/").split(QLatin1String(";"));
     
-    QByteArray envPath = qgetenv("PATH");
-    QList<QString> javaPathsfromPath = QString::fromLocal8Bit(envPath).replace("\\", "/").split(QLatin1String(";"));
+    auto envPath = qEnvironmentVariable("PATH");
+    QList<QString> javaPathsfromPath = envPath.replace("\\", "/").split(QLatin1String(";"));
     for (QString string : javaPathsfromPath) {
         javaPaths.append(string + "/javaw.exe");
     }
 #else
-    QList<QString> javaPaths = QString::fromLocal8Bit(env).split(QLatin1String(":"));
+    QList<QString> javaPaths = env.split(QLatin1String(":"));
 #endif
     for(QString i : javaPaths)
     {


### PR DESCRIPTION
this should find java installs from scoop as well as any other installer, that registers java in the PATH environment variable.

No idea if there was an issue for this, I couldn't find one, so I guess I never made one..