### PR TITLE
Update capabilities before first-run wizard

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -859,12 +859,13 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         qDebug() << "<> Application theme set.";
     }
 
+    updateCapabilities();
+
     if(createSetupWizard())
     {
         return;
     }
 
-    updateCapabilities();
     performMainStartupAction();
 }
 


### PR DESCRIPTION
Closes #1160 

On first run, the condition for the wizard would return, before running updateCapabilities(). This moves that call up, as its only dependency is the settings system.
