### PR TITLE
fix recursive crash on win64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,10 @@ set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 set(CMAKE_CXX_FLAGS "-Wall -pedantic -fstack-protector-strong --param=ssp-buffer-size=4 ${CMAKE_CXX_FLAGS}")
 
-if(WIN32)
+# Increases the stack size to 8MB for Windows, only when not building in Debug mode
+# because we don't want random users being affected by stack overflows in release builds,
+# but it's fine in debug builds for finding and fixing them
+if((NOT CMAKE_BUILD_TYPE STREQUAL "Debug") AND WIN32)
     set(CMAKE_EXE_LINKER_FLAGS "-Wl,--stack,8388608 ${CMAKE_EXE_LINKER_FLAGS}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 set(CMAKE_CXX_FLAGS "-Wall -pedantic -fstack-protector-strong --param=ssp-buffer-size=4 ${CMAKE_CXX_FLAGS}")
 
+if(WIN32)
+    set(CMAKE_EXE_LINKER_FLAGS "-Wl,--stack,8388608 ${CMAKE_EXE_LINKER_FLAGS}")
+endif()
+
 # Fix build with Qt 5.13
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
 


### PR DESCRIPTION
one of the contributors to PolyMC that moved over to Prism (TheLastRar) ended up finding this. I didn't understand what it was for until I fixed & ran a 64-bit Windows build myself, and got a 0xC00000FD (Stack overflow). This is caused by the massive recursive load of ATLauncher packs. This is a pretty jank fix as it is, and later should be re-engineered to not be recursive.

Signed-off-by: jdp_ <42700985+jdpatdiscord@users.noreply.github.com>