### PR TITLE
Suggestion: Drop quilt support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,17 @@ result/
 # Flatpak
 .flatpak-builder
 flatbuild
+
+# Cmake Files
+CMakeFiles
+CMakeCache.txt
+
+# Other stuff
+DartConfiguration.tcl
+LauncherScript
+org.polymc.PolyMC.desktop
+org.polymc.PolyMC.metainfo.xml
+polymc.manifest
+polymc.rc
+win_install.nsi
+build.sh

--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -599,7 +599,7 @@ void ComponentUpdateTask::resolveDependencies(bool checkOnly)
                     {
                         component->m_version = "3.1.2";
                     }
-                    else if (add.uid == "net.fabricmc.intermediary" || add.uid == "org.quiltmc.hashed")
+                    else if (add.uid == "net.fabricmc.intermediary")
                     {
                         auto minecraft = std::find_if(components.begin(), components.end(), [](ComponentPtr & cmp){
                             return cmp->getID() == "net.minecraft";

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -61,7 +61,6 @@
 static const QMap<QString, ModAPI::ModLoaderType> modloaderMapping{
     {"net.minecraftforge", ModAPI::Forge},
     {"net.fabricmc.fabric-loader", ModAPI::Fabric},
-    {"org.quiltmc.quilt-loader", ModAPI::Quilt}
 };
 
 PackProfile::PackProfile(MinecraftInstance * instance)

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -203,42 +203,6 @@ ModDetails ReadFabricModInfo(QByteArray contents)
     return details;
 }
 
-// https://github.com/QuiltMC/rfcs/blob/master/specification/0002-quilt.mod.json.md
-ModDetails ReadQuiltModInfo(QByteArray contents)
-{
-    QJsonParseError jsonError;
-    QJsonDocument jsonDoc = QJsonDocument::fromJson(contents, &jsonError);
-    auto object = Json::requireObject(jsonDoc, "quilt.mod.json");
-    auto schemaVersion = Json::ensureInteger(object.value("schema_version"), 0, "Quilt schema_version");
-
-    ModDetails details;
-
-    // https://github.com/QuiltMC/rfcs/blob/be6ba280d785395fefa90a43db48e5bfc1d15eb4/specification/0002-quilt.mod.json.md
-    if (schemaVersion == 1) {
-        auto modInfo = Json::requireObject(object.value("quilt_loader"), "Quilt mod info");
-
-        details.mod_id = Json::requireString(modInfo.value("id"), "Mod ID");
-        details.version = Json::requireString(modInfo.value("version"), "Mod version");
-
-        auto modMetadata = Json::ensureObject(modInfo.value("metadata"));
-
-        details.name = Json::ensureString(modMetadata.value("name"), details.mod_id);
-        details.description = Json::ensureString(modMetadata.value("description"));
-
-        auto modContributors = Json::ensureObject(modMetadata.value("contributors"));
-
-        // We don't really care about the role of a contributor here
-        details.authors += modContributors.keys();
-
-        auto modContact = Json::ensureObject(modMetadata.value("contact"));
-
-        if (modContact.contains("homepage")) {
-            details.homeurl = Json::requireString(modContact.value("homepage"));
-        }
-    }
-    return details;
-}
-
 ModDetails ReadForgeInfo(QByteArray contents)
 {
     ModDetails details;
@@ -345,16 +309,6 @@ void LocalModParseTask::processAsZip()
         }
 
         m_result->details = ReadMCModInfo(file.readAll());
-        file.close();
-        zip.close();
-        return;
-    } else if (zip.setCurrentFile("quilt.mod.json")) {
-        if (!file.open(QIODevice::ReadOnly)) {
-            zip.close();
-            return;
-        }
-
-        m_result->details = ReadQuiltModInfo(file.readAll());
         file.close();
         zip.close();
         return;

--- a/launcher/modplatform/ModAPI.h
+++ b/launcher/modplatform/ModAPI.h
@@ -59,8 +59,7 @@ class ModAPI {
         Forge = 1 << 0,
         Cauldron = 1 << 1,
         LiteLoader = 1 << 2,
-        Fabric = 1 << 3,
-        Quilt = 1 << 4
+        Fabric = 1 << 3
     };
     Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
 
@@ -99,8 +98,6 @@ class ModAPI {
                 return "liteloader";
             case Fabric:
                 return "fabric";
-            case Quilt:
-                return "quilt";
         }
         return "";
     }

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -76,9 +76,6 @@ class FlameAPI : public NetworkModAPI {
             return 1;
         if (loaders & Fabric)
             return 4;
-        // TODO: remove this once Quilt drops official Fabric support
-        if (loaders & Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
-            return 4;  // Quilt would probably be 5
         return 0;
     }
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -257,7 +257,6 @@ bool FlameCreationTask::createInstance()
 
     QString forgeVersion;
     QString fabricVersion;
-    // TODO: is Quilt relevant here?
     for (auto& loader : m_pack.minecraft.modLoaders) {
         auto id = loader.id;
         if (id.startsWith("forge-")) {

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -55,15 +55,13 @@ class ModrinthAPI : public NetworkModAPI {
     static auto getModLoaderStrings(const ModLoaderTypes types) -> const QStringList
     {
         QStringList l;
-        for (auto loader : {Forge, Fabric, Quilt})
+        for (auto loader : {Forge, Fabric})
         {
             if ((types & loader) || types == Unspecified)
             {
                 l << ModAPI::getModLoaderString(loader);
             }
         }
-        if ((types & Quilt) && (~types & Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
-            l << ModAPI::getModLoaderString(Fabric);
         return l;
     }
 
@@ -132,7 +130,7 @@ class ModrinthAPI : public NetworkModAPI {
 
     inline auto validateModLoaders(ModLoaderTypes loaders) const -> bool
     {
-        return (loaders == Unspecified) || (loaders & (Forge | Fabric | Quilt));
+        return (loaders == Unspecified) || (loaders & (Forge | Fabric));
     }
 
 };

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -108,7 +108,7 @@ void ModrinthCheckUpdate::executeTask()
                 // Sometimes a version may have multiple files, one with "forge" and one with "fabric",
                 // so we may want to filter it
                 QString loader_filter;
-                static auto flags = { ModAPI::ModLoaderType::Forge, ModAPI::ModLoaderType::Fabric, ModAPI::ModLoaderType::Quilt };
+                static auto flags = { ModAPI::ModLoaderType::Forge, ModAPI::ModLoaderType::Fabric };
                 for (auto flag : flags) {
                     if (m_loaders.testFlag(flag)) {
                         loader_filter = api.getModLoaderString(flag);

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -211,8 +211,6 @@ bool ModrinthCreationTask::createInstance()
 
     if (!fabricVersion.isEmpty())
         components->setComponentVersion("net.fabricmc.fabric-loader", fabricVersion);
-    if (!quiltVersion.isEmpty())
-        components->setComponentVersion("org.quiltmc.quilt-loader", quiltVersion);
     if (!forgeVersion.isEmpty())
         components->setComponentVersion("net.minecraftforge", forgeVersion);
 
@@ -376,8 +374,6 @@ bool ModrinthCreationTask::parseManifest(const QString& index_path, std::vector<
                     minecraftVersion = Json::requireString(*it, "Minecraft version");
                 } else if (name == "fabric-loader") {
                     fabricVersion = Json::requireString(*it, "Fabric Loader version");
-                } else if (name == "quilt-loader") {
-                    quiltVersion = Json::requireString(*it, "Quilt Loader version");
                 } else if (name == "forge") {
                     forgeVersion = Json::requireString(*it, "Forge version");
                 } else {

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -33,7 +33,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
    private:
     QWidget* m_parent = nullptr;
 
-    QString minecraftVersion, fabricVersion, quiltVersion, forgeVersion;
+    QString minecraftVersion, fabricVersion, forgeVersion;
     QString m_managed_id, m_managed_version_id, m_managed_name;
     QString m_source_url;
 

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -190,8 +190,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
                 // <Technic library name prefix> -> <our component name>
                 static QMap<QString, QString> loaderMap {
                     {"net.minecraftforge:minecraftforge:", "net.minecraftforge"},
-                    {"net.fabricmc:fabric-loader:", "net.fabricmc.fabric-loader"},
-                    {"org.quiltmc:quilt-loader:", "org.quiltmc.quilt-loader"}
+                    {"net.fabricmc:fabric-loader:", "net.fabricmc.fabric-loader"}
                 };
                 for (const auto& loader : loaderMap.keys())
                 {

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -243,9 +243,6 @@ void VersionPage::updateVersionControls()
     bool supportsFabric = minecraftVersion >= Version("1.14");
     ui->actionInstall_Fabric->setEnabled(controlsEnabled && supportsFabric);
 
-    bool supportsQuilt = minecraftVersion >= Version("1.14");
-    ui->actionInstall_Quilt->setEnabled(controlsEnabled && supportsQuilt);
-
     bool supportsLiteLoader = minecraftVersion <= Version("1.12.2");
     ui->actionInstall_LiteLoader->setEnabled(controlsEnabled && supportsLiteLoader);
 
@@ -395,7 +392,7 @@ void VersionPage::on_actionChange_version_triggered()
         return;
     }
     VersionSelectDialog vselect(list.get(), tr("Change %1 version").arg(name), this);
-    if (uid == "net.fabricmc.intermediary" || uid == "org.quiltmc.hashed")
+    if (uid == "net.fabricmc.intermediary")
     {
         vselect.setEmptyString(tr("No intermediary mappings versions are currently available."));
         vselect.setEmptyErrorString(tr("Couldn't load or download the intermediary mappings version lists!"));
@@ -495,33 +492,6 @@ void VersionPage::on_actionInstall_Fabric_triggered()
     {
         auto vsn = vselect.selectedVersion();
         m_profile->setComponentVersion("net.fabricmc.fabric-loader", vsn->descriptor());
-        m_profile->resolve(Net::Mode::Online);
-        preselect(m_profile->rowCount(QModelIndex())-1);
-        m_container->refreshContainer();
-    }
-}
-
-void VersionPage::on_actionInstall_Quilt_triggered()
-{
-    auto vlist = APPLICATION->metadataIndex()->get("org.quiltmc.quilt-loader");
-    if(!vlist)
-    {
-        return;
-    }
-    VersionSelectDialog vselect(vlist.get(), tr("Select Quilt Loader version"), this);
-    vselect.setEmptyString(tr("No Quilt Loader versions are currently available."));
-    vselect.setEmptyErrorString(tr("Couldn't load or download the Quilt Loader version lists!"));
-
-    auto currentVersion = m_profile->getComponentVersion("org.quiltmc.quilt-loader");
-    if(!currentVersion.isEmpty())
-    {
-        vselect.setCurrentVersion(currentVersion);
-    }
-
-    if (vselect.exec() && vselect.selectedVersion())
-    {
-        auto vsn = vselect.selectedVersion();
-        m_profile->setComponentVersion("org.quiltmc.quilt-loader", vsn->descriptor());
         m_profile->resolve(Net::Mode::Online);
         preselect(m_profile->rowCount(QModelIndex())-1);
         m_container->refreshContainer();

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -73,7 +73,6 @@ private slots:
     void on_actionChange_version_triggered();
     void on_actionInstall_Forge_triggered();
     void on_actionInstall_Fabric_triggered();
-    void on_actionInstall_Quilt_triggered();
     void on_actionAdd_Empty_triggered();
     void on_actionInstall_LiteLoader_triggered();
     void on_actionReload_triggered();

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -107,7 +107,6 @@
    <addaction name="separator"/>
    <addaction name="actionInstall_Forge"/>
    <addaction name="actionInstall_Fabric"/>
-   <addaction name="actionInstall_Quilt"/>
    <addaction name="actionInstall_LiteLoader"/>
    <addaction name="actionInstall_mods"/>
    <addaction name="separator"/>
@@ -191,14 +190,6 @@
    </property>
    <property name="toolTip">
     <string>Install the Fabric Loader package.</string>
-   </property>
-  </action>
-  <action name="actionInstall_Quilt">
-   <property name="text">
-    <string>Install Quilt</string>
-   </property>
-   <property name="toolTip">
-    <string>Install the Quilt Loader package.</string>
    </property>
   </action>
   <action name="actionInstall_LiteLoader">

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -65,7 +65,6 @@ VanillaPage::VanillaPage(NewInstanceDialog *dialog, QWidget *parent)
     connect(ui->noneFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->forgeFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->fabricFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
-    connect(ui->quiltFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->liteLoaderFilter, &QRadioButton::toggled, this, &VanillaPage::loaderFilterChanged);
     connect(ui->loaderRefreshBtn, &QPushButton::clicked, this, &VanillaPage::loaderRefresh);
 
@@ -145,20 +144,11 @@ void VanillaPage::loaderFilterChanged()
     else if(ui->fabricFilter->isChecked())
     {
         // FIXME: dirty hack because the launcher is unaware of Fabric's dependencies
-        if (Version(minecraftVersion) >= Version("1.14")) // Fabric/Quilt supported
+        if (Version(minecraftVersion) >= Version("1.14")) // Fabric
             ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "");
-        else // Fabric/Quilt unsupported
+        else // Fabric
             ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // clear list
         m_selectedLoader = "net.fabricmc.fabric-loader";
-    }
-    else if(ui->quiltFilter->isChecked())
-    {
-        // FIXME: dirty hack because the launcher is unaware of Quilt's dependencies (same as Fabric)
-        if (Version(minecraftVersion) >= Version("1.14")) // Fabric/Quilt supported
-            ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "");
-        else // Fabric/Quilt unsupported
-            ui->loaderVersionList->setExactFilter(BaseVersionList::ParentVersionRole, "AAA"); // clear list
-        m_selectedLoader = "org.quiltmc.quilt-loader";
     }
     else if(ui->liteLoaderFilter->isChecked())
     {

--- a/launcher/ui/pages/modplatform/VanillaPage.ui
+++ b/launcher/ui/pages/modplatform/VanillaPage.ui
@@ -215,16 +215,6 @@
             </widget>
            </item>
            <item>
-            <widget class="QRadioButton" name="quiltFilter">
-             <property name="text">
-              <string>Quilt</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">loaderBtnGroup</string>
-             </attribute>
-            </widget>
-           </item>
-           <item>
             <widget class="QRadioButton" name="liteLoaderFilter">
              <property name="text">
               <string>LiteLoader</string>

--- a/program_info/org.polymc.PolyMC.metainfo.xml.in
+++ b/program_info/org.polymc.PolyMC.metainfo.xml.in
@@ -16,7 +16,7 @@
     <p>PolyMC is a custom launcher for Minecraft that focuses on predictability, long term stability and simplicity.</p>
     <p>Features:</p>
     <ul>
-      <li>Easily install game modifications, such as Fabric, Forge and Quilt</li>
+      <li>Easily install game modifications, such as Fabric and Forge</li>
       <li>Control your java settings</li>
       <li>Manage worlds and resource packs from the launcher</li>
       <li>See logs and other details easily</li>


### PR DESCRIPTION
Quilt support is not necessary, as it's basically just a straight fabric fork with minor changes. There is not a large enough userbase to warrant keeping support for the loader itself, and there are very few, if any, quilt only mods.

Almost all quilt mods work on fabric and vise versa, so keeping support for it is just a waste of time and energy if something breaks.