### PR TITLE
Improve SDKMAN support; add ASDF support

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -448,7 +448,16 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDir("/opt/jdks");
     // flatpak
     scanJavaDir("/app/jdk");
-    scanJavaDir(FS::PathCombine(QDir::homePath(), ".sdkman/candidates/java"));
+
+    // Default SDKMAN directory can be overwritten via SDKMAN_DIR env var (default $HOME/.sdkman)
+    // see https://sdkman.io/install
+    auto sdkmanInstallPath = qEnvironmentVariable("SDKMAN_DIR", FS::PathCombine(QDir::homePath(), ".sdkman"));
+    scanJavaDir(FS::PathCombine(sdkmanInstallPath, "candidates/java"));
+    // Default ASDF directory can be overwritten via ASDF_DIR or ASDF_DATA_DIR env vars (default $HOME/.asdf)
+    // see https://asdf-vm.com/manage/configuration.html#asdf-dir
+    auto asdfDataPath = qEnvironmentVariable("ASDF_DATA_DIR", qEnvironmentVariable("ASDF_DIR", FS::PathCombine(QDir::homePath(), ".asdf")));
+    scanJavaDir(FS::PathCombine(asdfDataPath, "installs/java"));
+
     return addJavasFromEnv(javas);
 }
 #else


### PR DESCRIPTION
The #1631 is kinda straightforward and hardcodes SDKMAN directory path. The SDKMAN directory can be overwritten using the `SDKMAN_DIR` environment variable, so I created this PR to fix that issue.

I've also added [ASDF](https://asdf-vm.com/) support - it's similar to SDKMAN and very useful, so why not?

*I am not a C++ programmer, so I am open to suggestions for implementation and codestyle fixes*