### PR TITLE
Add clear metadata action

### DIFF
--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -162,6 +162,18 @@ auto HttpMetaCache::evictEntry(MetaEntryPtr entry) -> bool
     return true;
 }
 
+void HttpMetaCache::evictAll()
+{
+    for (QString& base : m_entries.keys()) {
+        EntryMap& map = m_entries[base];
+        qDebug() << "Evicting base" << base;
+        for (MetaEntryPtr entry : map.entry_list) {
+            if (!evictEntry(entry))
+                qWarning() << "Unexpected missing cache entry" << entry->basePath;
+        }
+    }
+}
+
 auto HttpMetaCache::staleEntry(QString base, QString resource_path) -> MetaEntryPtr
 {
     auto foo = new MetaEntry();

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -113,6 +113,7 @@ class HttpMetaCache : public QObject {
 
     // evict selected entry from cache
     auto evictEntry(MetaEntryPtr entry) -> bool;
+    void evictAll();
 
     void addBase(QString base, QString base_root);
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -258,6 +258,7 @@ public:
 
     QMenu * helpMenu = nullptr;
     TranslatedToolButton helpMenuButton;
+    TranslatedAction actionClearMetadata;
     TranslatedAction actionReportBug;
     TranslatedAction actionDISCORD;
     TranslatedAction actionMATRIX;
@@ -346,6 +347,13 @@ public:
         actionUndoTrashInstance->setEnabled(APPLICATION->instances()->trashedSomething());
         actionUndoTrashInstance->setShortcut(QKeySequence("Ctrl+Z"));
         all_actions.append(&actionUndoTrashInstance);
+
+        actionClearMetadata = TranslatedAction(MainWindow);
+        actionClearMetadata->setObjectName(QStringLiteral("actionClearMetadata"));
+        actionClearMetadata->setIcon(APPLICATION->getThemedIcon("refresh"));
+        actionClearMetadata.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Clear Metadata Cache"));
+        actionClearMetadata.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Clear cached metadata"));
+        all_actions.append(&actionClearMetadata);
 
         if (!BuildConfig.BUG_TRACKER_URL.isEmpty()) {
             actionReportBug = TranslatedAction(MainWindow);
@@ -445,6 +453,8 @@ public:
         helpMenu = new QMenu(MainWindow);
         helpMenu->setToolTipsVisible(true);
 
+        helpMenu->addAction(actionClearMetadata);
+
         if (!BuildConfig.BUG_TRACKER_URL.isEmpty()) {
             helpMenu->addAction(actionReportBug);
         }
@@ -537,6 +547,8 @@ public:
 
         helpMenu = menuBar->addMenu(tr("&Help"));
         helpMenu->setSeparatorsCollapsible(false);
+        helpMenu->addAction(actionClearMetadata);
+        helpMenu->addSeparator();
         helpMenu->addAction(actionAbout);
         helpMenu->addAction(actionOpenWiki);
         helpMenu->addAction(actionNewsMenuBar);
@@ -1978,6 +1990,11 @@ void MainWindow::on_actionManageAccounts_triggered()
 void MainWindow::on_actionReportBug_triggered()
 {
     DesktopServices::openUrl(QUrl(BuildConfig.BUG_TRACKER_URL));
+}
+
+void MainWindow::on_actionClearMetadata_triggered()
+{
+    APPLICATION->metacache()->evictAll();
 }
 
 void MainWindow::on_actionOpenWiki_triggered()

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -130,6 +130,8 @@ private slots:
 
     void on_actionReportBug_triggered();
 
+    void on_actionClearMetadata_triggered();
+
     void on_actionOpenWiki_triggered();
 
     void on_actionMoreNews_triggered();


### PR DESCRIPTION
This should help users if they migrated from another launcher and moved their metacache over. This is also helpful if there has been a recent change in our meta and users don't want to wait until their cached version expires.