### PR TITLE
Fix the mod updater not working as intended

### DIFF
--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -37,7 +37,8 @@ void ConcurrentTask::executeTask()
 {
     m_total_size = m_queue.size();
 
-    int num_starts = std::min(m_total_max_size, m_total_size);
+    // Start the least amount of tasks needed, but at least one
+    int num_starts = std::max(1, std::min(m_total_max_size, m_total_size));
     for (int i = 0; i < num_starts; i++) {
         QMetaObject::invokeMethod(this, &ConcurrentTask::startNext, Qt::QueuedConnection);
     }


### PR DESCRIPTION
This allows us to emit all the necessary stuff when we're finished in the case of starting a task with no subtasks, so that we don't get stuck waiting for a finished signal that never gets emitted. In particular, this caused the mod updater to not work properly :)