### PR TITLE
Emit correct signals on NetJob abort

### DIFF
--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -95,6 +95,11 @@ auto NetJob::abort() -> bool
         fullyAborted &= part->abort();
     }
 
+    if (fullyAborted)
+        emitAborted();
+    else
+        emitFailed(tr("Failed to abort all tasks in the NetJob!"));
+
     return fullyAborted;
 }
 


### PR DESCRIPTION
Fixes #1121

I made yet another oopsie in #966

It would be cool if we could have all aborts do it automatically, considering the amount of times we forget it, but idk how to do it without making changes to all tasks :c