### PR TITLE
feat: remove useless actions from instance toolbar

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -229,19 +229,13 @@ public:
     TranslatedAction actionRenameInstance;
     TranslatedAction actionChangeInstGroup;
     TranslatedAction actionChangeInstIcon;
-    TranslatedAction actionEditInstNotes;
     TranslatedAction actionEditInstance;
-    TranslatedAction actionWorlds;
-    TranslatedAction actionMods;
     TranslatedAction actionViewSelectedInstFolder;
-    TranslatedAction actionViewSelectedMCFolder;
     TranslatedAction actionDeleteInstance;
-    TranslatedAction actionConfig_Folder;
     TranslatedAction actionCAT;
     TranslatedAction actionCopyInstance;
     TranslatedAction actionLaunchInstanceOffline;
     TranslatedAction actionLaunchInstanceDemo;
-    TranslatedAction actionScreenshots;
     TranslatedAction actionExportInstance;
     QVector<TranslatedAction *> all_actions;
 
@@ -505,16 +499,8 @@ public:
         fileMenu->addAction(actionCloseWindow);
         fileMenu->addSeparator();
         fileMenu->addAction(actionEditInstance);
-        fileMenu->addAction(actionEditInstNotes);
-        fileMenu->addAction(actionMods);
-        fileMenu->addAction(actionWorlds);
-        fileMenu->addAction(actionScreenshots);
         fileMenu->addAction(actionChangeInstGroup);
-        fileMenu->addSeparator();
-        fileMenu->addAction(actionViewSelectedMCFolder);
-        fileMenu->addAction(actionConfig_Folder);
         fileMenu->addAction(actionViewSelectedInstFolder);
-        fileMenu->addSeparator();
         fileMenu->addAction(actionExportInstance);
         fileMenu->addAction(actionDeleteInstance);
         fileMenu->addAction(actionCopyInstance);
@@ -586,13 +572,7 @@ public:
     void setInstanceActionsEnabled(bool enabled)
     {
         actionEditInstance->setEnabled(enabled);
-        actionEditInstNotes->setEnabled(enabled);
-        actionMods->setEnabled(enabled);
-        actionWorlds->setEnabled(enabled);
-        actionScreenshots->setEnabled(enabled);
         actionChangeInstGroup->setEnabled(enabled);
-        actionViewSelectedMCFolder->setEnabled(enabled);
-        actionConfig_Folder->setEnabled(enabled);
         actionViewSelectedInstFolder->setEnabled(enabled);
         actionExportInstance->setEnabled(enabled);
         actionDeleteInstance->setEnabled(enabled);
@@ -687,34 +667,10 @@ public:
 
         actionEditInstance = TranslatedAction(MainWindow);
         actionEditInstance->setObjectName(QStringLiteral("actionEditInstance"));
-        actionEditInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Edit Inst&ance..."));
+        actionEditInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Edit..."));
         actionEditInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Change the instance settings, mods and versions."));
         actionEditInstance->setShortcut(QKeySequence(tr("Ctrl+I")));
         all_actions.append(&actionEditInstance);
-
-        actionEditInstNotes = TranslatedAction(MainWindow);
-        actionEditInstNotes->setObjectName(QStringLiteral("actionEditInstNotes"));
-        actionEditInstNotes.setTextId(QT_TRANSLATE_NOOP("MainWindow", "E&dit Notes..."));
-        actionEditInstNotes.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Edit the notes for the selected instance."));
-        all_actions.append(&actionEditInstNotes);
-
-        actionMods = TranslatedAction(MainWindow);
-        actionMods->setObjectName(QStringLiteral("actionMods"));
-        actionMods.setTextId(QT_TRANSLATE_NOOP("MainWindow", "View &Mods"));
-        actionMods.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "View the mods of this instance."));
-        all_actions.append(&actionMods);
-
-        actionWorlds = TranslatedAction(MainWindow);
-        actionWorlds->setObjectName(QStringLiteral("actionWorlds"));
-        actionWorlds.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&View Worlds"));
-        actionWorlds.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "View the worlds of this instance."));
-        all_actions.append(&actionWorlds);
-
-        actionScreenshots = TranslatedAction(MainWindow);
-        actionScreenshots->setObjectName(QStringLiteral("actionScreenshots"));
-        actionScreenshots.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Manage &Screenshots"));
-        actionScreenshots.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "View and upload screenshots for this instance."));
-        all_actions.append(&actionScreenshots);
 
         actionChangeInstGroup = TranslatedAction(MainWindow);
         actionChangeInstGroup->setObjectName(QStringLiteral("actionChangeInstGroup"));
