### PR TITLE
change: Added diagnostic logging for OAuth 2.0 token reply errors, an…

### DIFF
--- a/libraries/katabasis/src/DeviceFlow.cpp
+++ b/libraries/katabasis/src/DeviceFlow.cpp
@@ -230,6 +230,15 @@ void DeviceFlow::onDeviceAuthReplyFinished()
             qWarning() << "DeviceFlow::onDeviceAuthReplyFinished: Mandatory parameters missing from response";
             updateActivity(Activity::FailedHard);
         }
+    } else {
+        qWarning() << "DeviceFlow::onDeviceAuthReplyFinished: Token reply error:" << tokenReply->errorString();
+
+        QVariantMap params = parseJsonResponse(tokenReply->readAll());
+        foreach (QString key, params.keys()) {
+            qDebug() << "\t" << key << ": " << params.value(key).toString();
+        }
+
+        updateActivity(Activity::FailedHard);
     }
     tokenReply->deleteLater();
 }


### PR DESCRIPTION
…d made it fail the activity.

Signed-off-by: Kemonomodoki <kemonomodoki@firemail.cc>

(PRing on behalf of this person since PRs from randoms are blocked for the time being)