### PR TITLE
Add storage page to instances.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
             qt_ver: 6
             qt_host: linux
             qt_version: '6.2.4'
-            qt_modules: 'qt5compat qtimageformats'
+            qt_modules: 'qt5compat qtimageformats qtcharts'
 
           - os: windows-2022
             name: "Windows-Legacy"
@@ -44,7 +44,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_version: '6.3.0'
-            qt_modules: 'qt5compat qtimageformats'
+            qt_modules: 'qt5compat qtimageformats qtcharts'
 
           - os: macos-12
             name: macOS-Legacy
@@ -52,7 +52,7 @@ jobs:
             qt_ver: 5
             qt_host: mac
             qt_version: '5.15.2'
-            qt_modules: ''
+            qt_modules: 'qtcharts'
 
     runs-on: ${{ matrix.os }}
 
@@ -97,6 +97,7 @@ jobs:
             qt${{ matrix.qt_ver }}-base:p
             qt${{ matrix.qt_ver }}-svg:p
             qt${{ matrix.qt_ver }}-imageformats:p
+            qt${{ matrix.qt_ver }}-charts:p
             quazip-qt${{ matrix.qt_ver }}:p
             ccache:p
             nsis:p
@@ -154,7 +155,7 @@ jobs:
       - name: Install Qt (Linux)
         if: runner.os == 'Linux' && matrix.qt_ver != 6
         run: |
-          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
+          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5 libqt5charts5-dev
  
       - name: Install Qt (macOS and AppImage)
         if: runner.os == 'Linux' && matrix.qt_ver == 6 || runner.os == 'macOS'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,8 @@ set(Launcher_BUILD_TIMESTAMP "${TODAY}")
 include(QtVersionlessBackport)
 if(Launcher_QT_VERSION_MAJOR EQUAL 5)
     set(QT_VERSION_MAJOR 5)
-    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent Network Test Xml)
+    find_package(Qt5 REQUIRED COMPONENTS Core Widgets Concurrent Network Test
+      Xml Charts)
 
     if(NOT Launcher_FORCE_BUNDLED_LIBS)
         find_package(QuaZip-Qt5 1.3 QUIET)
@@ -164,7 +165,8 @@ if(Launcher_QT_VERSION_MAJOR EQUAL 5)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUNICODE -D_UNICODE")
 elseif(Launcher_QT_VERSION_MAJOR EQUAL 6)
     set(QT_VERSION_MAJOR 6)
