### PR TITLE
Fix winget updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
         description: Type of build (Debug, Release, RelWithDebInfo, MinSizeRel)
         type: string
         default: Debug
+        required: true
     secrets:
       SPARKLE_ED25519_KEY:
         description: Private key for signing Sparkle updates

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Create winget PR
         shell: pwsh
         run: |
-          git config --global user.email action@github.com
-          git config --global user.name actions-user
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           .\wingetcreate.exe update PolyMC.PolyMC-u $Env:URL -v $Env:VERSION -t $Env:TOKEN --submit
         env:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -7,8 +7,28 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@latest
-        with:
-          identifier: PolyMC.PolyMC
-          installers-regex: 'PolyMC-Windows-Setup-.+\.exe$'
-          token: ${{ secrets.WINGET_TOKEN }}
+      - name: Get version
+        id: get_version
+        run: |
+          version=""
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]
+          then
+            version="${{ github.event.client_payload.version }}"
+          else
+            version="${{ github.event.inputs.version }}"
+          fi
+          if [[ $version == v* ]]; then
+            version="${version:1}"
+          fi
+          echo "::set-output name=version::$version"
+      - name: Create winget PR
+        shell: pwsh
+        run: |
+          git config --global user.email action@github.com
+          git config --global user.name actions-user
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update PolyMC.PolyMC-u $Env:URL -v $Env:VERSION -t $Env:TOKEN --submit
+        env:
+          TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+          URL: ${{ format('https://github.com/PolyMC/PolyMC/releases/download/v{0}/dolt-windows-amd64.msi', steps.get_version.outputs.version) }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -31,4 +31,4 @@ jobs:
         env:
           TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
           VERSION: ${{ steps.get_version.outputs.version }}
-          URL: ${{ format('https://github.com/PolyMC/PolyMC/releases/download/v{0}/dolt-windows-amd64.msi', steps.get_version.outputs.version) }}
+          URL: ${{ format('https://github.com/PolyMC/PolyMC/releases/download/v{0}/PolyMC-Windows-Setup-{0}.exe', steps.get_version.outputs.version) }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -27,6 +27,7 @@ jobs:
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           .\wingetcreate.exe update PolyMC.PolyMC-u $Env:URL -v $Env:VERSION -t $Env:TOKEN --submit
         env:
-          TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
+          TOKEN: ${{ secrets.WINGET_TOKEN }}
           VERSION: ${{ steps.get_version.outputs.version }}
           URL: ${{ format('https://github.com/PolyMC/PolyMC/releases/download/v{0}/PolyMC-Windows-Setup-{0}.exe', steps.get_version.outputs.version) }}
+          


### PR DESCRIPTION
It appears the `winget` package updater has never worked for us. So, I've refactored the workflow so that it will (hopefully) work. 

I think there might be an issue with the YamlCreate.ps1 the previous action used. As a result, we're now running [`wingetcreate`](https://github.com/microsoft/winget-create), so hopefully we're good.

I've already PRed over 1.4.2 (microsoft/winget-pkgs#79165), but we should be good from now on.