### PR TITLE
Use std::filesystem in some filesystem utils

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             qt_ver: 6
 
           - os: macos-12
-            macosx_deployment_target: 10.14
+            macosx_deployment_target: 10.15
             qt_ver: 6
             qt_host: mac
             qt_version: '6.3.0'

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -280,8 +280,7 @@ QString DirNameFromString(QString string, QString inDir)
         if (num == 0) {
             dirName = baseName;
         } else {
-            dirName = baseName + QString::number(num);
-            ;
+            dirName = baseName + "(" + QString::number(num) + ")";
         }
 
         // If it's over 9000

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -61,6 +61,22 @@
 
 #include <filesystem>
 
+#if defined Q_OS_WIN32
+
+std::wstring toStdString(QString s)
+{
+    return s.toStdWString();
+}
+
+#else
+
+std::string toStdString(QString s)
+{
+    return s.toStdString();
+}
+
+#endif
+
 namespace FS {
 
 void ensureExists(const QDir& dir)
@@ -166,7 +182,7 @@ bool copy::operator()(const QString& offset)
         auto dst_path = PathCombine(dst, relative_path);
         ensureFilePathExists(dst_path);
 
-        std::filesystem::copy(src_path.toStdString(), dst_path.toStdString(), opt, err);
+        std::filesystem::copy(toStdString(src_path), toStdString(dst_path), opt, err);
         if (err) {
             qWarning() << "Failed to copy files:" << QString::fromStdString(err.message());
             qDebug() << "Source file:" << src_path;
@@ -181,7 +197,7 @@ bool deletePath(QString path)
 {
     std::error_code err;
 
-    std::filesystem::remove_all(path.toStdString(), err);
+    std::filesystem::remove_all(toStdString(path), err);
 
     if (err) {
         qWarning() << "Failed to remove files:" << QString::fromStdString(err.message());
@@ -368,7 +384,7 @@ bool overrideFolder(QString overwritten_path, QString override_path)
     std::error_code err;
     std::filesystem::copy_options opt = copy_opts::recursive | copy_opts::overwrite_existing;
 
-    std::filesystem::copy(override_path.toStdString(), overwritten_path.toStdString(), opt, err);
+    std::filesystem::copy(toStdString(override_path), toStdString(overwritten_path), opt, err);
 
     if (err) {
         qCritical() << QString("Failed to apply override from %1 to %2").arg(override_path, overwritten_path);

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -300,50 +300,6 @@ bool checkProblemticPathJava(QDir folder)
     return pathfoldername.contains("!", Qt::CaseInsensitive);
 }
 
-// Win32 crap
-#ifdef Q_OS_WIN
-
-bool called_coinit = false;
-
-HRESULT CreateLink(LPCCH linkPath, LPCWSTR targetPath, LPCWSTR args)
-{
-    HRESULT hres;
-
-    if (!called_coinit) {
-        hres = CoInitialize(NULL);
-        called_coinit = true;
-
-        if (!SUCCEEDED(hres)) {
-            qWarning("Failed to initialize COM. Error 0x%08lX", hres);
-            return hres;
-        }
-    }
-
-    IShellLink* link;
-    hres = CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, (LPVOID*)&link);
-
-    if (SUCCEEDED(hres)) {
-        IPersistFile* persistFile;
-
-        link->SetPath(targetPath);
-        link->SetArguments(args);
-
-        hres = link->QueryInterface(IID_IPersistFile, (LPVOID*)&persistFile);
-        if (SUCCEEDED(hres)) {
-            WCHAR wstr[MAX_PATH];
-
-            MultiByteToWideChar(CP_ACP, 0, linkPath, -1, wstr, MAX_PATH);
-
-            hres = persistFile->Save(wstr, TRUE);
-            persistFile->Release();
-        }
-        link->Release();
-    }
-    return hres;
-}
-
-#endif
-
 QString getDesktopDir()
 {
     return QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);

--- a/tests/FileSystem_test.cpp
+++ b/tests/FileSystem_test.cpp
@@ -4,6 +4,8 @@
 
 #include <FileSystem.h>
 
+#include <pathmatcher/RegexpMatcher.h>
+
 class FileSystemTest : public QObject
 {
     Q_OBJECT
@@ -98,6 +100,40 @@ slots:
                 qDebug() << entry;
             }
             QVERIFY(target_dir.entryList().contains("pack.mcmeta"));
+            QVERIFY(target_dir.entryList().contains("assets"));
+        };
+
+        // first try variant without trailing /
+        QVERIFY(!folder.endsWith('/'));
+        f();
+
+        // then variant with trailing /
+        folder.append('/');
+        QVERIFY(folder.endsWith('/'));
+        f();
+    }
+
+    void test_copy_with_blacklist()
+    {
+        QString folder = QFINDTESTDATA("testdata/FileSystem/test_folder");
+        auto f = [&folder]()
+        {
+            QTemporaryDir tempDir;
+            tempDir.setAutoRemove(true);
+            qDebug() << "From:" << folder << "To:" << tempDir.path();
+
+            QDir target_dir(FS::PathCombine(tempDir.path(), "test_folder"));
+            qDebug() << tempDir.path();
+            qDebug() << target_dir.path();
+            FS::copy c(folder, target_dir.path());
+            c.blacklist(new RegexpMatcher("[.]?mcmeta"));
+            c();
+
+            for(auto entry: target_dir.entryList())
+            {
+                qDebug() << entry;
+            }
+            QVERIFY(!target_dir.entryList().contains("pack.mcmeta"));
             QVERIFY(target_dir.entryList().contains("assets"));
         };
 


### PR DESCRIPTION
This simplifies some code in `FileSystem.cpp` by using some nice methods from the stdlib that aren't available in Qt. Unfortunately, this has the side effect of requiring macOS 10.15 or later.

Other changes made:
- Added a test case for file copy with blacklist
- Remove some Windows dead code
- Replace the renaming schema in case of duplicate names. Previously, it would append just a number to the end of the name, so you'd have `blah`, `blah1`, `blah2`, etc. Now, it's in the form `blah`, `blah(1)`, `blah(2)`, etc. This makes it more similar to other software.