### PR TITLE
make polymc build/work on platforms without std::filesystem, add macos-legacy package and remove old unnedeed hack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
       - name: Configure CMake (macOS-Legacy)
         if: runner.os == 'macOS' && matrix.qt_ver == 5
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DMACOSX_SPARKLE_UPDATE_PUBLIC_KEY="" -DMACOSX_SPARKLE_UPDATE_FEED_URL="" -G Ninja
 
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
@@ -254,7 +254,7 @@ jobs:
           tar -czf ../PolyMC.tar.gz *
 
       - name: Make Sparkle signature (macOS)
-        if: runner.os == 'macOS'
+        if: matrix.name == 'macOS'
         run: |
           if [ '${{ secrets.SPARKLE_ED25519_KEY }}' != '' ]; then
             brew install openssl@3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,20 @@ jobs:
             qt_ver: 6
 
           - os: macos-12
+            name: macOS
             macosx_deployment_target: 10.15
             qt_ver: 6
             qt_host: mac
             qt_version: '6.3.0'
             qt_modules: 'qt5compat qtimageformats'
+
+          - os: macos-12
+            name: macOS-Legacy
+            macosx_deployment_target: 10.13
+            qt_ver: 5
+            qt_host: mac
+            qt_version: '5.15.2'
+            qt_modules: ''
 
     runs-on: ${{ matrix.os }}
 
@@ -148,7 +157,7 @@ jobs:
           sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
  
       - name: Install Qt (macOS and AppImage)
-        if: matrix.qt_ver == 6 && runner.os != 'Windows'
+        if: runner.os == 'Linux' && matrix.qt_ver == 6 || runner.os == 'macOS'
         uses: jurplel/install-qt-action@v3
         with:
            version: ${{ matrix.qt_version }}
@@ -172,9 +181,14 @@ jobs:
       ##
 
       - name: Configure CMake (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.qt_ver == 6
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DLauncher_BUILD_PLATFORM=macOS -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -G Ninja
+
+      - name: Configure CMake (macOS-Legacy)
+        if: runner.os == 'macOS' && matrix.qt_ver == 5
+        run: |
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
 
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
@@ -339,7 +353,7 @@ jobs:
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v3
         with:
-          name: PolyMC-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}
+          name: PolyMC-${{ matrix.name }}-${{ env.VERSION }}-${{ inputs.build_type }}
           path: PolyMC.tar.gz
 
       - name: Upload binary zip (Windows)

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -40,6 +40,7 @@ jobs:
           mv PolyMC-Linux-Portable*/PolyMC-portable.tar.gz PolyMC-Linux-Portable-${{ env.VERSION }}.tar.gz
           mv PolyMC-Linux*/PolyMC.tar.gz PolyMC-Linux-${{ env.VERSION }}.tar.gz
           mv PolyMC-*.AppImage/PolyMC-*.AppImage PolyMC-Linux-${{ env.VERSION }}-x86_64.AppImage
+          mv PolyMC-macOS-Legacy*/PolyMC.tar.gz PolyMC-macOS-Legacy-${{ env.VERSION }}.tar.gz
           mv PolyMC-macOS*/PolyMC.tar.gz PolyMC-macOS-${{ env.VERSION }}.tar.gz
 
           tar -czf PolyMC-${{ env.VERSION }}.tar.gz PolyMC-${{ env.VERSION }}
@@ -80,4 +81,5 @@ jobs:
             PolyMC-Windows-Portable-${{ env.VERSION }}.zip
             PolyMC-Windows-Setup-${{ env.VERSION }}.exe
             PolyMC-macOS-${{ env.VERSION }}.tar.gz
+            PolyMC-macOS-Legacy-${{ env.VERSION }}.tar.gz
             PolyMC-${{ env.VERSION }}.tar.gz

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libraries/tomlplusplus"]
 	path = libraries/tomlplusplus
 	url = https://github.com/marzer/tomlplusplus.git
+[submodule "libraries/filesystem"]
+	path = libraries/filesystem
+	url = https://github.com/gulrak/filesystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,9 @@ if(NOT Launcher_FORCE_BUNDLED_LIBS)
     find_package(tomlplusplus 3.2.0 QUIET)
 endif()
 
+# Workaround ghc::filesystem bug
+set(GHC_FILESYSTEM_WITH_INSTALL OFF)
+
 ####################################### Program Info #######################################
 
 set(Launcher_APP_BINARY_NAME "polymc" CACHE STRING "Name of the Launcher binary")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 set(CMAKE_CXX_FLAGS "-Wall -pedantic -fstack-protector-strong --param=ssp-buffer-size=4 ${CMAKE_CXX_FLAGS}")
