### PR TITLE
Fix crash and memory leak because of Resources

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -706,7 +706,7 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
         {
             out << QString("%1:").arg(label);
             auto modList = model.allMods();
-            std::sort(modList.begin(), modList.end(), [](Mod::Ptr a, Mod::Ptr b) {
+            std::sort(modList.begin(), modList.end(), [](auto a, auto b) {
                 auto aName = a->fileinfo().completeBaseName();
                 auto bName = b->fileinfo().completeBaseName();
                 return aName.localeAwareCompare(bName) < 0;

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -234,7 +234,7 @@ auto ModFolderModel::allMods() -> QList<Mod*>
 {
     QList<Mod*> mods;
 
-    for (auto& res : m_resources) {
+    for (auto& res : qAsConst(m_resources)) {
         mods.append(static_cast<Mod*>(res.get()));
     }
 

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -251,7 +251,7 @@ bool ResourceFolderModel::update()
     return true;
 }
 
-void ResourceFolderModel::resolveResource(Resource::Ptr res)
+void ResourceFolderModel::resolveResource(Resource* res)
 {
     if (!res->shouldResolve()) {
         return;

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -68,7 +68,7 @@ class ResourceFolderModel : public QAbstractListModel {
     virtual bool update();
 
     /** Creates a new parse task, if needed, for 'res' and start it.*/
-    virtual void resolveResource(Resource::Ptr res);
+    virtual void resolveResource(Resource* res);
 
     [[nodiscard]] size_t size() const { return m_resources.size(); };
     [[nodiscard]] bool empty() const { return size() == 0; }
@@ -265,7 +265,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             }
 
             m_resources[row].reset(new_resource);
-            resolveResource(m_resources.at(row));
+            resolveResource(m_resources[row].get());
             emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
         }
     }
@@ -313,7 +313,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             for (auto& added : added_set) {
                 auto res = new_resources[added];
                 m_resources.append(res);
-                resolveResource(res);
+                resolveResource(m_resources.last().get());
             }
 
             endInsertRows();

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -247,7 +247,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             auto row = row_it.value();
 
             auto& new_resource = new_resources[kept];
-            auto const& current_resource = m_resources[row];
+            auto const& current_resource = m_resources.at(row);
 
             if (new_resource->dateTimeChanged() == current_resource->dateTimeChanged()) {
                 // no significant change, ignore...
@@ -265,7 +265,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             }
 
             m_resources[row].reset(new_resource);
-            resolveResource(m_resources[row].get());
+            resolveResource(m_resources.at(row).get());
             emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
         }
     }
@@ -324,7 +324,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
     {
         m_resources_index.clear();
         int idx = 0;
-        for (auto const& mod : m_resources) {
+        for (auto const& mod : qAsConst(m_resources)) {
             m_resources_index[mod->internal_id()] = idx;
             idx++;
         }

--- a/launcher/minecraft/mod/tasks/BasicFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/BasicFolderLoadTask.h
@@ -3,6 +3,7 @@
 #include <QDir>
 #include <QMap>
 #include <QObject>
+#include <QThread>
 
 #include <memory>
 
@@ -23,14 +24,14 @@ class BasicFolderLoadTask : public Task {
     [[nodiscard]] ResultPtr result() const { return m_result; }
 
    public:
-    BasicFolderLoadTask(QDir dir) : Task(nullptr, false), m_dir(dir), m_result(new Result)
+    BasicFolderLoadTask(QDir dir) : Task(nullptr, false), m_dir(dir), m_result(new Result), m_thread_to_spawn_into(thread())
     {
         m_create_func = [](QFileInfo const& entry) -> Resource* {
                 return new Resource(entry);
             };
     }
     BasicFolderLoadTask(QDir dir, std::function<Resource*(QFileInfo const&)> create_function)
-        : Task(nullptr, false), m_dir(dir), m_result(new Result), m_create_func(std::move(create_function))
+        : Task(nullptr, false), m_dir(dir), m_result(new Result), m_create_func(std::move(create_function)), m_thread_to_spawn_into(thread())
     {}
 
     [[nodiscard]] bool canAbort() const override { return true; }
@@ -42,9 +43,13 @@ class BasicFolderLoadTask : public Task {
 
     void executeTask() override
     {
+        if (thread() != m_thread_to_spawn_into)
+            connect(this, &Task::finished, this->thread(), &QThread::quit);
+
         m_dir.refresh();
         for (auto entry : m_dir.entryInfoList()) {
             auto resource = m_create_func(entry);
+            resource->moveToThread(m_thread_to_spawn_into);
             m_result->resources.insert(resource->internal_id(), resource);
         }
 
@@ -61,4 +66,7 @@ private:
     std::atomic<bool> m_aborted = false;
 
     std::function<Resource*(QFileInfo const&)> m_create_func;
+
+    /** This is the thread in which we should put new mod objects */
+    QThread* m_thread_to_spawn_into;
 };

--- a/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
+++ b/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
@@ -57,6 +57,8 @@ void ModFolderLoadTask::executeTask()
         if (mod->enabled()) {
             if (m_result->mods.contains(mod->internal_id())) {
                 m_result->mods[mod->internal_id()]->setStatus(ModStatus::Installed);
+                // Delete the object we just created, since a valid one is already in the mods list.
+                delete mod;
             }
             else {
                 m_result->mods[mod->internal_id()] = mod;

--- a/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
+++ b/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
@@ -99,7 +99,7 @@ void ModFolderLoadTask::executeTask()
     // Remove orphan metadata to prevent issues
     // See https://github.com/PolyMC/PolyMC/issues/996
     if (m_clean_orphan) {
-        QMutableMapIterator<QString, Mod::Ptr> iter(m_result->mods);
+        QMutableMapIterator iter(m_result->mods);
         while (iter.hasNext()) {
             auto mod = iter.next().value();
             if (mod->status() == ModStatus::NotInstalled) {

--- a/launcher/minecraft/mod/tasks/ModFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ModFolderLoadTask.h
@@ -79,4 +79,7 @@ private:
     ResultPtr m_result;
 
     std::atomic<bool> m_aborted = false;
+
+    /** This is the thread in which we should put new mod objects */
+    QThread* m_thread_to_spawn_into;
 };


### PR DESCRIPTION
Fixes #1136, and a memory leak while we're at it! =D

The problem was primarily to do with thread affinity issues when creating new resources in worker threads, and also because of creating temporary shared pointers to raw pointers when creating parse tasks, and also when trying to print the mod list :skull: 