### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -260,7 +260,7 @@ QString MinecraftInstance::getLocalLibraryPath() const
 bool MinecraftInstance::supportsDemo() const
 {
     Version instance_ver { getPackProfile()->getComponentVersion("net.minecraft") };
-    // Demo mode was introduced in 1.3.1: https://minecraft.fandom.com/wiki/Demo_mode#History
+    // Demo mode was introduced in 1.3.1: https://minecraft.wiki/w/Demo_mode#History
     // FIXME: Due to Version constraints atm, this can't handle well non-release versions
     return instance_ver >= Version("1.3.1");
 }

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -9,7 +9,7 @@
 #include "minecraft/mod/tasks/LocalResourcePackParseTask.h"
 
 // Values taken from:
-// https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+// https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 static const QMap<int, std::pair<Version, Version>> s_pack_format_versions = {
     { 1, { Version("1.6.1"), Version("1.8.9") } }, 
     { 2, { Version("1.9"), Version("1.10.2") } },

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -49,7 +49,7 @@ class ResourcePack : public Resource {
     mutable QMutex m_data_lock;
 
     /* The 'version' of a resource pack, as defined in the pack.mcmeta file.
-     * See https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+     * See https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
      */
     int m_pack_format = 0;
 

--- a/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
@@ -115,7 +115,7 @@ void processZIP(ResourcePack& pack)
     zip.close();
 }
 
-// https://minecraft.fandom.com/wiki/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
+// https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 void processMCMeta(ResourcePack& pack, QByteArray&& raw_data)
 {
     try {

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -107,14 +107,14 @@ QString InfoFrame::renderColorCodes(QString input) {
     //
     // TODO: Wrap links inside <a> tags
 
-    // https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes
+    // https://minecraft.wiki/w/Formatting_codes#Color_codes
     const QMap<QChar, QString> color_codes_map = {
         {'0', "#000000"}, {'1', "#0000AA"}, {'2', "#00AA00"}, {'3', "#00AAAA"}, {'4', "#AA0000"},
         {'5', "#AA00AA"}, {'6', "#FFAA00"}, {'7', "#AAAAAA"}, {'8', "#555555"}, {'9', "#5555FF"},
         {'a', "#55FF55"}, {'b', "#55FFFF"}, {'c', "#FF5555"}, {'d', "#FF55FF"}, {'e', "#FFFF55"},
         {'f', "#FFFFFF"}
     };
-    // https://minecraft.fandom.com/wiki/Formatting_codes#Formatting_codes
+    // https://minecraft.wiki/w/Formatting_codes#Formatting_codes
     const QMap<QChar, QString> formatting_codes_map = {
         {'l', "b"}, {'m', "s"}, {'n', "u"}, {'o', "i"}
     };


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.