### PR TITLE
Add modpack update page in instance settings

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -673,6 +673,8 @@ SET(LAUNCHER_SOURCES
     ui/pages/instance/GameOptionsPage.h
     ui/pages/instance/VersionPage.cpp
     ui/pages/instance/VersionPage.h
+    ui/pages/instance/ManagedPackPage.cpp
+    ui/pages/instance/ManagedPackPage.h
     ui/pages/instance/TexturePackPage.h
     ui/pages/instance/ResourcePackPage.h
     ui/pages/instance/ShaderPackPage.h
@@ -906,6 +908,7 @@ qt_wrap_ui(LAUNCHER_UI
     ui/pages/instance/OtherLogsPage.ui
     ui/pages/instance/InstanceSettingsPage.ui
     ui/pages/instance/VersionPage.ui
+    ui/pages/instance/ManagedPackPage.ui
     ui/pages/instance/WorldListPage.ui
     ui/pages/instance/ScreenshotsPage.ui
     ui/pages/modplatform/atlauncher/AtlOptionalModDialog.ui

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -268,6 +268,7 @@ void InstanceImportTask::processFlame()
     inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);
     inst_creation_task->setGroup(m_instGroup);
+    inst_creation_task->setConfirmUpdate(shouldConfirmUpdate());
     
     connect(inst_creation_task, &Task::succeeded, this, [this, inst_creation_task] {
         setOverride(inst_creation_task->shouldOverride());
@@ -332,6 +333,7 @@ void InstanceImportTask::processModrinth()
     inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);
     inst_creation_task->setGroup(m_instGroup);
+    inst_creation_task->setConfirmUpdate(shouldConfirmUpdate());
     
     connect(inst_creation_task, &Task::succeeded, this, [this, inst_creation_task] {
         setOverride(inst_creation_task->shouldOverride());

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -5,6 +5,7 @@
 #include "ui/pages/BasePageProvider.h"
 #include "ui/pages/instance/LogPage.h"
 #include "ui/pages/instance/VersionPage.h"
+#include "ui/pages/instance/ManagedPackPage.h"
 #include "ui/pages/instance/ModFolderPage.h"
 #include "ui/pages/instance/ResourcePackPage.h"
 #include "ui/pages/instance/TexturePackPage.h"
@@ -33,6 +34,7 @@ public:
         values.append(new LogPage(inst));
         std::shared_ptr<MinecraftInstance> onesix = std::dynamic_pointer_cast<MinecraftInstance>(inst);
         values.append(new VersionPage(onesix.get()));
+        values.append(ManagedPackPage::createPage(onesix.get()));
         auto modsPage = new ModFolderPage(onesix.get(), onesix->loaderModList());
         modsPage->setFilter("%1 (*.zip *.jar *.litemod)");
         values.append(modsPage);

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -18,6 +18,29 @@ InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& ol
     return InstanceNameChange::ShouldKeep;
 }
 
+ShouldUpdate askIfShouldUpdate(QWidget *parent, QString original_version_name)
+{
+    auto info = CustomMessageBox::selectable(
+        parent, QObject::tr("Similar modpack was found!"),
+        QObject::tr("One or more of your instances are from this same modpack%1. Do you want to create a "
+           "separate instance, or update the existing one?\n\nNOTE: Make sure you made a backup of your important instance data before "
+           "updating, as worlds can be corrupted and some configuration may be lost (due to pack overrides).")
+            .arg(original_version_name),
+        QMessageBox::Information, QMessageBox::Ok | QMessageBox::Reset | QMessageBox::Abort);
+    info->setButtonText(QMessageBox::Ok, QObject::tr("Create new instance"));
+    info->setButtonText(QMessageBox::Abort, QObject::tr("Update existing instance"));
+    info->setButtonText(QMessageBox::Reset, QObject::tr("Cancel"));
+
+    info->exec();
+
+    if (info->clickedButton() == info->button(QMessageBox::Ok))
+        return ShouldUpdate::SkipUpdating;
+    if (info->clickedButton() == info->button(QMessageBox::Abort))
+        return ShouldUpdate::Update;
+    return ShouldUpdate::Cancel;
+
+}
+
 QString InstanceName::name() const
 {
     if (!m_modified_name.isEmpty())

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -6,6 +6,8 @@
 /* Helpers */
 enum class InstanceNameChange { ShouldChange, ShouldKeep };
 [[nodiscard]] InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& old_name, const QString& new_name);
+enum class ShouldUpdate { Update, SkipUpdating, Cancel };
+[[nodiscard]] ShouldUpdate askIfShouldUpdate(QWidget* parent, QString original_version_name);
 
 struct InstanceName {
    public:

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -44,6 +44,9 @@ class InstanceTask : public Task, public InstanceName {
     void setGroup(const QString& group) { m_instGroup = group; }
     QString group() const { return m_instGroup; }
 
+    [[nodiscard]] bool shouldConfirmUpdate() const { return m_confirm_update; }
+    void setConfirmUpdate(bool confirm) { m_confirm_update = confirm; }
+
     bool shouldOverride() const { return m_override_existing; }
 
    protected:
@@ -56,4 +59,5 @@ class InstanceTask : public Task, public InstanceName {
     QString m_stagingPath;
 
     bool m_override_existing = false;
+    bool m_confirm_update = true;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -67,22 +67,10 @@ bool FlameCreationTask::updateInstance()
     auto version_id = inst->getManagedPackVersionName();
     auto version_str = !version_id.isEmpty() ? tr(" (version %1)").arg(version_id) : "";
 
-    auto info = CustomMessageBox::selectable(
-        m_parent, tr("Similar modpack was found!"),
-        tr("One or more of your instances are from this same modpack%1. Do you want to create a "
-           "separate instance, or update the existing one?\n\nNOTE: Make sure you made a backup of your important instance data before "
-           "updating, as worlds can be corrupted and some configuration may be lost (due to pack overrides).")
-            .arg(version_str), QMessageBox::Information, QMessageBox::Ok | QMessageBox::Reset | QMessageBox::Abort);
-    info->setButtonText(QMessageBox::Ok, tr("Update existing instance"));
-    info->setButtonText(QMessageBox::Abort, tr("Create new instance"));
-    info->setButtonText(QMessageBox::Reset, tr("Cancel"));
-
-    info->exec();
-
-    if (info->clickedButton() == info->button(QMessageBox::Abort))
+    auto should_update = askIfShouldUpdate(m_parent, version_str);
+    if (should_update == ShouldUpdate::SkipUpdating)
         return false;
-
-    if (info->clickedButton() == info->button(QMessageBox::Reset)) {
+    if (should_update == ShouldUpdate::Cancel) {
         m_abort = true;
         return false;
     }

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -67,12 +67,14 @@ bool FlameCreationTask::updateInstance()
     auto version_id = inst->getManagedPackVersionName();
     auto version_str = !version_id.isEmpty() ? tr(" (version %1)").arg(version_id) : "";
 
-    auto should_update = askIfShouldUpdate(m_parent, version_str);
-    if (should_update == ShouldUpdate::SkipUpdating)
-        return false;
-    if (should_update == ShouldUpdate::Cancel) {
-        m_abort = true;
-        return false;
+    if (shouldConfirmUpdate()) {
+        auto should_update = askIfShouldUpdate(m_parent, version_str);
+        if (should_update == ShouldUpdate::SkipUpdating)
+            return false;
+        if (should_update == ShouldUpdate::Cancel) {
+            m_abort = true;
+            return false;
+        }
     }
 
     QDir old_inst_dir(inst->instanceRoot());

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -49,12 +49,14 @@ bool ModrinthCreationTask::updateInstance()
     auto version_name = inst->getManagedPackVersionName();
     auto version_str = !version_name.isEmpty() ? tr(" (version %1)").arg(version_name) : "";
 
-    auto should_update = askIfShouldUpdate(m_parent, version_str);
-    if (should_update == ShouldUpdate::SkipUpdating)
-        return false;
-    if (should_update == ShouldUpdate::Cancel) {
-        m_abort = true;
-        return false;
+    if (shouldConfirmUpdate()) {
+        auto should_update = askIfShouldUpdate(m_parent, version_str);
+        if (should_update == ShouldUpdate::SkipUpdating)
+            return false;
+        if (should_update == ShouldUpdate::Cancel) {
+            m_abort = true;
+            return false;
+        }
     }
 
     // Remove repeated files, we don't need to download them!

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -49,23 +49,10 @@ bool ModrinthCreationTask::updateInstance()
     auto version_name = inst->getManagedPackVersionName();
     auto version_str = !version_name.isEmpty() ? tr(" (version %1)").arg(version_name) : "";
 
-    auto info = CustomMessageBox::selectable(
-        m_parent, tr("Similar modpack was found!"),
-        tr("One or more of your instances are from this same modpack%1. Do you want to create a "
-           "separate instance, or update the existing one?\n\nNOTE: Make sure you made a backup of your important instance data before "
-           "updating, as worlds can be corrupted and some configuration may be lost (due to pack overrides).")
-            .arg(version_str),
-        QMessageBox::Information, QMessageBox::Ok | QMessageBox::Reset | QMessageBox::Abort);
-    info->setButtonText(QMessageBox::Ok, tr("Create new instance"));
-    info->setButtonText(QMessageBox::Abort, tr("Update existing instance"));
-    info->setButtonText(QMessageBox::Reset, tr("Cancel"));
-
-    info->exec();
-
-    if (info->clickedButton() == info->button(QMessageBox::Ok))
+    auto should_update = askIfShouldUpdate(m_parent, version_str);
+    if (should_update == ShouldUpdate::SkipUpdating)
         return false;
-
-    if (info->clickedButton() == info->button(QMessageBox::Reset)) {
+    if (should_update == ShouldUpdate::Cancel) {
         m_abort = true;
         return false;
     }

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -128,6 +128,7 @@ auto loadIndexedVersion(QJsonObject &obj) -> ModpackVersion
 
     file.name = Json::requireString(obj, "name");
     file.version = Json::requireString(obj, "version_number");
+    file.changelog = Json::ensureString(obj, "changelog");
 
     file.id = Json::requireString(obj, "id");
     file.project_id = Json::requireString(obj, "project_id");

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -80,6 +80,7 @@ struct ModpackExtra {
 struct ModpackVersion {
     QString name;
     QString version;
+    QString changelog;
 
     QString id;
     QString project_id;

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -132,6 +132,12 @@ InstanceWindow::InstanceWindow(InstancePtr instance, QWidget *parent)
     {
         connect(m_instance.get(), &BaseInstance::statusChanged, this, &InstanceWindow::on_instanceStatusChanged);
     }
+
+    // add ourself as the modpack page's instance window
+    {
+        static_cast<ManagedPackPage*>(m_container->getPage("managed_pack"))->setInstanceWindow(this);
+    }
+
     show();
 }
 

--- a/launcher/ui/pages/BasePageContainer.h
+++ b/launcher/ui/pages/BasePageContainer.h
@@ -1,10 +1,13 @@
 #pragma once
 
+class BasePage;
+
 class BasePageContainer
 {
 public:
     virtual ~BasePageContainer(){};
     virtual bool selectPage(QString pageId) = 0;
+    virtual BasePage* getPage(QString pageId) { return nullptr; };
     virtual void refreshContainer() = 0;
     virtual bool requestClose() = 0;
 };

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -1,0 +1,129 @@
+#include "ManagedPackPage.h"
+#include "ui_ManagedPackPage.h"
+
+#include <QListView>
+#include <QProxyStyle>
+
+#include "Application.h"
+
+/** This is just to override the combo box popup behavior so that the combo box doesn't take the whole screen.
+ *  ... thanks Qt.
+ */
+class NoBigComboBoxStyle : public QProxyStyle {
+    Q_OBJECT
+
+   public:
+    NoBigComboBoxStyle(QStyle* style) : QProxyStyle(style) {}
+
+    // clang-format off
+    int styleHint(QStyle::StyleHint hint, const QStyleOption* option = nullptr, const QWidget* widget = nullptr, QStyleHintReturn* returnData = nullptr) const override
+    {
+        if (hint == QStyle::SH_ComboBox_Popup)
+            return false;
+
+        return QProxyStyle::styleHint(hint, option, widget, returnData);
+    }
+    // clang-format on
+};
+
+ManagedPackPage* ManagedPackPage::createPage(BaseInstance* inst, QString type, QWidget* parent)
+{
+    if (type == "modrinth")
+        return new ModrinthManagedPackPage(inst, parent);
+    if (type == "flame")
+        return new FlameManagedPackPage(inst, parent);
+
+    return new GenericManagedPackPage(inst, parent);
+}
+
+ManagedPackPage::ManagedPackPage(BaseInstance* inst, QWidget* parent) : QWidget(parent), ui(new Ui::ManagedPackPage), m_inst(inst)
+{
+    Q_ASSERT(inst);
+
+    ui->setupUi(this);
+
+    ui->versionsComboBox->setStyle(new NoBigComboBoxStyle(ui->versionsComboBox->style()));
+}
+
+ManagedPackPage::~ManagedPackPage()
+{
+    delete ui;
+}
+
+void ManagedPackPage::openedImpl()
+{
+    ui->packName->setText(m_inst->getManagedPackName());
+    ui->packVersion->setText(m_inst->getManagedPackVersionName());
+    ui->packOrigin->setText(tr("Website: %1    |    Pack ID: %2    |    Version ID: %3")
+                                .arg(displayName(), m_inst->getManagedPackID(), m_inst->getManagedPackVersionID()));
+
+    parseManagedPack();
+}
+
+QString ManagedPackPage::displayName() const
+{
+    auto type = m_inst->getManagedPackType();
+    if (type.isEmpty())
+        return {};
+    return type.replace(0, 1, type[0].toUpper());
+}
+
+QIcon ManagedPackPage::icon() const
+{
+    return APPLICATION->getThemedIcon(m_inst->getManagedPackType());
+}
+
+QString ManagedPackPage::helpPage() const
+{
+    return {};
+}
+
+void ManagedPackPage::retranslate()
+{
+    ui->retranslateUi(this);
+}
+
+bool ManagedPackPage::shouldDisplay() const
+{
+    return m_inst->isManagedPack();
+}
+
+ModrinthManagedPackPage::ModrinthManagedPackPage(BaseInstance* inst, QWidget* parent) : ManagedPackPage(inst, parent)
+{
+    Q_ASSERT(inst->isManagedPack());
+    connect(ui->versionsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(suggestVersion()));
+}
+
+void ModrinthManagedPackPage::parseManagedPack()
+{
+}
+
+QString ModrinthManagedPackPage::url() const
+{
+    return {};
+}
+
+void ModrinthManagedPackPage::suggestVersion()
+{
+}
+
+FlameManagedPackPage::FlameManagedPackPage(BaseInstance* inst, QWidget* parent) : ManagedPackPage(inst, parent)
+{
+    Q_ASSERT(inst->isManagedPack());
+    connect(ui->versionsComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(suggestVersion()));
+}
+
+void FlameManagedPackPage::parseManagedPack()
+{
+}
+
+QString FlameManagedPackPage::url() const
+{
+    return {};
+}
+
+void FlameManagedPackPage::suggestVersion()
+{
+}
+
+#include "ManagedPackPage.moc"

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -127,10 +127,19 @@ void ModrinthManagedPackPage::parseManagedPack()
         }
 
         for (auto version : m_pack.versions) {
+            QString name;
+
             if (!version.name.contains(version.version))
-                ui->versionsComboBox->addItem(QString("%1 — %2").arg(version.name, version.version), QVariant(version.id));
+                name = QString("%1 — %2").arg(version.name, version.version);
             else
-                ui->versionsComboBox->addItem(version.name, QVariant(version.id));
+                name = version.name;
+
+            // NOTE: the id from version isn't the same id in the modpack format spec...
+            // e.g. HexMC's 4.4.0 has versionId 4.0.0 in the modpack index..............
+            if (version.version == m_inst->getManagedPackVersionName())
+                name.append(tr(" (Current)"));
+
+            ui->versionsComboBox->addItem(name, QVariant(version.id));
         }
 
         suggestVersion();

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -81,6 +81,10 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
 
    public slots:
     void suggestVersion() override;
+
+   private:
+    Modrinth::Modpack m_pack;
+    ModrinthAPI m_api;
 };
 
 class FlameManagedPackPage final : public ManagedPackPage {

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -1,0 +1,98 @@
+#pragma once
+
+#include "BaseInstance.h"
+
+#include "modplatform/modrinth/ModrinthAPI.h"
+#include "modplatform/modrinth/ModrinthPackManifest.h"
+
+#include "ui/pages/BasePage.h"
+
+#include <QWidget>
+
+namespace Ui {
+class ManagedPackPage;
+}
+
+class ManagedPackPage : public QWidget, public BasePage {
+    Q_OBJECT
+
+   public:
+    inline static ManagedPackPage* createPage(BaseInstance* inst, QWidget* parent = nullptr)
+    {
+        return ManagedPackPage::createPage(inst, inst->getManagedPackType(), parent);
+    }
+
+    static ManagedPackPage* createPage(BaseInstance* inst, QString type, QWidget* parent = nullptr);
+    ~ManagedPackPage() override;
+
+    [[nodiscard]] QString displayName() const override;
+    [[nodiscard]] QIcon icon() const override;
+    [[nodiscard]] QString helpPage() const override;
+    [[nodiscard]] QString id() const override { return "managed_pack"; }
+    [[nodiscard]] bool shouldDisplay() const override;
+
+    void openedImpl() override;
+
+    bool apply() override { return true; }
+    void retranslate() override;
+
+    /** Gets the necessary information about the managed pack, such as
+     *  available versions*/
+    virtual void parseManagedPack() {};
+
+    /** URL of the managed pack.
+     *  Not the version-specific one.
+     */
+    [[nodiscard]] virtual QString url() const { return {}; };
+
+   public slots:
+    /** Gets the current version selection and update the changelog.
+     */
+    virtual void suggestVersion() {};
+
+   protected:
+    ManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+
+   protected:
+    Ui::ManagedPackPage* ui;
+    BaseInstance* m_inst;
+
+    bool m_loaded = false;
+};
+
+/** Simple page for when we aren't a managed pack. */
+class GenericManagedPackPage final : public ManagedPackPage {
+    Q_OBJECT
+
+   public:
+    GenericManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr) : ManagedPackPage(inst, parent) {}
+    ~GenericManagedPackPage() override = default;
+};
+
+class ModrinthManagedPackPage final : public ManagedPackPage {
+    Q_OBJECT
+
+   public:
+    ModrinthManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+    ~ModrinthManagedPackPage() override = default;
+
+    void parseManagedPack() override;
+    [[nodiscard]] QString url() const override;
+
+   public slots:
+    void suggestVersion() override;
+};
+
+class FlameManagedPackPage final : public ManagedPackPage {
+    Q_OBJECT
+
+   public:
+    FlameManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+    ~FlameManagedPackPage() override = default;
+
+    void parseManagedPack() override;
+    [[nodiscard]] QString url() const override;
+
+   public slots:
+    void suggestVersion() override;
+};

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -13,6 +13,9 @@ namespace Ui {
 class ManagedPackPage;
 }
 
+class InstanceTask;
+class InstanceWindow;
+
 class ManagedPackPage : public QWidget, public BasePage {
     Q_OBJECT
 
@@ -45,15 +48,28 @@ class ManagedPackPage : public QWidget, public BasePage {
      */
     [[nodiscard]] virtual QString url() const { return {}; };
 
+    void setInstanceWindow(InstanceWindow* window) { m_instance_window = window; }
+
    public slots:
     /** Gets the current version selection and update the changelog.
      */
     virtual void suggestVersion() {};
 
-   protected:
-    ManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+    virtual void update() {};
 
    protected:
+    ManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr);
+
+    /** Run the InstanceTask, with a progress dialog and all.
+     *  Similar to MainWindow::instanceFromInstanceTask
+     *
+     *  Returns whether the task was successful.
+     */
+    bool runUpdateTask(InstanceTask*);
+
+   protected:
+    InstanceWindow* m_instance_window = nullptr;
+
     Ui::ManagedPackPage* ui;
     BaseInstance* m_inst;
 
@@ -65,7 +81,7 @@ class GenericManagedPackPage final : public ManagedPackPage {
     Q_OBJECT
 
    public:
-    GenericManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr) : ManagedPackPage(inst, parent) {}
+    GenericManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr) : ManagedPackPage(inst, instance_window, parent) {}
     ~GenericManagedPackPage() override = default;
 };
 
@@ -73,7 +89,7 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
     Q_OBJECT
 
    public:
-    ModrinthManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+    ModrinthManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr);
     ~ModrinthManagedPackPage() override = default;
 
     void parseManagedPack() override;
@@ -81,6 +97,8 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
 
    public slots:
     void suggestVersion() override;
+
+    void update() override;
 
    private:
     Modrinth::Modpack m_pack;
@@ -91,7 +109,7 @@ class FlameManagedPackPage final : public ManagedPackPage {
     Q_OBJECT
 
    public:
-    FlameManagedPackPage(BaseInstance* inst, QWidget* parent = nullptr);
+    FlameManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr);
     ~FlameManagedPackPage() override = default;
 
     void parseManagedPack() override;

--- a/launcher/ui/pages/instance/ManagedPackPage.ui
+++ b/launcher/ui/pages/instance/ManagedPackPage.ui
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ManagedPackPage</class>
+ <widget class="QWidget" name="ManagedPackPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>731</width>
+    <height>538</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QGroupBox" name="packInformationBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Pack information</string>
+       </property>
+       <layout class="QFormLayout" name="formLayout_2">
+        <item row="0" column="0">
+         <layout class="QHBoxLayout" name="packNameLayout">
+          <item>
+           <widget class="QLabel" name="packNameLabel">
+            <property name="text">
+             <string>Pack name:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="packName">
+            <property name="text">
+             <string notr="true">placeholder</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <layout class="QHBoxLayout" name="packVersionLayout">
+          <item>
+           <widget class="QLabel" name="packVersionLabel">
+            <property name="text">
+             <string>Current version:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="packVersion">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string notr="true">placeholder</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
+         <layout class="QHBoxLayout" name="packOriginLayout">
+          <item>
+           <widget class="QLabel" name="packOriginLabel">
+            <property name="text">
+             <string>Provider information:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="packOrigin">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="text">
+             <string notr="true">placeholder</string>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="updateToVersionLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Update to version:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="versionsComboBox"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="updateButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Update pack</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="changelogBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>Changelog</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QTextBrowser" name="changelogTextBrowser"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/launcher/ui/widgets/PageContainer.cpp
+++ b/launcher/ui/widgets/PageContainer.cpp
@@ -130,6 +130,11 @@ bool PageContainer::selectPage(QString pageId)
     return false;
 }
 
+BasePage* PageContainer::getPage(QString pageId)
+{
+    return m_model->findPageEntryById(pageId);
+}
+
 void PageContainer::refreshContainer()
 {
     m_proxyModel->invalidate();

--- a/launcher/ui/widgets/PageContainer.h
+++ b/launcher/ui/widgets/PageContainer.h
@@ -79,6 +79,7 @@ public:
     }
 
     virtual bool selectPage(QString pageId) override;
+    BasePage* getPage(QString pageId) override;
 
     void refreshContainer() override;
     virtual void setParentContainer(BasePageContainer * container)


### PR DESCRIPTION
TODO:
- [x] Modrinth modpack page
- [ ] Flame modpack page
- [ ] Fix icons with managed packs not from MR/CF (or probably hide them since we can't update them yet anyways)
- [ ] Make the changelog thing parse the content as markdown
- [ ] Add link to the modpack page in the mod provider

and probably some more stuff i forgot about :x