### PR TITLE
don't set arbitrary minimum for jvm memory

### DIFF
--- a/launcher/ui/pages/global/JavaPage.ui
+++ b/launcher/ui/pages/global/JavaPage.ui
@@ -96,7 +96,7 @@
              <string notr="true"> MiB</string>
             </property>
             <property name="minimum">
-             <number>128</number>
+             <number>1</number>
             </property>
             <property name="maximum">
              <number>65536</number>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -151,7 +151,7 @@
              <string notr="true"> MiB</string>
             </property>
             <property name="minimum">
-             <number>128</number>
+             <number>1</number>
             </property>
             <property name="maximum">
              <number>65536</number>


### PR DESCRIPTION
Hard minimum was 128MiB for some reason, don't see why people shouldn't be able to choose. There are certain versions and mods of MC that can run with less.