### PR TITLE
Minor changes to curseforge workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ set(Launcher_MSA_CLIENT_ID "6b329578-bfec-42a3-b503-303ab3f2ac96" CACHE STRING "
 # https://support.curseforge.com/en/support/solutions/articles/9000207405-curse-forge-3rd-party-api-terms-and-conditions
 # NOTE: CurseForge requires you to change this if you make any kind of derivative work.
 set(Launcher_CURSEFORGE_API_KEY "" CACHE STRING "API key for the CurseForge platform")
-set(Launcher_CURSEFORGE_API_KEY_API_URL "https://fluchschmieden-entwickler-sind-alle.skids.lol/api" CACHE STRING "URL to fetch the Curseforge API key from.")
+set(Launcher_CURSEFORGE_API_KEY_API_URL "https://cf.polymc.org/api" CACHE STRING "URL to fetch the Curseforge API key from.")
 
 
 #### Check the current Git commit and branch

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -953,32 +953,6 @@ void Application::performMainStartupAction()
 {
     m_status = Application::Initialized;
 
-    {
-        bool shouldFetch = m_settings->get("FlameKeyShouldBeFetchedOnStartup").toBool();
-        if (shouldFetch && !(capabilities() & Capability::SupportsFlame))
-        {
-            auto response = QMessageBox::question(nullptr,
-                                                  tr("Curseforge Core API Key"),
-                                                  tr("Should PolyMC try to fetch the Official Curseforge Launcher's API Key? "
-                                                  "Using this key technically breaks Curseforge's Terms of Service, but this distribution of PolyMC "
-                                                  "does not come with a Curseforge API key by default, so without this key or another valid API key, "
-                                                  "which you can always change in the settings, you won't be able to download Curseforge modpacks."),
-                                                  QMessageBox::Yes | QMessageBox::No);
-
-            if (response == QMessageBox::Yes)
-            {
-                QString apiKey = GuiUtil::fetchFlameKey();
-                if (!apiKey.isEmpty())
-                {
-                    m_settings->set("FlameKeyOverride", apiKey);
-                    updateCapabilities();
-                }
-            }
-
-            m_settings->set("FlameKeyShouldBeFetchedOnStartup", false);
-        }
-    }
-
     if(!m_instanceIdToLaunch.isEmpty())
     {
         auto inst = instances()->getInstanceById(m_instanceIdToLaunch);
@@ -1008,6 +982,32 @@ void Application::performMainStartupAction()
             return;
         }
     }
+
+    {
+        bool shouldFetch = m_settings->get("FlameKeyShouldBeFetchedOnStartup").toBool();
+        if (!BuildConfig.FLAME_API_KEY_API_URL.isEmpty() && shouldFetch && !(capabilities() & Capability::SupportsFlame))
+        {
+            auto response = QMessageBox::question(nullptr,
+                                                  tr("Curseforge Core API Key"),
+                                                  tr("Should PolyMC try to fetch the Official Curseforge Launcher's API Key? "
+                                                     "Using this key technically breaks Curseforge's Terms of Service, but this distribution of PolyMC "
+                                                     "does not come with a Curseforge API key by default, so without this key or another valid API key, "
+                                                     "which you can always change in the settings, you won't be able to download Curseforge modpacks."),
+                                                  QMessageBox::Yes | QMessageBox::No);
+
+            if (response == QMessageBox::Yes)
+            {
+                QString apiKey = GuiUtil::fetchFlameKey();
+                if (!apiKey.isEmpty())
+                {
+                    m_settings->set("FlameKeyOverride", apiKey);
+                    updateCapabilities();
+                }
+            }
+        }
+        m_settings->set("FlameKeyShouldBeFetchedOnStartup", false);
+    }
+
     if(!m_mainWindow)
     {
         // normal main window

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -52,6 +52,9 @@
 
 QString GuiUtil::fetchFlameKey(QWidget *parentWidget)
 {
+    if (BuildConfig.FLAME_API_KEY_API_URL.isEmpty())
+        return "";
+
     ProgressDialog prog(parentWidget);
     auto flameKeyTask = std::make_unique<FetchFlameAPIKey>();
     prog.execWithTask(flameKeyTask.get());

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -89,6 +89,9 @@ APIPage::APIPage(QWidget *parent) :
     ui->metaURL->setPlaceholderText(BuildConfig.META_URL);
     ui->userAgentLineEdit->setPlaceholderText(BuildConfig.USER_AGENT);
 
+    if (BuildConfig.FLAME_API_KEY_API_URL.isEmpty())
+        ui->fetchKeyButton->hide();
+
     loadSettings();
 
     resetBaseURLNote();


### PR DESCRIPTION
- Change domain name to one that we control so we don't have to change it if the other domain goes down for whatever reason.
- Add the ability to disable the CF key fetching thing by setting the Launcher_CURSEFORGE_API_KEY_API_URL to an empty string.