@@ -723,38 +679,22 @@ public:
         actionChangeInstGroup->setShortcut(QKeySequence(tr("Ctrl+G")));
         all_actions.append(&actionChangeInstGroup);
 
-        actionViewSelectedMCFolder = TranslatedAction(MainWindow);
-        actionViewSelectedMCFolder->setObjectName(QStringLiteral("actionViewSelectedMCFolder"));
-        actionViewSelectedMCFolder.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Minec&raft Folder"));
-        actionViewSelectedMCFolder.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open the selected instance's Minecraft folder in a file browser."));
-        actionViewSelectedMCFolder->setShortcut(QKeySequence(tr("Ctrl+M")));
-        all_actions.append(&actionViewSelectedMCFolder);
-
-        actionConfig_Folder = TranslatedAction(MainWindow);
-        actionConfig_Folder->setObjectName(QStringLiteral("actionConfig_Folder"));
-        actionConfig_Folder.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Confi&g Folder"));
-        actionConfig_Folder.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open the instance's config folder."));
-        // Qt on macOS is "smart" and will eat up this action when added to the menu bar because it starts with the word "config"...
-        // Docs: https://doc.qt.io/qt-5/qmenubar.html#qmenubar-as-a-global-menu-bar
-        actionConfig_Folder->setMenuRole(QAction::NoRole);
-        all_actions.append(&actionConfig_Folder);
-
         actionViewSelectedInstFolder = TranslatedAction(MainWindow);
         actionViewSelectedInstFolder->setObjectName(QStringLiteral("actionViewSelectedInstFolder"));
-        actionViewSelectedInstFolder.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Instance Folder"));
+        actionViewSelectedInstFolder.setTextId(QT_TRANSLATE_NOOP("MainWindow", "&Folder"));
         actionViewSelectedInstFolder.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open the selected instance's root folder in a file browser."));
         all_actions.append(&actionViewSelectedInstFolder);
 
         actionExportInstance = TranslatedAction(MainWindow);
         actionExportInstance->setObjectName(QStringLiteral("actionExportInstance"));
-        actionExportInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "E&xport Instance..."));
+        actionExportInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "E&xport..."));
         actionExportInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Export the selected instance as a zip file."));
         actionExportInstance->setShortcut(QKeySequence(tr("Ctrl+E")));
         all_actions.append(&actionExportInstance);
 
         actionDeleteInstance = TranslatedAction(MainWindow);
         actionDeleteInstance->setObjectName(QStringLiteral("actionDeleteInstance"));
-        actionDeleteInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Dele&te Instance"));
+        actionDeleteInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Dele&te"));
         actionDeleteInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Delete the selected instance."));
         actionDeleteInstance->setShortcuts({QKeySequence(tr("Backspace")), QKeySequence::Delete});
         actionDeleteInstance->setAutoRepeat(false);
@@ -763,7 +703,7 @@ public:
         actionCopyInstance = TranslatedAction(MainWindow);
         actionCopyInstance->setObjectName(QStringLiteral("actionCopyInstance"));
         actionCopyInstance->setIcon(APPLICATION->getThemedIcon("copy"));
-        actionCopyInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Cop&y Instance..."));
+        actionCopyInstance.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Cop&y..."));
         actionCopyInstance.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Copy the selected instance."));
         actionCopyInstance->setShortcut(QKeySequence(tr("Ctrl+D")));
         all_actions.append(&actionCopyInstance);
