### PR TITLE
Never invalidate libraries cache entries by time elapsed

### DIFF
--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -88,6 +88,9 @@ QList<NetAction::Ptr> Library::getDownloads(
             options |= Net::Download::Option::AcceptLocalFiles;
         }
 
+        // Don't add a time limit for the libraries cache entry validity
+        options |= Net::Download::Option::MakeEternal;
+
         if(sha1.size())
         {
             auto rawSha1 = QByteArray::fromHex(sha1.toLatin1());

--- a/launcher/minecraft/update/FMLLibrariesTask.cpp
+++ b/launcher/minecraft/update/FMLLibrariesTask.cpp
@@ -63,11 +63,12 @@ void FMLLibrariesTask::executeTask()
     setStatus(tr("Downloading FML libraries..."));
     auto dljob = new NetJob("FML libraries", APPLICATION->network());
     auto metacache = APPLICATION->metacache();
+    Net::Download::Options options = Net::Download::Option::MakeEternal;
     for (auto &lib : fmlLibsToProcess)
     {
         auto entry = metacache->resolveEntry("fmllibs", lib.filename);
         QString urlString = BuildConfig.FMLLIBS_BASE_URL + lib.filename;
-        dljob->addNetAction(Net::Download::makeCached(QUrl(urlString), entry));
+        dljob->addNetAction(Net::Download::makeCached(QUrl(urlString), entry, options));
     }
 
     connect(dljob, &NetJob::succeeded, this, &FMLLibrariesTask::fmllibsFinished);

--- a/launcher/net/Download.cpp
+++ b/launcher/net/Download.cpp
@@ -60,7 +60,7 @@ auto Download::makeCached(QUrl url, MetaEntryPtr entry, Options options) -> Down
     dl->m_url = url;
     dl->m_options = options;
     auto md5Node = new ChecksumValidator(QCryptographicHash::Md5);
-    auto cachedNode = new MetaCacheSink(entry, md5Node);
+    auto cachedNode = new MetaCacheSink(entry, md5Node, options.testFlag(Option::MakeEternal));
     dl->m_sink.reset(cachedNode);
     return dl;
 }

--- a/launcher/net/Download.h
+++ b/launcher/net/Download.h
@@ -49,7 +49,7 @@ class Download : public NetAction {
 
    public:
     using Ptr = shared_qobject_ptr<class Download>;
-    enum class Option { NoOptions = 0, AcceptLocalFiles = 1 };
+    enum class Option { NoOptions = 0, AcceptLocalFiles = 1, MakeEternal = 2 };
     Q_DECLARE_FLAGS(Options, Option)
 
    protected:

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -229,8 +229,13 @@ void HttpMetaCache::Load()
         foo->etag = Json::ensureString(element_obj, "etag");
         foo->local_changed_timestamp = Json::ensureDouble(element_obj, "last_changed_timestamp");
         foo->remote_changed_timestamp = Json::ensureString(element_obj, "remote_changed_timestamp");
-        foo->current_age = Json::ensureDouble(element_obj, "current_age");
-        foo->max_age = Json::ensureDouble(element_obj, "max_age");
+
+        foo->makeEternal(Json::ensureBoolean(element_obj, "eternal", false));
+        if (!foo->isEternal()) {
+            foo->current_age = Json::ensureDouble(element_obj, "current_age");
+            foo->max_age = Json::ensureDouble(element_obj, "max_age");
+        }
+
         // presumed innocent until closer examination
         foo->stale = false;
 
@@ -271,8 +276,12 @@ void HttpMetaCache::SaveNow()
             entryObj.insert("last_changed_timestamp", QJsonValue(double(entry->local_changed_timestamp)));
             if (!entry->remote_changed_timestamp.isEmpty())
                 entryObj.insert("remote_changed_timestamp", QJsonValue(entry->remote_changed_timestamp));
-            entryObj.insert("current_age", QJsonValue(double(entry->current_age)));
-            entryObj.insert("max_age", QJsonValue(double(entry->max_age)));
+            if (entry->isEternal()) {
+                entryObj.insert("eternal", true);
+            } else {
+                entryObj.insert("current_age", QJsonValue(double(entry->current_age)));
+                entryObj.insert("max_age", QJsonValue(double(entry->max_age)));
+            }
             entriesArr.append(entryObj);
         }
     }

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -64,13 +64,17 @@ class MetaEntry {
     auto getMD5Sum() -> QString { return md5sum; }
     void setMD5Sum(QString md5sum) { this->md5sum = md5sum; }
 
+    /* Whether the entry expires after some time (false) or not (true). */
+    void makeEternal(bool eternal) { is_eternal = eternal; }
+    [[nodiscard]] bool isEternal() const { return is_eternal; }
+
     auto getCurrentAge() -> qint64 { return current_age; }
     void setCurrentAge(qint64 age) { current_age = age; }
 
     auto getMaximumAge() -> qint64 { return max_age; }
     void setMaximumAge(qint64 age) { max_age = age; }
 
-    bool isExpired(qint64 offset) { return current_age >= max_age - offset; };
+    bool isExpired(qint64 offset) { return !is_eternal && (current_age >= max_age - offset); };
 
    protected:
     QString baseId;
@@ -78,10 +82,13 @@ class MetaEntry {
     QString relativePath;
     QString md5sum;
     QString etag;
+
     qint64 local_changed_timestamp = 0;
     QString remote_changed_timestamp;  // QString for now, RFC 2822 encoded time
     qint64 current_age = 0;
     qint64 max_age = 0;
+    bool is_eternal = false;
+
     bool stale = true;
 };
 

--- a/launcher/net/MetaCacheSink.h
+++ b/launcher/net/MetaCacheSink.h
@@ -42,7 +42,7 @@
 namespace Net {
 class MetaCacheSink : public FileSink {
    public:
-    MetaCacheSink(MetaEntryPtr entry, ChecksumValidator* md5sum);
+    MetaCacheSink(MetaEntryPtr entry, ChecksumValidator* md5sum, bool is_eternal = false);
     virtual ~MetaCacheSink() = default;
 
     auto hasLocalData() -> bool override;
@@ -54,5 +54,6 @@ class MetaCacheSink : public FileSink {
    private:
     MetaEntryPtr m_entry;
     ChecksumValidator* m_md5Node;
+    bool m_is_eternal;
 };
 }  // namespace Net


### PR DESCRIPTION
Fixes #1071

This allows you to mark a cached result as eternal, meaning it'll never expire as a result of being too old. It is applied to libraries and FML libs to restore the behavior prior to #920. It will, however, invalidate the cache one last time, because old entries will not have the eternal bool in the `metacache`. Is this fine? :thinking: 