### PR TITLE
fix hang when importing certain modpacks

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -164,22 +164,20 @@ void InstanceImportTask::processZipPack()
     }
     else
     {
-        QString mmcRoot = MMCZip::findFolderOfFileInZip(m_packZip.get(), "instance.cfg");
-        QString flameRoot = MMCZip::findFolderOfFileInZip(m_packZip.get(), "manifest.json");
-
-        if (!mmcRoot.isNull())
-        {
-            // process as MultiMC instance/pack
-            qDebug() << "MultiMC:" << mmcRoot;
-            root = mmcRoot;
-            m_modpackType = ModpackType::MultiMC;
-        }
-        else if(!flameRoot.isNull())
+        auto [rootDirectory, fileName] = MMCZip::findFolderOfFileInZip(m_packZip.get(), {"manifest.json", "instance.cfg"});
+        if(fileName == "manifest.json")
         {
             // process as Flame pack
-            qDebug() << "Flame:" << flameRoot;
-            root = flameRoot;
+            qDebug() << "Flame:" << rootDirectory;
+            root = rootDirectory;
             m_modpackType = ModpackType::Flame;
+        }
+        else if (fileName == "instance.cfg")
+        {
+            // process as MultiMC instance/pack
+            qDebug() << "MultiMC:" << rootDirectory;
+            root = rootDirectory;
+            m_modpackType = ModpackType::MultiMC;
         }
     }
     if(m_modpackType == ModpackType::Unknown)

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -78,11 +78,11 @@ namespace MMCZip
     bool createModdedJar(QString sourceJarPath, QString targetJarPath, const QList<Mod*>& mods);
 
     /**
-     * Find a single file in archive by file name (not path)
+     * Breath-first find a single file in archive by a list of file names (not path)
      *
-     * \return the path prefix where the file is
+     * \return pair of {file parent directory, file name}
      */
-    QString findFolderOfFileInZip(QuaZip * zip, const QString & what, const QString &root = QString(""));
+    std::pair<QString, QString> findFolderOfFileInZip(QuaZip * zip, QSet<const QString> what, const QString &root = QString(""));
 
     /**
      * Find a multiple files of the same name in archive by file name

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -285,7 +285,7 @@ void World::readFromZip(const QFileInfo &file)
     {
         return;
     }
-    auto location = MMCZip::findFolderOfFileInZip(&zip, "level.dat");
+    auto [location, _] = MMCZip::findFolderOfFileInZip(&zip, {"level.dat"});
     is_valid = !location.isEmpty();
     if (!is_valid)
     {


### PR DESCRIPTION
Modified findFolderOfFileInZip to use a breadth-first search and support searching for multiple file names in one pass. This should prevent or at least make it less likely to hang while importing certain packs.