### PR TITLE
fix: prevent stack overflow in ConcurrentTask

### DIFF
--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -101,9 +101,8 @@ void ConcurrentTask::startNext()
     setStepStatus(next->isMultiStep() ? next->getStepStatus() : next->getStatus());
     updateState();
 
-    QCoreApplication::processEvents();
-
-    next->start();
+    QMetaObject::invokeMethod(
+        this, [=] { next->start(); }, Qt::QueuedConnection);
 }
 
 void ConcurrentTask::subTaskSucceeded(Task::Ptr task)


### PR DESCRIPTION
This fixes the stack overflow when opening the ATLauncher mod list on Windows at the root cause instead of working around it by increasing the stack size like #1503 does.