### PR TITLE
Add flag to build with or without DRM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(Launcher_DISCORD_URL "https://discord.gg/Z52pwxWCHP" CACHE STRING "URL for t
 set(Launcher_SUBREDDIT_URL "https://www.reddit.com/r/PolyMCLauncher/" CACHE STRING "URL for the subreddit.")
 
 # Builds
+set(Launcher_DRM ON CACHE BOOL "Offline mode requires a premium account if enabled")
 set(Launcher_FORCE_BUNDLED_LIBS OFF CACHE BOOL "Prevent using system libraries, if they are available as submodules")
 set(Launcher_QT_VERSION_MAJOR "5" CACHE STRING "Major Qt version to build against")
 

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -112,6 +112,8 @@ Config::Config()
     MATRIX_URL = "@Launcher_MATRIX_URL@";
     DISCORD_URL = "@Launcher_DISCORD_URL@";
     SUBREDDIT_URL = "@Launcher_SUBREDDIT_URL@";
+    
+    DRM = @Launcher_DRM@;
 }
 
 QString Config::versionString() const

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -35,6 +35,9 @@
  *      limitations under the License.
  */
 
+#define ON true
+#define OFF false
+
 #pragma once
 #include <QString>
 
@@ -141,6 +144,8 @@ class Config {
     QString MATRIX_URL;
     QString DISCORD_URL;
     QString SUBREDDIT_URL;
+    
+    bool DRM;
 
     QString RESOURCE_BASE = "https://resources.download.minecraft.net/";
     QString LIBRARY_BASE = "https://libraries.minecraft.net/";

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -188,7 +188,7 @@ void AccountListPage::on_actionAddMicrosoft_triggered()
 
 void AccountListPage::on_actionAddOffline_triggered()
 {
-    if (!m_accounts->anyAccountIsValid()) {
+    if (BuildConfig.DRM && !m_accounts->anyAccountIsValid()) {
         QMessageBox::warning(
             this,
             tr("Error"),

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -36,6 +36,8 @@
 
 #include "Application.h"
 
+#include "BuildConfig.h"
+
 #include <QMessageBox>
 #include <QLabel>
 #include <QEvent>
@@ -422,7 +424,7 @@ void VersionPage::on_actionChange_version_triggered()
 
 void VersionPage::on_actionDownload_All_triggered()
 {
-    if (!APPLICATION->accounts()->anyAccountIsValid())
+    if (BuildConfig.DRM && !APPLICATION->accounts()->anyAccountIsValid())
     {
         CustomMessageBox::selectable(
             this, tr("Error"),


### PR DESCRIPTION
Adds a CMake flag that controls whether or not the build will lock offline mode behind logging in with a premium account.
Defaults to including DRM but can be disabled by adding ``-DLauncher_DRM=OFF`` to the build flags.