-if(UNIX AND APPLE)
-    set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
-endif()
 
 # Fix build with Qt 5.13
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ endif()
 add_subdirectory(libraries/katabasis) # An OAuth2 library that tried to do too much
 add_subdirectory(libraries/gamemode)
 add_subdirectory(libraries/murmur2) # Hash for usage with the CurseForge API
+add_subdirectory(libraries/filesystem) # Implementation of std::filesystem for old C++, for usage in old macOS
 
 ############################### Built Artifacts ###############################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,13 +189,13 @@ if (Qt5_POSITION_INDEPENDENT_CODE)
     SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
-# Find toml++
 if(NOT Launcher_FORCE_BUNDLED_LIBS)
+    # Find toml++
     find_package(tomlplusplus 3.2.0 QUIET)
-endif()
 
-# Workaround ghc::filesystem bug
-set(GHC_FILESYSTEM_WITH_INSTALL OFF)
+    # Find ghc_filesystem
+    find_package(ghc_filesystem QUIET)
+endif()
 
 ####################################### Program Info #######################################
 
@@ -326,7 +326,14 @@ endif()
 add_subdirectory(libraries/katabasis) # An OAuth2 library that tried to do too much
 add_subdirectory(libraries/gamemode)
 add_subdirectory(libraries/murmur2) # Hash for usage with the CurseForge API
-add_subdirectory(libraries/filesystem) # Implementation of std::filesystem for old C++, for usage in old macOS
+if (NOT ghc_filesystem_FOUND)
+    message(STATUS "Using bundled ghc_filesystem")
+    set(GHC_FILESYSTEM_WITH_INSTALL OFF) # Workaround ghc::filesystem bug
+    add_subdirectory(libraries/filesystem) # Implementation of std::filesystem for old C++, for usage in old macOS
+    add_library(ghcFilesystem::ghc_filesystem ALIAS ghc_filesystem)
+else()
+    message(STATUS "Using system ghc_filesystem")
+endif()
 
 ############################### Built Artifacts ###############################
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -976,7 +976,7 @@ target_link_libraries(Launcher_logic
     BuildConfig
     Katabasis
     Qt${QT_VERSION_MAJOR}::Widgets
-    ghc_filesystem
+    ghcFilesystem::ghc_filesystem
 )
 
 if (UNIX AND NOT CYGWIN AND NOT APPLE)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -976,6 +976,7 @@ target_link_libraries(Launcher_logic
     BuildConfig
     Katabasis
     Qt${QT_VERSION_MAJOR}::Widgets
+    ghc_filesystem
 )
 
 if (UNIX AND NOT CYGWIN AND NOT APPLE)

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -10,6 +10,14 @@ This library has served as a base for some (much more full-featured and advanced
 
 Copyright belongs to Petr Mrázek, unless explicitly stated otherwise in the source files. Available under the Apache 2.0 license.
 
+## filesystem
+
+Gulrak's implementation of C++17 std::filesystem for C++11 /C++14/C++17/C++20 on Windows, macOS, Linux and FreeBSD.
+
+See [github repo](https://github.com/gulrak/filesystem).
+
+MIT licensed.
+
 ## gamemode
 
 A performance optimization daemon.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@
 , ninja
 , jdk8
 , jdk
+, ghc_filesystem
 , zlib
 , file
 , wrapQtAppsHook
@@ -49,7 +50,7 @@ stdenv.mkDerivation rec {
 
   src = lib.cleanSource self;
 
-  nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk file wrapQtAppsHook ];
+  nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk ghc_filesystem file wrapQtAppsHook ];
   buildInputs = [ qtbase quazip zlib ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
closes #1173 

2901039a485c27c686ebadebf8b67a5126ce9df0 adds the macos-legacy package
5bdb3703ede735129d7eb57c0b1f6d2c497e3fa2 removes an old multimc-era unnedeed hack
c520faed6d0e5e9472622f848ad8512b6c71c8e0 and 124097d3a50ba4ae97478ce7d33e5d33690cef75 make polymc build/work on platforms without std::filesystem
2aff7bac4aa5dc39b2b68eb2f9d894be832d48c9 disables the updater on macos-legacy since i have no idea on how to make that work. if you do and you want to, feel free to
89e45a61b33ed7ae73aa9903149530462fd760b6 workarounds https://github.com/gulrak/filesystem/issues/160
03d077e915cf2bf06474b17e51e0c664f57eb348 and 03d077e915cf2bf06474b17e51e0c664f57eb348 make it possible to use a system install of ghc-filesystem
