### PR TITLE
Add categorized logging

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -134,19 +134,11 @@ using namespace Commandline;
     "\n"
 
 namespace {
+
+/** This is used so that we can output to the log file in addition to the CLI. */
 void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    const char *levels = "DWCFIS";
-    const QString format("%1 %2 %3\n");
-
-    qint64 msecstotal = APPLICATION->timeSinceStart();
-    qint64 seconds = msecstotal / 1000;
-    qint64 msecs = msecstotal % 1000;
-    QString foo;
-    char buf[1025] = {0};
-    ::snprintf(buf, 1024, "%5lld.%03lld", seconds, msecs);
-
-    QString out = format.arg(buf).arg(levels[type]).arg(msg);
+    QString out = qFormatLogMessage(type, context, msg);
 
     APPLICATION->logFile->write(out.toUtf8());
     APPLICATION->logFile->flush();
@@ -489,6 +481,15 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
             return;
         }
         qInstallMessageHandler(appDebugOutput);
+
+        // TODO: Set filter rules based on CLI arguments
+        qSetMessagePattern(
+                "%{time process}" " "
+                "%{if-debug}D%{endif}" "%{if-info}I%{endif}" "%{if-warning}W%{endif}" "%{if-critical}C%{endif}" "%{if-fatal}F%{endif}"
+                " " "|" " "
+                "%{if-category}[%{category}]: %{endif}"
+                "%{message}\n");
+
         qDebug() << "<> Log initialized.";
     }
 

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -294,5 +294,7 @@ public:
     bool m_liveCheck = false;
     QUrl m_zipToImport;
     std::unique_ptr<QFile> logFile;
