### PR TITLE
Add wayland support to nix packages

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,6 +18,8 @@
 , extraJDKs ? [ ]
 , extra-cmake-modules
 , qtcharts
+, qtwayland
+, wayland
   # flake
 , self
 , version
@@ -36,6 +38,7 @@ let
     libXxf86vm
     libpulseaudio
     libGL
+    wayland
   ];
 
   # This variable will be passed to Minecraft by PolyMC
@@ -51,7 +54,7 @@ stdenv.mkDerivation rec {
   src = lib.cleanSource self;
 
   nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk ghc_filesystem file wrapQtAppsHook ];
-  buildInputs = [ qtbase quazip zlib qtcharts ];
+  buildInputs = [ qtbase quazip zlib qtcharts qtwayland ];
 
   dontWrapQtApps = true;
 


### PR DESCRIPTION
Add support for wayland display server in the nix package. Fixes #1186. I've tested this on my wayland system and both `polymc` and `polymc-qt6` packages work as expected now.
```sh
- system: `"x86_64-linux"`
 - host os: `Linux 6.8.1, NixOS, 24.05 (Uakari), 24.05.20240329.d8fe5e6`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.18.2`
```