-    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Network Test Xml Core5Compat)
+    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Concurrent Network Test
+      Xml Charts Core5Compat)
     list(APPEND Launcher_QT_LIBS Qt6::Core5Compat)
 
     if(NOT Launcher_FORCE_BUNDLED_LIBS)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -996,7 +996,7 @@ target_link_libraries(Launcher_logic
     Qt${QT_VERSION_MAJOR}::Concurrent
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Widgets
-    Qt${QT_VERSION_MAJOR}Charts
+    Qt${QT_VERSION_MAJOR}::Charts
     ${Launcher_QT_LIBS}
 )
 target_link_libraries(Launcher_logic

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -996,6 +996,7 @@ target_link_libraries(Launcher_logic
     Qt${QT_VERSION_MAJOR}::Concurrent
     Qt${QT_VERSION_MAJOR}::Gui
     Qt${QT_VERSION_MAJOR}::Widgets
+    Qt${QT_VERSION_MAJOR}Charts
     ${Launcher_QT_LIBS}
 )
 target_link_libraries(Launcher_logic

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -694,6 +694,8 @@ SET(LAUNCHER_SOURCES
     ui/pages/instance/ServersPage.h
     ui/pages/instance/WorldListPage.cpp
     ui/pages/instance/WorldListPage.h
+    ui/pages/instance/StoragePage.cpp
+    ui/pages/instance/StoragePage.h
 
     # GUI - global settings pages
     ui/pages/global/AccountListPage.cpp
@@ -910,6 +912,7 @@ qt_wrap_ui(LAUNCHER_UI
     ui/pages/instance/VersionPage.ui
     ui/pages/instance/WorldListPage.ui
     ui/pages/instance/ScreenshotsPage.ui
+    ui/pages/instance/StoragePage.ui
     ui/pages/modplatform/atlauncher/AtlOptionalModDialog.ui
     ui/pages/modplatform/atlauncher/AtlPage.ui
     ui/pages/modplatform/VanillaPage.ui

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -16,6 +16,7 @@
 #include "ui/pages/instance/WorldListPage.h"
 #include "ui/pages/instance/ServersPage.h"
 #include "ui/pages/instance/GameOptionsPage.h"
+#include "ui/pages/instance/StoragePage.h"
 
 class InstancePageProvider : public QObject, public BasePageProvider
 {
@@ -46,6 +47,7 @@ public:
         // values.append(new GameOptionsPage(onesix.get()));
         values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
         values.append(new InstanceSettingsPage(onesix.get()));
+        values.append(new StoragePage(onesix.get()));
         auto logMatcher = inst->getLogFileMatcher();
         if(logMatcher)
         {

--- a/launcher/resources/OSX/OSX.qrc
+++ b/launcher/resources/OSX/OSX.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/OSX/scalable/storage.svg
+++ b/launcher/resources/OSX/scalable/storage.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 24 24"
+   enable-background="new 0 0 24 24"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs80" />
+<rect
+   fill="none"
+   width="24"
+   height="24"
+   id="rect66" />
+
+
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#FFFFFF"
+   d="M18.5,5h-1.1c0-0.6-0.6-1-1.4-1c-0.8,0-1.4,0.4-1.4,1h-1.1v2h5V5z"
+   id="path75" />
+<g
+   id="g3784"
+   transform="matrix(0.73845672,0,0,0.73845672,4.237417,0.430303)"
+   style="fill:#e6e6e6;fill-opacity:1;stroke:#585858;stroke-opacity:1"><rect
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#585858;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1197"
+     width="17.458458"
+     height="17.458458"
+     x="7.1934299"
+     y="6.9381723"
+     ry="2.1458371" /><rect
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#585858;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1774"
+     width="17.458458"
+     height="6.6479607"
+     x="7.1934299"
+     y="17.748669"
+     ry="1.7275306" /><circle
+     style="fill:#585858;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path1828"
+     cx="21.224644"
+     cy="21.072649"
+     r="0.95399094" /></g></svg>

--- a/launcher/resources/flat/flat.qrc
+++ b/launcher/resources/flat/flat.qrc
@@ -40,6 +40,7 @@
         <file>scalable/status-good.svg</file>
         <file>scalable/status-running.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/flat/scalable/storage.svg
+++ b/launcher/resources/flat/scalable/storage.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   fill="#757575"
+   height="24"
+   viewBox="0 0 24 24"
+   width="24"
+   version="1.1"
+   id="svg1594"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1598" />
+  <g
+     id="g3784-3"
+     transform="matrix(1.0718486,0,0,1.0718486,-5.0666791,-4.7930816)"
+     style="fill:#757575;fill-opacity:1;stroke:#757575;stroke-opacity:1">
+    <rect
+       style="fill:#757575;fill-opacity:1;stroke:#757575;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1197-6"
+       width="17.458458"
+       height="17.458458"
+       x="7.1934299"
+       y="6.9381723"
+       ry="2.1458371" />
+    <rect
+       style="fill:#757575;fill-opacity:1;stroke:#757575;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1774-7"
+       width="17.458458"
+       height="6.6479607"
+       x="7.1934299"
+       y="17.748669"
+       ry="1.7275306" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:#757575;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path1828-5"
+       cx="21.224644"
+       cy="21.072649"
+       r="0.95399094" />
+  </g>
+  <g
+     id="g3784"
+     transform="matrix(0.95836194,0,0,0.95836194,-3.2596703,-3.0150411)"
+     style="fill:#757575;fill-opacity:1;stroke:#ffffff;stroke-opacity:1">
+    <rect
+       style="fill:#757575;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1197"
+       width="17.458458"
+       height="17.458458"
+       x="7.1934299"
+       y="6.9381723"
+       ry="2.1458371" />
+    <rect
+       style="fill:#757575;fill-opacity:1;stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1774"
+       width="17.458458"
+       height="6.6479607"
+       x="7.1934299"
+       y="17.748669"
+       ry="1.7275306" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path1828"
+       cx="21.224644"
+       cy="21.072649"
+       r="0.95399094" />
+  </g>
+</svg>

--- a/launcher/resources/iOS/iOS.qrc
+++ b/launcher/resources/iOS/iOS.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/iOS/scalable/storage.svg
+++ b/launcher/resources/iOS/scalable/storage.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 32 32"
+   xml:space="preserve"
+   sodipodi:docname="storage.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview1540"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="4.9939416"
+   inkscape:cx="20.925355"
+   inkscape:cy="15.618925"
+   inkscape:window-width="909"
+   inkscape:window-height="1064"
+   inkscape:window-x="1001"
+   inkscape:window-y="6"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Calque_1" /><defs
+   id="defs5152" />
+
+<g
+   id="g3784"
+   transform="matrix(1.4769134,0,0,1.4769134,-7.5163878,-7.1393945)"
+   style="stroke:#3366cc;stroke-opacity:1"><rect
+     style="fill:none;stroke:#3366cc;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1197"
+     width="17.458458"
+     height="17.458458"
+     x="7.1934299"
+     y="6.9381723"
+     ry="2.1458371" /><rect
+     style="fill:none;stroke:#3366cc;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1774"
+     width="17.458458"
+     height="6.6479607"
+     x="7.1934299"
+     y="17.748669"
+     ry="1.7275306" /><circle
+     style="fill:#3366cc;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+     id="path1828"
+     cx="21.224644"
+     cy="21.072649"
+     r="0.95399094" /></g></svg>

--- a/launcher/resources/pe_blue/pe_blue.qrc
+++ b/launcher/resources/pe_blue/pe_blue.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/pe_blue/scalable/storage.svg
+++ b/launcher/resources/pe_blue/scalable/storage.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 32 32"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs4421" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#3366CC"
+   d="M26,32H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h20c3.3,0,6,2.7,6,6  v20C32,29.3,29.3,32,26,32z"
+   id="path4374" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#DAEEFF"
+   d="M28,6c0-1.1-0.9-2-2-2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20  c1.1,0,2-0.9,2-2V6z"
+   id="path4376" />
+
+<g
+   id="g4388">
+</g>
+<g
+   id="g4390">
+</g>
+<g
+   id="g4392">
+</g>
+<g
+   id="g4394">
+</g>
+<g
+   id="g4396">
+</g>
+<g
+   id="g4398">
+</g>
+<g
+   id="g4400">
+</g>
+<g
+   id="g4402">
+</g>
+<g
+   id="g4404">
+</g>
+<g
+   id="g4406">
+</g>
+<g
+   id="g4408">
+</g>
+<g
+   id="g4410">
+</g>
+<g
+   id="g4412">
+</g>
+<g
+   id="g4414">
+</g>
+<g
+   id="g4416">
+</g>
+<g
+   id="g3784"
+   transform="translate(0.07734108,0.33259869)"
+   style="stroke:#666666;stroke-opacity:1"><rect
+     style="fill:none;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1197"
+     width="17.458458"
+     height="17.458458"
+     x="7.1934299"
+     y="6.9381723"
+     ry="2.1458371" /><rect
+     style="fill:none;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1774"
+     width="17.458458"
+     height="6.6479607"
+     x="7.1934299"
+     y="17.748669"
+     ry="1.7275306" /><circle
+     style="fill:#666666;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+     id="path1828"
+     cx="21.224644"
+     cy="21.072649"
+     r="0.95399094" /></g></svg>

--- a/launcher/resources/pe_colored/pe_colored.qrc
+++ b/launcher/resources/pe_colored/pe_colored.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/pe_colored/scalable/storage.svg
+++ b/launcher/resources/pe_colored/scalable/storage.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 32 32"
+   xml:space="preserve"
+   sodipodi:docname="storage.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+   id="namedview271"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="9.9878833"
+   inkscape:cx="15.468743"
+   inkscape:cy="20.524869"
+   inkscape:window-width="909"
+   inkscape:window-height="1064"
+   inkscape:window-x="1001"
+   inkscape:window-y="6"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g3784" /><defs
+   id="defs3662" />
+<g
+   id="g3645">
+	<rect
+   x="6"
+   y="0"
+   fill="none"
+   width="20"
+   height="0"
+   id="rect3635" />
+	<polygon
+   fill="none"
+   points="0,6 0,6 0,26 0,26 0,9  "
+   id="polygon3637" />
+	<polygon
+   fill="none"
+   points="32,6 32,9 32,26 32,26 32,6  "
+   id="polygon3639" />
+	<path
+   fill="#39B54A"
+   d="M32,9V6c0-3.3-2.7-6-6-6H6C2.7,0,0,2.7,0,6v3H32z"
+   id="path3641" />
+	<path
+   fill="#8C6239"
+   d="M0,9v17c0,3.3,2.7,6,6,6h20c3.3,0,6-2.7,6-6V9H0z"
+   id="path3643" />
+</g>
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#F2F2F2"
+   d="M28,6c0-1.1-0.9-2-2-2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20  c1.1,0,2-0.9,2-2V6z"
+   id="path3647" />
+
+<g
+   id="g3784"
+   transform="translate(0.07734108,0.33259869)"
+   style="stroke:#666666;stroke-opacity:1"><rect
+     style="fill:none;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1197"
+     width="17.458458"
+     height="17.458458"
+     x="7.1934299"
+     y="6.9381723"
+     ry="2.1458371" /><rect
+     style="fill:none;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+     id="rect1774"
+     width="17.458458"
+     height="6.6479607"
+     x="7.1934299"
+     y="17.748669"
+     ry="1.7275306" /><circle
+     style="fill:#666666;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+     id="path1828"
+     cx="21.224644"
+     cy="21.072649"
+     r="0.95399094" /></g></svg>

--- a/launcher/resources/pe_dark/pe_dark.qrc
+++ b/launcher/resources/pe_dark/pe_dark.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/pe_dark/scalable/storage.svg
+++ b/launcher/resources/pe_dark/scalable/storage.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 32 32"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs2339" />
+
+
+
+<g
+   id="g2306">
+</g>
+<g
+   id="g2308">
+</g>
+<g
+   id="g2310">
+</g>
+<g
+   id="g2312">
+</g>
+<g
+   id="g2314">
+</g>
+<g
+   id="g2316">
+</g>
+<g
+   id="g2318">
+</g>
+<g
+   id="g2320">
+</g>
+<g
+   id="g2322">
+</g>
+<g
+   id="g2324">
+</g>
+<g
+   id="g2326">
+</g>
+<g
+   id="g2328">
+</g>
+<g
+   id="g2330">
+</g>
+<g
+   id="g2332">
+</g>
+<g
+   id="g2334">
+</g>
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#f2f2f2"
+   d="m 26.077341,32.020895 h -20 c -3.3,0 -6.00000002,-2.7 -6.00000002,-6 V 6.0208954 c 0,-3.3 2.70000002,-5.99999999 6.00000002,-5.99999999 h 20 c 3.3,0 6,2.69999999 6,5.99999999 V 26.020895 c 0,3.3 -2.7,6 -6,6 z"
+   id="path659"
+   style="fill:#000000;fill-opacity:1" /><path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#4d4d4d"
+   d="m 28.077341,6.0208954 c 0,-1.1 -0.9,-2 -2,-2 h -20 c -1.1,0 -2,0.9 -2,2 V 26.020895 c 0,1.1 0.9,2 2,2 h 20 c 1.1,0 2,-0.9 2,-2 z"
+   id="path661"
+   style="fill:#f2f2f2;fill-opacity:1;stroke:none;stroke-opacity:1" /><rect
+   style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+   id="rect1197"
+   width="17.458458"
+   height="17.458458"
+   x="7.270771"
+   y="6.9590669"
+   ry="2.1458371" /><rect
+   style="fill:none;stroke:#666666;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+   id="rect1774"
+   width="17.458458"
+   height="6.6479607"
+   x="7.270771"
+   y="17.769564"
+   ry="1.7275306" /><circle
+   style="fill:#666666;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+   id="path1828"
+   cx="21.301985"
+   cy="21.093542"
+   r="0.95399094" /></svg>

--- a/launcher/resources/pe_light/pe_light.qrc
+++ b/launcher/resources/pe_light/pe_light.qrc
@@ -32,6 +32,7 @@
         <file>scalable/status-bad.svg</file>
         <file>scalable/status-good.svg</file>
         <file>scalable/status-yellow.svg</file>
+        <file>scalable/storage.svg</file>
         <file>scalable/viewfolder.svg</file>
         <file>scalable/worlds.svg</file>
     </qresource>

--- a/launcher/resources/pe_light/scalable/storage.svg
+++ b/launcher/resources/pe_light/scalable/storage.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Calque_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 32 32"
+   enable-background="new 0 0 32 32"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs706" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#F2F2F2"
+   d="M26,32H6c-3.3,0-6-2.7-6-6V6c0-3.3,2.7-6,6-6h20c3.3,0,6,2.7,6,6  v20C32,29.3,29.3,32,26,32z"
+   id="path659" />
+<path
+   fill-rule="evenodd"
+   clip-rule="evenodd"
+   fill="#4D4D4D"
+   d="M28,6c0-1.1-0.9-2-2-2H6C4.9,4,4,4.9,4,6v20c0,1.1,0.9,2,2,2h20  c1.1,0,2-0.9,2-2V6z"
+   id="path661" />
+
+<g
+   id="g673">
+</g>
+<g
+   id="g675">
+</g>
+<g
+   id="g677">
+</g>
+<g
+   id="g679">
+</g>
+<g
+   id="g681">
+</g>
+<g
+   id="g683">
+</g>
+<g
+   id="g685">
+</g>
+<g
+   id="g687">
+</g>
+<g
+   id="g689">
+</g>
+<g
+   id="g691">
+</g>
+<g
+   id="g693">
+</g>
+<g
+   id="g695">
+</g>
+<g
+   id="g697">
+</g>
+<g
+   id="g699">
+</g>
+<g
+   id="g701">
+</g>
+<rect
+   style="fill:none;stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none"
+   id="rect1197"
+   width="17.458458"
+   height="17.458458"
+   x="7.1934299"
+   y="6.9381723"
+   ry="2.1458371" /><rect
+   style="fill:none;stroke:#ffffff;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none"
+   id="rect1774"
+   width="17.458458"
+   height="6.6479607"
+   x="7.1934299"
+   y="17.748669"
+   ry="1.7275306" /><circle
+   style="fill:#ffffff;stroke:none;stroke-width:1.5;stroke-linecap:round;stroke-dasharray:none"
+   id="path1828"
+   cx="21.224644"
+   cy="21.072649"
+   r="0.95399094" /></svg>

--- a/launcher/ui/pages/instance/StoragePage.cpp
+++ b/launcher/ui/pages/instance/StoragePage.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  PolyMC - Minecraft Launcher
+ *  Copyright (c) 2022 Slendi <slendi@socopon.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "StoragePage.h"
+#include <QTabBar>
+#include "ui_StoragePage.h"
+
+#include <filesystem>
+#include <string>
+
+unsigned get_directory_size(std::string path)
+{
+    if (!std::filesystem::exists(path))
+        return 0;
+    unsigned file_size_total = 0;
+    for (auto const& entry : std::filesystem::directory_iterator(path)) {
+        if (entry.is_directory())
+            file_size_total += get_directory_size(entry.path().string());
+        else
+            file_size_total += entry.file_size();
+    }
+    return file_size_total;
+}
+
+void clear_directory_inner(std::string path)
+{
+    if (!std::filesystem::exists(path))
+        return;
+
+    for (auto const& entry : std::filesystem::directory_iterator(path))
+        std::filesystem::remove_all(entry);
+}
+
+StoragePage::StoragePage(BaseInstance* inst, QWidget* parent) : QWidget(parent), ui(new Ui::StoragePage), m_inst(inst)
+{
+    ui->setupUi(this);
+
+    update_calculations();
+}
+
+StoragePage::~StoragePage()
+{
+    delete ui;
+}
+
+bool StoragePage::apply()
+{
+    return true;
+}
+
+void StoragePage::retranslate()
+{
+    ui->retranslateUi(this);
+}
+
+void StoragePage::HandleClearScreenshotsButton()
+{
+    auto path = (m_inst->gameRoot() + "/screenshots").toStdString();
+    clear_directory_inner(path);
+    update_calculations();
+}
+
+void StoragePage::HandleClearLogsButton()
+{
+    auto path = (m_inst->gameRoot() + "/logs").toStdString();
+    clear_directory_inner(path);
+    update_calculations();
+}
+
+void StoragePage::HandleClearAllButton()
+{
+    HandleClearScreenshotsButton();
+    HandleClearLogsButton();
+}
+
+void StoragePage::update_calculations()
+{
+    m_size_resource_packs = get_directory_size((m_inst->gameRoot() + "/texturepacks").toStdString()) +
+                            get_directory_size((m_inst->gameRoot() + "/resourcepacks").toStdString());
+    m_size_mods = get_directory_size(m_inst->modsRoot().toStdString());
+    m_size_saves = get_directory_size((m_inst->gameRoot() + "/saves").toStdString());
+    m_size_screenshots = get_directory_size((m_inst->gameRoot() + "/screenshots").toStdString());
+    m_size_logs = get_directory_size((m_inst->gameRoot() + "/logs").toStdString());
+
+    QLocale locale = this->locale();
+    ui->label_resource_packs->setText(locale.formattedDataSize(m_size_resource_packs));
+    ui->label_mods->setText(locale.formattedDataSize(m_size_mods));
+    ui->label_saves->setText(locale.formattedDataSize(m_size_saves));
+    ui->label_screenshots->setText(locale.formattedDataSize(m_size_screenshots));
+    ui->label_logs->setText(locale.formattedDataSize(m_size_logs));
+    ui->label_combined->setText(
+        locale.formattedDataSize(m_size_resource_packs + m_size_mods + m_size_saves + m_size_screenshots + m_size_logs));
+
+    connect(ui->button_clear_screenshots, &QPushButton::clicked, this, &StoragePage::HandleClearScreenshotsButton);
+    connect(ui->button_clear_logs, &QPushButton::clicked, this, &StoragePage::HandleClearLogsButton);
+    connect(ui->button_clear_all, &QPushButton::clicked, this, &StoragePage::HandleClearAllButton);
+}

--- a/launcher/ui/pages/instance/StoragePage.cpp
+++ b/launcher/ui/pages/instance/StoragePage.cpp
@@ -50,11 +50,11 @@ StoragePage::StoragePage(BaseInstance* inst, QWidget* parent) : QWidget(parent),
     m_confirmation_box->addButton(QMessageBox::No);
     m_confirmation_box->setDefaultButton(QMessageBox::No);
 
-    m_series = new QtCharts::QPieSeries(this);
+    m_series = new QPieSeries(this);
     m_series->setLabelsVisible();
-    m_series->setLabelsPosition(QtCharts::QPieSlice::LabelInsideHorizontal);
-    m_chart_view = new QtCharts::QChartView(this);
-    m_chart = new QtCharts::QChart();
+    m_series->setLabelsPosition(QPieSlice::LabelInsideHorizontal);
+    m_chart_view = new QChartView(this);
+    m_chart = new QChart();
     m_chart->setParent(this);
     m_chart->addSeries(m_series);
     m_chart->setBackgroundVisible(false);

--- a/launcher/ui/pages/instance/StoragePage.h
+++ b/launcher/ui/pages/instance/StoragePage.h
@@ -22,10 +22,14 @@
 #pragma once
 
 #include <QWidget>
+#include <QtCharts/QChartView>
+#include <QtCharts/QPieSeries>
+#include <QtCharts/QPieSlice>
 
 #include "BaseInstance.h"
 #include "ui/pages/BasePage.h"
 #include <Application.h>
+#include <qmessagebox.h>
 
 namespace Ui
 {
@@ -61,15 +65,19 @@ public:
     }
     void retranslate() override;
 
-    void HandleClearScreenshotsButton();
-    void HandleClearLogsButton();
-    void HandleClearAllButton();
+    void handleClearScreenshotsButton();
+    void handleClearLogsButton();
+    void handleClearAllButton();
 
-    void update_calculations();
+    void updateCalculations();
 
 private:
     Ui::StoragePage *ui;
     BaseInstance *m_inst;
 
-    unsigned m_size_resource_packs, m_size_mods, m_size_saves, m_size_screenshots, m_size_logs;
+    QtCharts::QPieSeries *m_series;
+    QtCharts::QChart *m_chart;
+    QtCharts::QChartView *m_chart_view;
+
+    QMessageBox *m_confirmation_box;
 };

--- a/launcher/ui/pages/instance/StoragePage.h
+++ b/launcher/ui/pages/instance/StoragePage.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  PolyMC - Minecraft Launcher
+ *  Copyright (c) 2022 Slendi <slendi@socopon.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ */
+
+#pragma once
+
+#include <QWidget>
+
+#include "BaseInstance.h"
+#include "ui/pages/BasePage.h"
+#include <Application.h>
+
+namespace Ui
+{
+class StoragePage;
+}
+
+class StoragePage : public QWidget, public BasePage
+{
+    Q_OBJECT
+
+public:
+    explicit StoragePage(BaseInstance *inst, QWidget *parent = 0);
+    virtual ~StoragePage();
+    virtual QString displayName() const override
+    {
+        return tr("Storage");
+    }
+    virtual QIcon icon() const override
+    {
+        auto icon = APPLICATION->getThemedIcon("notes");
+        if(icon.isNull())
+            icon = APPLICATION->getThemedIcon("news");
+        return icon;
+    }
+    virtual QString id() const override
+    {
+        return "storage";
+    }
+    virtual bool apply() override;
+    virtual QString helpPage() const override
+    {
+        return "Storage";
+    }
+    void retranslate() override;
+
+    void HandleClearScreenshotsButton();
+    void HandleClearLogsButton();
+    void HandleClearAllButton();
+
+    void update_calculations();
+
+private:
+    Ui::StoragePage *ui;
+    BaseInstance *m_inst;
+
+    unsigned m_size_resource_packs, m_size_mods, m_size_saves, m_size_screenshots, m_size_logs;
+};

--- a/launcher/ui/pages/instance/StoragePage.h
+++ b/launcher/ui/pages/instance/StoragePage.h
@@ -31,6 +31,10 @@
 #include <Application.h>
 #include <qmessagebox.h>
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+using namespace QtCharts;
+#endif
+
 namespace Ui
 {
 class StoragePage;
@@ -75,9 +79,9 @@ private:
     Ui::StoragePage *ui;
     BaseInstance *m_inst;
 
-    QtCharts::QPieSeries *m_series;
-    QtCharts::QChart *m_chart;
-    QtCharts::QChartView *m_chart_view;
+    QPieSeries *m_series;
+    QChart *m_chart;
+    QChartView *m_chart_view;
 
     QMessageBox *m_confirmation_box;
 };

--- a/launcher/ui/pages/instance/StoragePage.h
+++ b/launcher/ui/pages/instance/StoragePage.h
@@ -45,7 +45,7 @@ public:
     }
     virtual QIcon icon() const override
     {
-        auto icon = APPLICATION->getThemedIcon("notes");
+        auto icon = APPLICATION->getThemedIcon("storage");
         if(icon.isNull())
             icon = APPLICATION->getThemedIcon("news");
         return icon;

--- a/launcher/ui/pages/instance/StoragePage.ui
+++ b/launcher/ui/pages/instance/StoragePage.ui
@@ -13,6 +13,62 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="3">
+      <widget class="QPushButton" name="button_clear_screenshots">
+       <property name="text">
+        <string>Clear Screenshots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QLabel" name="label_remaining">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Disk space used</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_screenshots">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="label_combined">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Disk space remaining</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="label_used">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_saves">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="sizePolicy">
@@ -26,39 +82,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="label_resource_packs">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>0 B</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Mods</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="label_mods">
-       <property name="text">
-        <string>0 B</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_3">
        <property name="sizePolicy">
@@ -68,14 +91,20 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Saves</string>
+        <string>Worlds</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_saves">
+     <item row="7" column="3">
+      <widget class="QPushButton" name="pushButton_5">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
-        <string>0 B</string>
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -92,44 +121,10 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QLabel" name="label_screenshots">
+     <item row="5" column="3">
+      <widget class="QPushButton" name="button_clear_all">
        <property name="text">
-        <string>0 B</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QPushButton" name="button_clear_screenshots">
-       <property name="text">
-        <string>Clear Screenshots</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Logs</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="label_logs">
-       <property name="text">
-        <string>0 B</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QPushButton" name="button_clear_logs">
-       <property name="text">
-        <string>Clear Logs</string>
+        <string>Clear All</string>
        </property>
       </widget>
      </item>
@@ -146,22 +141,48 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="label_combined">
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_logs">
        <property name="text">
         <string>0 B</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="2">
-      <widget class="QPushButton" name="button_clear_all">
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>Clear all</string>
+        <string>Logs</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="pushButton">
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_mods">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_resource_packs">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="3">
+      <widget class="QPushButton" name="pushButton_4">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -173,46 +194,80 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="pushButton_3">
-       <property name="enabled">
-        <bool>false</bool>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
        <property name="text">
-        <string/>
+        <string>Mods</string>
        </property>
-       <property name="flat">
-        <bool>true</bool>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="QPushButton" name="button_clear_logs">
+       <property name="text">
+        <string>Clear Logs</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QPushButton" name="pushButton_2">
+      <widget class="QPushButton" name="button_goto_resouce_packs">
        <property name="enabled">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <property name="text">
-        <string/>
+        <string>Go to Resource packs</string>
        </property>
        <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="button_goto_mods">
+       <property name="enabled">
         <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Go to Mods</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPushButton" name="button_goto_worlds">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Go to Worlds</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QPushButton" name="button_goto_other_logs">
+       <property name="text">
+        <string>Go to Other Logs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QPushButton" name="button_goto_screenshots">
+       <property name="text">
+        <string>Go to Screenshots</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/launcher/ui/pages/instance/StoragePage.ui
+++ b/launcher/ui/pages/instance/StoragePage.ui
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StoragePage</class>
+ <widget class="QWidget" name="StoragePage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>731</width>
+    <height>538</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Resource packs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_resource_packs">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Mods</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="label_mods">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Saves</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="label_saves">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Screenshots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_screenshots">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QPushButton" name="button_clear_screenshots">
+       <property name="text">
+        <string>Clear Screenshots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Logs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="label_logs">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QPushButton" name="button_clear_logs">
+       <property name="text">
+        <string>Clear Logs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Combined</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="label_combined">
+       <property name="text">
+        <string>0 B</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QPushButton" name="button_clear_all">
+       <property name="text">
+        <string>Clear all</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPushButton" name="pushButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="pushButton_3">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="pushButton_2">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="flat">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This patch adds a new page to instance settings which allows users to manage storage. 

This PR aims to fix the following issue: #1189.

Features:
- [x] Basic display of storage occupied.
- [x] Display remaining disk space.
- [x] Create graph.