@@ -797,19 +737,9 @@ public:
         instanceToolBar->addSeparator();
 
         instanceToolBar->addAction(actionEditInstance);
-        instanceToolBar->addAction(actionEditInstNotes);
-        instanceToolBar->addAction(actionMods);
-        instanceToolBar->addAction(actionWorlds);
-        instanceToolBar->addAction(actionScreenshots);
         instanceToolBar->addAction(actionChangeInstGroup);
 
-        instanceToolBar->addSeparator();
-
-        instanceToolBar->addAction(actionViewSelectedMCFolder);
-        instanceToolBar->addAction(actionConfig_Folder);
         instanceToolBar->addAction(actionViewSelectedInstFolder);
-
-        instanceToolBar->addSeparator();
 
         instanceToolBar->addAction(actionExportInstance);
         instanceToolBar->addAction(actionDeleteInstance);
@@ -1890,15 +1820,6 @@ void MainWindow::on_actionViewCentralModsFolder_triggered()
     DesktopServices::openDirectory(APPLICATION->settings()->get("CentralModsDir").toString(), true);
 }
 
-void MainWindow::on_actionConfig_Folder_triggered()
-{
-    if (m_selectedInstance)
-    {
-        QString str = m_selectedInstance->instanceConfigFolder();
-        DesktopServices::openDirectory(QDir(str).absolutePath());
-    }
-}
-
 void MainWindow::checkForUpdates()
 {
     if(BuildConfig.UPDATER_ENABLED)
@@ -1932,29 +1853,9 @@ void MainWindow::globalSettingsClosed()
     update();
 }
 
-void MainWindow::on_actionEditInstNotes_triggered()
-{
-    APPLICATION->showInstanceWindow(m_selectedInstance, "notes");
-}
-
-void MainWindow::on_actionWorlds_triggered()
-{
-    APPLICATION->showInstanceWindow(m_selectedInstance, "worlds");
-}
-
-void MainWindow::on_actionMods_triggered()
-{
-    APPLICATION->showInstanceWindow(m_selectedInstance, "mods");
-}
-
 void MainWindow::on_actionEditInstance_triggered()
 {
     APPLICATION->showInstanceWindow(m_selectedInstance);
-}
-
-void MainWindow::on_actionScreenshots_triggered()
-{
-    APPLICATION->showInstanceWindow(m_selectedInstance, "screenshots");
 }
 
 void MainWindow::on_actionManageAccounts_triggered()
@@ -2041,20 +1942,6 @@ void MainWindow::on_actionViewSelectedInstFolder_triggered()
     if (m_selectedInstance)
     {
         QString str = m_selectedInstance->instanceRoot();
-        DesktopServices::openDirectory(QDir(str).absolutePath());
-    }
-}
-
-void MainWindow::on_actionViewSelectedMCFolder_triggered()
-{
-    if (m_selectedInstance)
-    {
-        QString str = m_selectedInstance->gameRoot();
-        if (!FS::ensureFilePathExists(str))
-        {
-            // TODO: report error
-            return;
-        }
         DesktopServices::openDirectory(QDir(str).absolutePath());
     }
 }

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -112,11 +112,7 @@ private slots:
 
     void on_actionViewInstanceFolder_triggered();
 
-    void on_actionConfig_Folder_triggered();
-
     void on_actionViewSelectedInstFolder_triggered();
-
-    void on_actionViewSelectedMCFolder_triggered();
 
     void refreshInstances();
 
@@ -158,14 +154,6 @@ private slots:
     }
 
     void on_actionEditInstance_triggered();
-
-    void on_actionEditInstNotes_triggered();
-
-    void on_actionMods_triggered();
-
-    void on_actionWorlds_triggered();
-
-    void on_actionScreenshots_triggered();
 
     void taskEnd();
 


### PR DESCRIPTION
Fixes https://github.com/PolyMC/PolyMC/issues/1148

removes a few redundant buttons from the instance toolbar