### PR TITLE
Remove opted out versions from the download selector when using the 'Any' filter

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -265,7 +265,9 @@ void ModPage::updateModVersions(int prev_count)
                 break;
             }
         }
-        if(valid || m_filter->versions.size() == 0)
+
+        // Only add the version if it's valid or using the 'Any' filter, but never if the version is opted out
+        if ((valid || m_filter->versions.empty()) && !optedOut(version))
             ui->versionSelectionBox->addItem(version.version, QVariant(i));
     }
     if (ui->versionSelectionBox->count() == 0 && prev_count != 0) { 

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -51,6 +51,7 @@ class ModPage : public QWidget, public BasePage {
 
     auto shouldDisplay() const -> bool override = 0;
     virtual auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool = 0;
+    virtual bool optedOut(ModPlatform::IndexedVersion& ver) const { return false; };
 
     auto apiProvider() -> ModAPI* { return api.get(); };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -67,6 +67,11 @@ auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver, QString min
     return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty();
 }
 
+bool FlameModPage::optedOut(ModPlatform::IndexedVersion& ver) const
+{
+    return ver.downloadUrl.isEmpty();
+}
+
 // I don't know why, but doing this on the parent class makes it so that
 // other mod providers start loading before being selected, at least with
 // my Qt, so we need to implement this in every derived class...

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -61,6 +61,7 @@ class FlameModPage : public ModPage {
     inline auto metaEntryBase() const -> QString override { return "FlameMods"; };
 
     auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, ModAPI::ModLoaderTypes loaders = ModAPI::Unspecified) const -> bool override;
+    bool optedOut(ModPlatform::IndexedVersion& ver) const override;
 
     auto shouldDisplay() const -> bool override;
 };


### PR DESCRIPTION
Even if the purpose of the 'Any' filter is allowing you to download any of the mod's versions, you wouldn't be able to do so anyways when the mod is opted out. Worse yet, if you try to download the mod, it fails to do so (because downloadUrl is null), but the metadata for it is generated, so it is shown in the mod list, and can be really confusing to users.