+
+    QStringList m_custom_logging;
 };
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -14,6 +14,8 @@ set(CORE_SOURCES
     InstanceList.cpp
     InstanceTask.h
     InstanceTask.cpp
+    Log.h
+    Log.cpp
     LoggedProcess.h
     LoggedProcess.cpp
     MessageLevel.cpp

--- a/launcher/Commandline.h
+++ b/launcher/Commandline.h
@@ -136,8 +136,9 @@ public:
      * @brief define an option that takes an additional argument
      * @param name the parameter name
      * @param def the default value
+     * @param null_when_missing if false, use the default value when the option is missing, otherwise use a null QVariant
      */
-    void addOption(QString name, QVariant def = QVariant());
+    void addOption(QString name, QVariant def = QVariant(), bool null_when_missing = false);
 
     /**
      * @brief define a positional argument
@@ -207,7 +208,6 @@ private:
         otOption
     };
 
-    // Important: the common part MUST BE COMMON ON ALL THREE structs
     struct CommonDef
     {
         QString name;
@@ -216,27 +216,16 @@ private:
         QVariant def;
     };
 
-    struct OptionDef
+    struct OptionDef : CommonDef
     {
-        // common
-        QString name;
-        QString doc;
-        QString metavar;
-        QVariant def;
-        // option
-        OptionType type;
+        OptionType type {};
         QChar flag;
+        bool null_when_missing = false;
     };
 
-    struct PositionalDef
+    struct PositionalDef : CommonDef
     {
-        // common
-        QString name;
-        QString doc;
-        QString metavar;
-        QVariant def;
-        // positional
-        bool required;
+        bool required = true;
     };
 
     QHash<QString, OptionDef *> m_options;

--- a/launcher/Log.cpp
+++ b/launcher/Log.cpp
@@ -1,0 +1,2 @@
+#include "Log.h"
+

--- a/launcher/Log.cpp
+++ b/launcher/Log.cpp
@@ -1,2 +1,5 @@
 #include "Log.h"
 
+Q_LOGGING_CATEGORY(auth, "Auth")
+Q_LOGGING_CATEGORY(auth_accountlist, "Auth.AccountList")
+Q_LOGGING_CATEGORY(auth_refreshschedule, "Auth.RefreshSchedule")

--- a/launcher/Log.h
+++ b/launcher/Log.h
@@ -1,0 +1,2 @@
+#include <QLoggingCategory>
+

--- a/launcher/Log.h
+++ b/launcher/Log.h
@@ -1,2 +1,4 @@
+#pragma once
+
 #include <QLoggingCategory>
 

--- a/launcher/Log.h
+++ b/launcher/Log.h
@@ -2,3 +2,6 @@
 
 #include <QLoggingCategory>
 
+Q_DECLARE_LOGGING_CATEGORY(auth)
+Q_DECLARE_LOGGING_CATEGORY(auth_accountlist)
+Q_DECLARE_LOGGING_CATEGORY(auth_refreshschedule)

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -34,12 +34,15 @@
  */
 
 #include "AccountData.h"
+
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QDebug>
 #include <QUuid>
 #include <QRegularExpression>
+
+#include "Log.h"
 
 namespace {
 void tokenToJSONV3(QJsonObject &parent, Katabasis::Token t, const char * tokenName) {
@@ -154,7 +157,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
         auto idV = tokenObject.value("id");
         auto nameV = tokenObject.value("name");
         if(!idV.isString() || !nameV.isString()) {
-            qWarning() << "mandatory profile attributes are missing or of unexpected type";
+            qCWarning(auth) << "mandatory profile attributes are missing or of unexpected type";
             return MinecraftProfile();
         }
         out.name = nameV.toString();
@@ -164,7 +167,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
     {
         auto skinV = tokenObject.value("skin");
         if(!skinV.isObject()) {
-            qWarning() << "skin is missing";
+            qCWarning(auth) << "skin is missing";
             return MinecraftProfile();
         }
         auto skinObj = skinV.toObject();
@@ -172,7 +175,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
         auto urlV = skinObj.value("url");
         auto variantV = skinObj.value("variant");
         if(!idV.isString() || !urlV.isString() || !variantV.isString()) {
-            qWarning() << "mandatory skin attributes are missing or of unexpected type";
+            qCWarning(auth) << "mandatory skin attributes are missing or of unexpected type";
             return MinecraftProfile();
         }
         out.skin.id = idV.toString();
@@ -186,7 +189,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
             out.skin.data = QByteArray::fromBase64(dataV.toString().toLatin1());
         }
         else if (!dataV.isUndefined()) {
-            qWarning() << "skin data is something unexpected";
+            qCWarning(auth) << "skin data is something unexpected";
             return MinecraftProfile();
         }
     }
@@ -194,13 +197,13 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
     {
         auto capesV = tokenObject.value("capes");
         if(!capesV.isArray()) {
-            qWarning() << "capes is not an array!";
+            qCWarning(auth) << "capes is not an array!";
             return MinecraftProfile();
         }
         auto capesArray = capesV.toArray();
         for(auto capeV: capesArray) {
             if(!capeV.isObject()) {
-                qWarning() << "cape is not an object!";
+                qCWarning(auth) << "cape is not an object!";
                 return MinecraftProfile();
             }
             auto capeObj = capeV.toObject();
@@ -208,7 +211,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
             auto urlV = capeObj.value("url");
             auto aliasV = capeObj.value("alias");
             if(!idV.isString() || !urlV.isString() || !aliasV.isString()) {
-                qWarning() << "mandatory skin attributes are missing or of unexpected type";
+                qCWarning(auth) << "mandatory skin attributes are missing or of unexpected type";
                 return MinecraftProfile();
             }
             Cape cape;
@@ -223,7 +226,7 @@ MinecraftProfile profileFromJSONV3(const QJsonObject &parent, const char * token
                 cape.data = QByteArray::fromBase64(dataV.toString().toLatin1());
             }
             else if (!dataV.isUndefined()) {
-                qWarning() << "cape data is something unexpected";
+                qCWarning(auth) << "cape data is something unexpected";
                 return MinecraftProfile();
             }
             out.capes[cape.id] = cape;
@@ -262,7 +265,7 @@ bool entitlementFromJSONV3(const QJsonObject &parent, MinecraftEntitlement & out
         auto ownsMinecraftV = entitlementObject.value("ownsMinecraft");
         auto canPlayMinecraftV = entitlementObject.value("canPlayMinecraft");
         if(!ownsMinecraftV.isBool() || !canPlayMinecraftV.isBool()) {
-            qWarning() << "mandatory attributes are missing or of unexpected type";
+            qCWarning(auth) << "mandatory attributes are missing or of unexpected type";
             return false;
         }
         out.canPlayMinecraft = canPlayMinecraftV.toBool(false);
@@ -313,7 +316,7 @@ bool AccountData::resumeStateFromV2(QJsonObject data) {
         bool legacy = profileObject.value("legacy").toBool(false);
         if (id.isEmpty() || name.isEmpty())
         {
-            qWarning() << "Unable to load a profile" << name << "because it was missing an ID or a name.";
+            qCWarning(auth) << "Unable to load a profile" << name << "because it was missing an ID or a name.";
             continue;
         }
         if(id == currentProfile) {
@@ -342,7 +345,7 @@ bool AccountData::resumeStateFromV2(QJsonObject data) {
 bool AccountData::resumeStateFromV3(QJsonObject data) {
     auto typeV = data.value("type");
     if(!typeV.isString()) {
-        qWarning() << "Failed to parse account data: type is missing.";
+        qCWarning(auth) << "Failed to parse account data: type is missing.";
         return false;
     }
     auto typeS = typeV.toString();
@@ -353,7 +356,7 @@ bool AccountData::resumeStateFromV3(QJsonObject data) {
     } else if (typeS == "Offline") {
         type = AccountType::Offline;
     } else {
-        qWarning() << "Failed to parse account data: type is not recognized.";
+        qCWarning(auth) << "Failed to parse account data: type is not recognized.";
         return false;
     }
 

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -281,7 +281,7 @@ bool AccountData::resumeStateFromV2(QJsonObject data) {
     // The JSON object must at least have a username for it to be valid.
     if (!data.value("username").isString())
     {
-        qCritical() << "Can't load Mojang account info from JSON object. Username field is missing or of the wrong type.";
+        qCCritical(auth) << "Can't load Mojang account info from JSON object. Username field is missing or of the wrong type.";
         return false;
     }
 
@@ -292,7 +292,7 @@ bool AccountData::resumeStateFromV2(QJsonObject data) {
     QJsonArray profileArray = data.value("profiles").toArray();
     if (profileArray.size() < 1)
     {
-        qCritical() << "Can't load Mojang account with username \"" << userName << "\". No profiles found.";
+        qCCritical(auth) << "Can't load Mojang account with username \"" << userName << "\". No profiles found.";
         return false;
     }
 

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -454,7 +454,7 @@ bool AccountList::loadList()
 {
     if (m_listFilePath.isEmpty())
     {
-        qCritical() << "Can't load Mojang account list. No file path given and no default set.";
+        qCCritical(auth_accountlist) << "Can't load Mojang account list. No file path given and no default set.";
         return false;
     }
 
@@ -464,7 +464,7 @@ bool AccountList::loadList()
     // TODO: We should probably report this error to the user.
     if (!file.open(QIODevice::ReadOnly))
     {
-        qCritical() << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
+        qCCritical(auth_accountlist) << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
         return false;
     }
 
@@ -478,7 +478,7 @@ bool AccountList::loadList()
     // Fail if the JSON is invalid.
     if (parseError.error != QJsonParseError::NoError)
     {
-        qCritical() << QString("Failed to parse account list file: %1 at offset %2")
+        qCCritical(auth_accountlist) << QString("Failed to parse account list file: %1 at offset %2")
                             .arg(parseError.errorString(), QString::number(parseError.offset))
                             .toUtf8();
         return false;
@@ -487,7 +487,7 @@ bool AccountList::loadList()
     // Make sure the root is an object.
     if (!jsonDoc.isObject())
     {
-        qCritical() << "Invalid account list JSON: Root should be an array.";
+        qCCritical(auth_accountlist) << "Invalid account list JSON: Root should be an array.";
         return false;
     }
 
@@ -583,7 +583,7 @@ bool AccountList::saveList()
 {
     if (m_listFilePath.isEmpty())
     {
-        qCritical() << "Can't save Mojang account list. No file path given and no default set.";
+        qCCritical(auth_accountlist) << "Can't save Mojang account list. No file path given and no default set.";
         return false;
     }
 
@@ -633,7 +633,7 @@ bool AccountList::saveList()
     // TODO: We should probably report this error to the user.
     if (!file.open(QIODevice::WriteOnly))
     {
-        qCritical() << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
+        qCCritical(auth_accountlist) << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
         return false;
     }
 

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -506,7 +506,7 @@ bool AccountList::loadList()
         break;
         default: {
             QString newName = "accounts-old.json";
-            qWarning() << "Unknown format version when loading account list. Existing one will be renamed to" << newName;
+            qCWarning(auth_accountlist) << "Unknown format version when loading account list. Existing one will be renamed to" << newName;
             // Attempt to rename the old version.
             file.rename(newName);
             return false;
@@ -540,7 +540,7 @@ bool AccountList::loadV2(QJsonObject& root) {
         }
         else
         {
-            qWarning() << "Failed to load an account.";
+            qCWarning(auth_accountlist) << "Failed to load an account.";
         }
     }
     endResetModel();
@@ -571,7 +571,7 @@ bool AccountList::loadV3(QJsonObject& root) {
         }
         else
         {
-            qWarning() << "Failed to load an account.";
+            qCWarning(auth_accountlist) << "Failed to load an account.";
         }
     }
     endResetModel();
@@ -759,7 +759,7 @@ void AccountList::beginActivity() {
 
 void AccountList::endActivity() {
     if(m_activityCount == 0) {
-        qWarning() << m_name << " - Activity count would become below zero";
+        qCWarning(auth_accountlist) << m_name << " - Activity count would become below zero";
         return;
     }
     bool deactivating = m_activityCount == 1;

--- a/launcher/minecraft/auth/AuthRequest.cpp
+++ b/launcher/minecraft/auth/AuthRequest.cpp
@@ -42,6 +42,7 @@
 
 #include "Application.h"
 #include "AuthRequest.h"
+#include "Log.h"
 #include "katabasis/Globals.h"
 
 AuthRequest::AuthRequest(QObject *parent): QObject(parent) {
@@ -92,7 +93,7 @@ void AuthRequest::onRequestFinished() {
 }
 
 void AuthRequest::onRequestError(QNetworkReply::NetworkError error) {
-    qWarning() << "AuthRequest::onRequestError: Error" << (int)error;
+    qCWarning(auth) << "AuthRequest::onRequestError: Error" << (int)error;
     if (status_ == Idle) {
         return;
     }
@@ -102,8 +103,8 @@ void AuthRequest::onRequestError(QNetworkReply::NetworkError error) {
     errorString_ = reply_->errorString();
     httpStatus_ = reply_->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     error_ = error;
-    qWarning() << "AuthRequest::onRequestError: Error string: " << errorString_;
-    qWarning() << "AuthRequest::onRequestError: HTTP status" << httpStatus_ << reply_->attribute(QNetworkRequest::HttpReasonPhraseAttribute).toString();
+    qCWarning(auth) << "AuthRequest::onRequestError: Error string: " << errorString_;
+    qCWarning(auth) << "AuthRequest::onRequestError: HTTP status" << httpStatus_ << reply_->attribute(QNetworkRequest::HttpReasonPhraseAttribute).toString();
 
     // QTimer::singleShot(10, this, SLOT(finish()));
 }
@@ -120,7 +121,7 @@ void AuthRequest::onSslErrors(QList<QSslError> errors) {
 
 void AuthRequest::onUploadProgress(qint64 uploaded, qint64 total) {
     if (status_ == Idle) {
-        qWarning() << "AuthRequest::onUploadProgress: No pending request";
+        qCWarning(auth) << "AuthRequest::onUploadProgress: No pending request";
         return;
     }
     if (reply_ != qobject_cast<QNetworkReply *>(sender())) {
@@ -155,7 +156,7 @@ void AuthRequest::setup(const QNetworkRequest &req, QNetworkAccessManager::Opera
 void AuthRequest::finish() {
     QByteArray data;
     if (status_ == Idle) {
-        qWarning() << "AuthRequest::finish: No pending request";
+        qCWarning(auth) << "AuthRequest::finish: No pending request";
         return;
     }
     data = reply_->readAll();

--- a/launcher/minecraft/auth/AuthRequest.cpp
+++ b/launcher/minecraft/auth/AuthRequest.cpp
@@ -112,9 +112,9 @@ void AuthRequest::onRequestError(QNetworkReply::NetworkError error) {
 void AuthRequest::onSslErrors(QList<QSslError> errors) {
     int i = 1;
     for (auto error : errors) {
-        qCritical() << "LOGIN SSL Error #" << i << " : " << error.errorString();
+        qCCritical(auth) << "LOGIN SSL Error #" << i << " : " << error.errorString();
         auto cert = error.certificate();
-        qCritical() << "Certificate in question:\n" << cert.toText();
+        qCCritical(auth) << "Certificate in question:\n" << cert.toText();
         i++;
     }
 }

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -321,7 +321,7 @@ void MinecraftAccount::decrementUses()
     {
         emit changed();
         // FIXME: we now need a better way to identify accounts...
-        qWarning() << "Profile" << data.profileId() << "is no longer in use.";
+        qCWarning(auth) << "Profile" << data.profileId() << "is no longer in use.";
     }
 }
 
@@ -333,6 +333,6 @@ void MinecraftAccount::incrementUses()
     {
         emit changed();
         // FIXME: we now need a better way to identify accounts...
-        qWarning() << "Profile" << data.profileId() << "is now in use.";
+        qCWarning(auth) << "Profile" << data.profileId() << "is now in use.";
     }
 }

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -48,6 +48,8 @@
 
 #include <QPainter>
 
+#include "Log.h"
+
 #include "flows/MSA.h"
 #include "flows/Mojang.h"
 #include "flows/Offline.h"

--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -1,5 +1,6 @@
 #include "Parsers.h"
 #include "Json.h"
+#include "Log.h"
 
 #include <QJsonDocument>
 #include <QJsonArray>
@@ -74,9 +75,9 @@ bool getBool(QJsonValue value, bool & out) {
 */
 
 bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString name) {
-    qDebug() << "Parsing" << name <<":";
+    qCDebug(auth) << "Parsing" << name <<":";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
@@ -131,14 +132,14 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
         return false;
     }
     output.validity = Katabasis::Validity::Certain;
-    qDebug() << name << "is valid.";
+    qCDebug(auth) << name << "is valid.";
     return true;
 }
 
 bool parseMinecraftProfile(QByteArray & data, MinecraftProfile &output) {
-    qDebug() << "Parsing Minecraft profile...";
+    qCDebug(auth) << "Parsing Minecraft profile...";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
 
     QJsonParseError jsonError;
@@ -274,9 +275,9 @@ decoded base64 "value":
 */
 
 bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
-    qDebug() << "Parsing Minecraft profile...";
+    qCDebug(auth) << "Parsing Minecraft profile...";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
 
     QJsonParseError jsonError;
@@ -388,9 +389,9 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
 }
 
 bool parseMinecraftEntitlements(QByteArray & data, MinecraftEntitlement &output) {
-    qDebug() << "Parsing Minecraft entitlements...";
+    qCDebug(auth) << "Parsing Minecraft entitlements...";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
 
     QJsonParseError jsonError;
@@ -423,9 +424,9 @@ bool parseMinecraftEntitlements(QByteArray & data, MinecraftEntitlement &output)
 }
 
 bool parseRolloutResponse(QByteArray & data, bool& result) {
-    qDebug() << "Parsing Rollout response...";
+    qCDebug(auth) << "Parsing Rollout response...";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
 
     QJsonParseError jsonError;
@@ -454,9 +455,9 @@ bool parseRolloutResponse(QByteArray & data, bool& result) {
 
 bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
     QJsonParseError jsonError;
-    qDebug() << "Parsing Mojang response...";
+    qCDebug(auth) << "Parsing Mojang response...";
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
@@ -486,7 +487,7 @@ bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
         return false;
     }
     output.validity = Katabasis::Validity::Certain;
-    qDebug() << "Mojang response is valid.";
+    qCDebug(auth) << "Mojang response is valid.";
     return true;
 }
 

--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -82,26 +82,26 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
         return false;
     }
 
     auto obj = doc.object();
     if(!getDateTime(obj.value("IssueInstant"), output.issueInstant)) {
-        qWarning() << "User IssueInstant is not a timestamp";
+        qCWarning(auth) << "User IssueInstant is not a timestamp";
         return false;
     }
     if(!getDateTime(obj.value("NotAfter"), output.notAfter)) {
-        qWarning() << "User NotAfter is not a timestamp";
+        qCWarning(auth) << "User NotAfter is not a timestamp";
         return false;
     }
     if(!getString(obj.value("Token"), output.token)) {
-        qWarning() << "User Token is not a string";
+        qCWarning(auth) << "User Token is not a string";
         return false;
     }
     auto arrayVal = obj.value("DisplayClaims").toObject().value("xui");
     if(!arrayVal.isArray()) {
-        qWarning() << "Missing xui claims array";
+        qCWarning(auth) << "Missing xui claims array";
         return false;
     }
     bool foundUHS = false;
@@ -119,7 +119,7 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
         for(auto iter = obj.begin(); iter != obj.end(); iter++) {
             QString claim;
             if(!getString(obj.value(iter.key()), claim)) {
-                qWarning() << "display claim " << iter.key() << " is not a string...";
+                qCWarning(auth) << "display claim " << iter.key() << " is not a string...";
                 return false;
             }
             output.extra[iter.key()] = claim;
@@ -128,7 +128,7 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
         break;
     }
     if(!foundUHS) {
-        qWarning() << "Missing uhs";
+        qCWarning(auth) << "Missing uhs";
         return false;
     }
     output.validity = Katabasis::Validity::Certain;
@@ -145,18 +145,18 @@ bool parseMinecraftProfile(QByteArray & data, MinecraftProfile &output) {
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
         return false;
     }
 
     auto obj = doc.object();
     if(!getString(obj.value("id"), output.id)) {
-        qWarning() << "Minecraft profile id is not a string";
+        qCWarning(auth) << "Minecraft profile id is not a string";
         return false;
     }
 
     if(!getString(obj.value("name"), output.name)) {
-        qWarning() << "Minecraft profile name is not a string";
+        qCWarning(auth) << "Minecraft profile name is not a string";
         return false;
     }
 
@@ -283,18 +283,18 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response as JSON: " << jsonError.errorString();
         return false;
     }
 
     auto obj = Json::requireObject(doc, "mojang minecraft profile");
     if(!getString(obj.value("id"), output.id)) {
-        qWarning() << "Minecraft profile id is not a string";
+        qCWarning(auth) << "Minecraft profile id is not a string";
         return false;
     }
 
     if(!getString(obj.value("name"), output.name)) {
-        qWarning() << "Minecraft profile name is not a string";
+        qCWarning(auth) << "Minecraft profile name is not a string";
         return false;
     }
 
@@ -322,20 +322,20 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
     }
 
     if (texturePayload.isNull()) {
-        qWarning() << "No texture payload data";
+        qCWarning(auth) << "No texture payload data";
         return false;
     }
 
     doc = QJsonDocument::fromJson(texturePayload, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response as JSON: " << jsonError.errorString();
         return false;
     }
 
     obj = Json::requireObject(doc, "session texture payload");
     auto textures = obj.value("textures");
     if (!textures.isObject()) {
-        qWarning() << "No textures array in response";
+        qCWarning(auth) << "No textures array in response";
         return false;
     }
 
@@ -353,7 +353,7 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
             if (idx.key() == "SKIN") {
                 auto skin = idx->toObject();
                 if (!getString(skin.value("url"), skinOut.url)) {
-                    qWarning() << "Skin url is not a string";
+                    qCWarning(auth) << "Skin url is not a string";
                     return false;
                 }
 
@@ -367,7 +367,7 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
             else if (idx.key() == "CAPE") {
                 auto cape = idx->toObject();
                 if (!getString(cape.value("url"), capeOut.url)) {
-                    qWarning() << "Cape url is not a string";
+                    qCWarning(auth) << "Cape url is not a string";
                     return false;
                 }
 
@@ -397,7 +397,7 @@ bool parseMinecraftEntitlements(QByteArray & data, MinecraftEntitlement &output)
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
         return false;
     }
 
@@ -432,22 +432,22 @@ bool parseRolloutResponse(QByteArray & data, bool& result) {
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from https://api.minecraftservices.com/rollout/v1/msamigration as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response from https://api.minecraftservices.com/rollout/v1/msamigration as JSON: " << jsonError.errorString();
         return false;
     }
 
     auto obj = doc.object();
     QString feature;
     if(!getString(obj.value("feature"), feature)) {
-        qWarning() << "Rollout feature is not a string";
+        qCWarning(auth) << "Rollout feature is not a string";
         return false;
     }
     if(feature != "msamigration") {
-        qWarning() << "Rollout feature is not what we expected (msamigration), but is instead \"" << feature << "\"";
+        qCWarning(auth) << "Rollout feature is not what we expected (msamigration), but is instead \"" << feature << "\"";
         return false;
     }
     if(!getBool(obj.value("rollout"), result)) {
-        qWarning() << "Rollout feature is not a string";
+        qCWarning(auth) << "Rollout feature is not a string";
         return false;
     }
     return true;
@@ -461,14 +461,14 @@ bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
 #endif
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from api.minecraftservices.com/launcher/login as JSON: " << jsonError.errorString();
+        qCWarning(auth) << "Failed to parse response from api.minecraftservices.com/launcher/login as JSON: " << jsonError.errorString();
         return false;
     }
 
     auto obj = doc.object();
     double expires_in = 0;
     if(!getNumber(obj.value("expires_in"), expires_in)) {
-        qWarning() << "expires_in is not a valid number";
+        qCWarning(auth) << "expires_in is not a valid number";
         return false;
     }
     auto currentTime = QDateTime::currentDateTimeUtc();
@@ -477,13 +477,13 @@ bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
 
     QString username;
     if(!getString(obj.value("username"), username)) {
-        qWarning() << "username is not valid";
+        qCWarning(auth) << "username is not valid";
         return false;
     }
 
     // TODO: it's a JWT... validate it?
     if(!getString(obj.value("access_token"), output.token)) {
-        qWarning() << "access_token is not valid";
+        qCWarning(auth) << "access_token is not valid";
         return false;
     }
     output.validity = Katabasis::Validity::Certain;

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -26,6 +26,7 @@
 #include <QDebug>
 
 #include "Application.h"
+#include "Log.h"
 
 Yggdrasil::Yggdrasil(AccountData *data, QObject *parent)
     : AccountTask(data, parent)
@@ -177,9 +178,9 @@ void Yggdrasil::sslErrors(QList<QSslError> errors) {
 void Yggdrasil::processResponse(QJsonObject responseData) {
     // Read the response data. We need to get the client token, access token, and the selected
     // profile.
-    qDebug() << "Processing authentication response.";
+    qCDebug(auth) << "Processing authentication response.";
 
-    // qDebug() << responseData;
+    // qCDebug(auth) << responseData;
     // If we already have a client token, make sure the one the server gave us matches our
     // existing one.
     QString clientToken = responseData.value("clientToken").toString("");
@@ -197,7 +198,7 @@ void Yggdrasil::processResponse(QJsonObject responseData) {
     }
 
     // Now, we set the access token.
-    qDebug() << "Getting access token.";
+    qCDebug(auth) << "Getting access token.";
     QString accessToken = responseData.value("accessToken").toString("");
     if (accessToken.isEmpty()) {
         // Fail if the server didn't give us an access token.
@@ -233,7 +234,7 @@ void Yggdrasil::processResponse(QJsonObject responseData) {
 
     // We've made it through the minefield of possible errors. Return true to indicate that
     // we've succeeded.
-    qDebug() << "Finished reading authentication response.";
+    qCDebug(auth) << "Finished reading authentication response.";
     changeState(AccountTaskState::STATE_SUCCEEDED);
 }
 
@@ -317,13 +318,13 @@ void Yggdrasil::processReply() {
         // We were able to parse the server's response. Woo!
         // Call processError. If a subclass has overridden it then they'll handle their
         // stuff there.
-        qDebug() << "The request failed, but the server gave us an error message. Processing error.";
+        qCDebug(auth) << "The request failed, but the server gave us an error message. Processing error.";
         processError(doc.object());
     }
     else {
         // The server didn't say anything regarding the error. Give the user an unknown
         // error.
-        qDebug() << "The request failed and the server gave no error message. Unknown error.";
+        qCDebug(auth) << "The request failed and the server gave no error message. Unknown error.";
         changeState(
             AccountTaskState::STATE_FAILED_SOFT,
             tr("An unknown error occurred when trying to communicate with the authentication server: %1").arg(m_netReply->errorString())

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -168,9 +168,9 @@ void Yggdrasil::abortByTimeout() {
 void Yggdrasil::sslErrors(QList<QSslError> errors) {
     int i = 1;
     for (auto error : errors) {
-        qCritical() << "LOGIN SSL Error #" << i << " : " << error.errorString();
+        qCCritical(auth) << "LOGIN SSL Error #" << i << " : " << error.errorString();
         auto cert = error.certificate();
-        qCritical() << "Certificate in question:\n" << cert.toText();
+        qCCritical(auth) << "Certificate in question:\n" << cert.toText();
         i++;
     }
 }
@@ -305,7 +305,7 @@ void Yggdrasil::processReply() {
                 AccountTaskState::STATE_FAILED_SOFT,
                 tr("Failed to parse authentication server response JSON response: %1 at offset %2.").arg(jsonError.errorString()).arg(jsonError.offset)
             );
-            qCritical() << replyData;
+            qCCritical(auth) << replyData;
         }
         return;
     }

--- a/launcher/minecraft/auth/flows/AuthFlow.cpp
+++ b/launcher/minecraft/auth/flows/AuthFlow.cpp
@@ -6,7 +6,8 @@
 #include "AuthFlow.h"
 #include "katabasis/Globals.h"
 
-#include <Application.h>
+#include "Application.h"
+#include "Log.h"
 
 AuthFlow::AuthFlow(AccountData * data, QObject *parent) :
     AccountTask(data, parent)
@@ -37,7 +38,7 @@ void AuthFlow::nextStep() {
         return;
     }
     m_currentStep = m_steps.front();
-    qDebug() << "AuthFlow:" << m_currentStep->describe();
+    qCDebug(auth) << "AuthFlow:" << m_currentStep->describe();
     m_steps.pop_front();
     connect(m_currentStep.get(), &AuthStep::finished, this, &AuthFlow::stepFinished);
     connect(m_currentStep.get(), &AuthStep::showVerificationUriAndCode, this, &AuthFlow::showVerificationUriAndCode);

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -3,6 +3,8 @@
 #include <QNetworkRequest>
 #include <QUuid>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
@@ -26,7 +28,7 @@ void EntitlementsStep::perform() {
     AuthRequest *requestor = new AuthRequest(this);
     connect(requestor, &AuthRequest::finished, this, &EntitlementsStep::onRequestDone);
     requestor->get(request);
-    qDebug() << "Getting entitlements...";
+    qCDebug(auth) << "Getting entitlements...";
 }
 
 void EntitlementsStep::rehydrate() {
@@ -42,7 +44,7 @@ void EntitlementsStep::onRequestDone(
     requestor->deleteLater();
 
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
 
     // TODO: check presence of same entitlementsRequestId?

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -57,7 +57,7 @@ void LauncherLoginStep::onRequestDone(
     qCDebug(auth) << data;
 #endif
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Reply error:" << error;
+        qCWarning(auth) << "Reply error:" << error;
 #ifndef NDEBUG
         qCDebug(auth) << data;
 #endif
@@ -77,7 +77,7 @@ void LauncherLoginStep::onRequestDone(
     }
 
     if(!Parsers::parseMojangResponse(data, m_data->yggdrasilToken)) {
-        qWarning() << "Could not parse login_with_xbox response...";
+        qCWarning(auth) << "Could not parse login_with_xbox response...";
 #ifndef NDEBUG
         qCDebug(auth) << data;
 #endif

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -2,6 +2,8 @@
 
 #include <QNetworkRequest>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 #include "minecraft/auth/AccountTask.h"
@@ -36,7 +38,7 @@ void LauncherLoginStep::perform() {
     AuthRequest *requestor = new AuthRequest(this);
     connect(requestor, &AuthRequest::finished, this, &LauncherLoginStep::onRequestDone);
     requestor->post(request, requestBody.toUtf8());
-    qDebug() << "Getting Minecraft access token...";
+    qCDebug(auth) << "Getting Minecraft access token...";
 }
 
 void LauncherLoginStep::rehydrate() {
@@ -52,12 +54,12 @@ void LauncherLoginStep::onRequestDone(
     requestor->deleteLater();
 
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
 #ifndef NDEBUG
-        qDebug() << data;
+        qCDebug(auth) << data;
 #endif
         if (Net::isApplicationError(error)) {
             emit finished(
@@ -77,7 +79,7 @@ void LauncherLoginStep::onRequestDone(
     if(!Parsers::parseMojangResponse(data, m_data->yggdrasilToken)) {
         qWarning() << "Could not parse login_with_xbox response...";
 #ifndef NDEBUG
-        qDebug() << data;
+        qCDebug(auth) << data;
 #endif
         emit finished(
             AccountTaskState::STATE_FAILED_SOFT,

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -42,6 +42,7 @@
 #include "minecraft/auth/Parsers.h"
 
 #include "Application.h"
+#include "Log.h"
 
 using OAuth2 = Katabasis::DeviceFlow;
 using Activity = Katabasis::Activity;
@@ -119,9 +120,9 @@ void MSAStep::onOAuthActivityChanged(Katabasis::Activity activity) {
             QVariantMap extraTokens = m_oauth2->extraTokens();
 #ifndef NDEBUG
             if (!extraTokens.isEmpty()) {
-                qDebug() << "Extra tokens in response:";
+                qCDebug(auth) << "Extra tokens in response:";
                 foreach (QString key, extraTokens.keys()) {
-                    qDebug() << "\t" << key << ":" << extraTokens.value(key);
+                    qCDebug(auth) << "\t" << key << ":" << extraTokens.value(key);
                 }
             }
 #endif

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -2,6 +2,8 @@
 
 #include <QNetworkRequest>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
@@ -41,7 +43,7 @@ void MinecraftProfileStep::onRequestDone(
     requestor->deleteLater();
 
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     if (error == QNetworkReply::ContentNotFoundError) {
         // NOTE: Succeed even if we do not have a profile. This is a valid account state.

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -59,13 +59,13 @@ void MinecraftProfileStep::onRequestDone(
         return;
     }
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Error getting profile:";
-        qWarning() << " HTTP Status:        " << requestor->httpStatus_;
-        qWarning() << " Internal error no.: " << error;
-        qWarning() << " Error string:       " << requestor->errorString_;
+        qCWarning(auth) << "Error getting profile:";
+        qCWarning(auth) << " HTTP Status:        " << requestor->httpStatus_;
+        qCWarning(auth) << " Internal error no.: " << error;
+        qCWarning(auth) << " Error string:       " << requestor->errorString_;
 
-        qWarning() << " Response:";
-        qWarning() << QString::fromUtf8(data);
+        qCWarning(auth) << " Response:";
+        qCWarning(auth) << QString::fromUtf8(data);
 
         if (Net::isApplicationError(error)) {
             emit finished(

--- a/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
@@ -62,13 +62,13 @@ void MinecraftProfileStepMojang::onRequestDone(
         return;
     }
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Error getting profile:";
-        qWarning() << " HTTP Status:        " << requestor->httpStatus_;
-        qWarning() << " Internal error no.: " << error;
-        qWarning() << " Error string:       " << requestor->errorString_;
+        qCWarning(auth) << "Error getting profile:";
+        qCWarning(auth) << " HTTP Status:        " << requestor->httpStatus_;
+        qCWarning(auth) << " Internal error no.: " << error;
+        qCWarning(auth) << " Error string:       " << requestor->errorString_;
 
-        qWarning() << " Response:";
-        qWarning() << QString::fromUtf8(data);
+        qCWarning(auth) << " Response:";
+        qCWarning(auth) << QString::fromUtf8(data);
 
         if (Net::isApplicationError(error)) {
             emit finished(

--- a/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
@@ -2,6 +2,8 @@
 
 #include <QNetworkRequest>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
@@ -44,7 +46,7 @@ void MinecraftProfileStepMojang::onRequestDone(
     requestor->deleteLater();
 
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     if (error == QNetworkReply::ContentNotFoundError) {
         // NOTE: Succeed even if we do not have a profile. This is a valid account state.

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -4,6 +4,8 @@
 #include <QJsonParseError>
 #include <QJsonDocument>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
@@ -47,7 +49,7 @@ void XboxAuthorizationStep::perform() {
     AuthRequest *requestor = new AuthRequest(this);
     connect(requestor, &AuthRequest::finished, this, &XboxAuthorizationStep::onRequestDone);
     requestor->post(request, xbox_auth_data.toUtf8());
-    qDebug() << "Getting authorization token for " << m_relyingParty;
+    qCDebug(auth) << "Getting authorization token for " << m_relyingParty;
 }
 
 void XboxAuthorizationStep::onRequestDone(
@@ -59,7 +61,7 @@ void XboxAuthorizationStep::onRequestDone(
     requestor->deleteLater();
 
 #ifndef NDEBUG
-    qDebug() << data;
+    qCDebug(auth) << data;
 #endif
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -64,7 +64,7 @@ void XboxAuthorizationStep::onRequestDone(
     qCDebug(auth) << data;
 #endif
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Reply error:" << error;
+        qCWarning(auth) << "Reply error:" << error;
         if (Net::isApplicationError(error)) {
             if(!processSTSError(error, data, headers)) {
                 emit finished(
@@ -120,7 +120,7 @@ bool XboxAuthorizationStep::processSTSError(
         QJsonParseError jsonError;
         QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
         if(jsonError.error) {
-            qWarning() << "Cannot parse error XSTS response as JSON: " << jsonError.errorString();
+            qCWarning(auth) << "Cannot parse error XSTS response as JSON: " << jsonError.errorString();
             emit finished(
                 AccountTaskState::STATE_FAILED_SOFT,
                 tr("Cannot parse %1 authorization error response as JSON: %2").arg(m_authorizationKind, jsonError.errorString())

--- a/launcher/minecraft/auth/steps/XboxProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.cpp
@@ -56,7 +56,7 @@ void XboxProfileStep::onRequestDone(
     requestor->deleteLater();
 
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Reply error:" << error;
+        qCWarning(auth) << "Reply error:" << error;
 #ifndef NDEBUG
         qCDebug(auth) << data;
 #endif

--- a/launcher/minecraft/auth/steps/XboxProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.cpp
@@ -3,6 +3,7 @@
 #include <QNetworkRequest>
 #include <QUrlQuery>
 
+#include "Log.h"
 
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
@@ -43,7 +44,7 @@ void XboxProfileStep::perform() {
     AuthRequest *requestor = new AuthRequest(this);
     connect(requestor, &AuthRequest::finished, this, &XboxProfileStep::onRequestDone);
     requestor->get(request);
-    qDebug() << "Getting Xbox profile...";
+    qCDebug(auth) << "Getting Xbox profile...";
 }
 
 void XboxProfileStep::onRequestDone(
@@ -57,7 +58,7 @@ void XboxProfileStep::onRequestDone(
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
 #ifndef NDEBUG
-        qDebug() << data;
+        qCDebug(auth) << data;
 #endif
         if (Net::isApplicationError(error)) {
             emit finished(
@@ -75,7 +76,7 @@ void XboxProfileStep::onRequestDone(
     }
 
 #ifndef NDEBUG
-    qDebug() << "XBox profile: " << data;
+    qCDebug(auth) << "XBox profile: " << data;
 #endif
 
     emit finished(AccountTaskState::STATE_WORKING, tr("Got Xbox profile"));

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -55,7 +55,7 @@ void XboxUserStep::onRequestDone(
     requestor->deleteLater();
 
     if (error != QNetworkReply::NoError) {
-        qWarning() << "Reply error:" << error;
+        qCWarning(auth) << "Reply error:" << error;
         if (Net::isApplicationError(error)) {
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                 tr("XBox user authentication failed: %1").arg(requestor->errorString_)
@@ -72,7 +72,7 @@ void XboxUserStep::onRequestDone(
 
     Katabasis::Token temp;
     if(!Parsers::parseXTokenResponse(data, temp, "UToken")) {
-        qWarning() << "Could not parse user authentication response...";
+        qCWarning(auth) << "Could not parse user authentication response...";
         emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("XBox user authentication response could not be understood."));
         return;
     }

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -2,6 +2,8 @@
 
 #include <QNetworkRequest>
 
+#include "Log.h"
+
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
@@ -41,7 +43,7 @@ void XboxUserStep::perform() {
     auto *requestor = new AuthRequest(this);
     connect(requestor, &AuthRequest::finished, this, &XboxUserStep::onRequestDone);
     requestor->post(request, xbox_auth_data.toUtf8());
-    qDebug() << "First layer of XBox auth ... commencing.";
+    qCDebug(auth) << "First layer of XBox auth ... commencing.";
 }
 
 void XboxUserStep::onRequestDone(

--- a/program_info/polymc.6.scd
+++ b/program_info/polymc.6.scd
@@ -38,6 +38,19 @@ Here are the current features of PolyMC.
 *-a, --profile*=PROFILE
 	Use the account specified by PROFILE (only valid in combination with --launch).
 
+*-L, --custom-logging*=CATEGORY_LIST
+	Include / exclude certain logging categories from being shown.
+
+	Use it with no arguments (or with a 'list' argument) to show the possible
+	categories. You can use the '\*' character as a wildcard.
+
+	Examples:
+
+	'polymc -L' - Show the list of possible categories.
+
+	'polymc -L "Auth=false,Auth.\*=false"' - Disable all logging for
+	authentication.
+
 # EXIT STATUS
 
 *0*


### PR DESCRIPTION
This adds support for adding categories and subcategories to logging messages, allowing you to
1. Know more or less from the message itself from where the message came from in the code
2. Enable / Disable logging from some categories easily

Categories can be enabled / disabled via a command-line parameter. Currently, I've only categorized authentication logs, since the primary purpose of those changes to me were to be able to disable the annoying debug messages from the MS auth responses, that always get in my way when developing other stuff >:(