### PR TITLE
Improve language model

### DIFF
--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -86,6 +86,10 @@ struct Language
         else {
             result = locale.nativeLanguageName();
         }
+
+        if (result.isEmpty()) {
+            result = key;
+        }
         return result;
     }
 

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -398,7 +398,7 @@ void TranslationsModel::reloadLocalFiles()
                 return false;
             }
         }
-        return a.key < b.key;
+        return a.languageName().toLower() < b.languageName().toLower();
     });
     endInsertRows();
 }


### PR DESCRIPTION
Recently, the language `tok` was added on Weblate. Seems like Qt does not know what the native name is, which is why we need a fallback to avoid an empty string.

Also, sort languages by their display name, instead of their key.