### PR TITLE
fix(MMCZip): ignore invalid file paths in extractSubDir

### DIFF
--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -292,8 +292,13 @@ std::optional<QStringList> MMCZip::extractSubDir(QuaZip *zip, const QString & su
     do
     {
         QString name = zip->getCurrentFileName();
-        if(!name.startsWith(subdir))
+        if(!QDir::cleanPath(name).startsWith(subdir))
         {
+            continue;
+        }
+        if (QDir::isAbsolutePath(name) || QDir::cleanPath(name).startsWith(".."))
+        {
+            qDebug() << "extractSubDir: Skipping file that tries to place itself in an absolute location or in a parent directory.";
             continue;
         }
 


### PR DESCRIPTION
Ignores files that have an absolute path or a path beginning with ..