### PR TITLE
Include JDK 21 into the nix derivation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,6 +6,7 @@
 , wrapQtAppsHook
 , jdk8
 , jdk17
+, jdk21
 , xorg
 , libpulseaudio
 , qtbase
@@ -16,7 +17,7 @@
 , wayland
 , qtwayland
 , msaClientID ? ""
-, jdks ? [ jdk17 jdk8 ]
+, jdks ? [ jdk21 jdk17 jdk8 ]
 , enableLTO ? false
   # flake
 , self

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -19,9 +19,9 @@
 , msaClientID ? ""
 , jdks ? [ jdk21 jdk17 jdk8 ]
 , enableLTO ? false
-  # flake
 , self
 , version
+  # flake
 }:
 
 let


### PR DESCRIPTION
This solves a small oversight. Now JDK 21 will be included so you can play versions of Minecraft equal or higher than 1.20.5