### PR TITLE
Update Nix package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712129508,
-        "narHash": "sha256-FBVpEX0eLiqX3jnSL3rmJHqHhbuCikJZyDyV3Cl3qAY=",
+        "lastModified": 1722141560,
+        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d03a4482228d4d6dbd2d4b425b6dfcd49ebe765f",
+        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     "tomlplusplus": {
       "flake": false,
       "locked": {
-        "lastModified": 1710824845,
-        "narHash": "sha256-A9XuCfVcLle/tMNaH7aqb1leM+t3wwC9ER5RIbMMovo=",
+        "lastModified": 1720775063,
+        "narHash": "sha256-9j8qNCITFPvKECY5Sjb2Ri5KcPzRrF0e7G2CUemIhBw=",
         "owner": "marzer",
         "repo": "tomlplusplus",
-        "rev": "1f7884e59165e517462f922e7b6de131bd9844f3",
+        "rev": "e2bae9d559b4956a831fcef10ac8f01c88cb0d13",
         "type": "github"
       },
       "original": {

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -3,12 +3,12 @@
 , cmake
 , ninja
 , jdk8
+, gamemode
 , ghc_filesystem
 , zlib
 , file
 , qtbase
 , quazip
-, msaClientID ? ""
 , extra-cmake-modules
 , qtcharts
 , qtwayland
@@ -17,6 +17,8 @@
 , version
 , libnbtplusplus
 , tomlplusplus
+, msaClientID ? ""
+, gamemodeSupport ? stdenv.isLinux
 , enableLTO ? false
 }:
 
@@ -27,7 +29,9 @@ stdenv.mkDerivation {
   src = lib.cleanSource self;
 
   nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk8 ghc_filesystem file ];
-  buildInputs = [ qtbase quazip zlib qtcharts ] ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
+  buildInputs = [ qtbase quazip zlib qtcharts ]
+    ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
+    ++ lib.optional gamemodeSupport gamemode;
 
   postUnpack = ''
     # Copy libnbtplusplus
@@ -47,6 +51,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-GNinja"
     "-DLauncher_QT_VERSION_MAJOR=${lib.versions.major qtbase.version}"
+    "-DLauncher_BUILD_PLATFORM=nix"
   ]
   ++ lib.optionals enableLTO [ "-DENABLE_LTO=on" ]
   ++ lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ];


### PR DESCRIPTION
- Updated Nix flake. This fixes theming, which was broken on newer systems due to a version mismatch.
- Added xrandr to the path inside the wrapped binary. Xrandr is required by older LWJGL versions. This allows launching old MC versions without a system Xrandr installation.
- Added options to the wrapped package that allow for the user to add additonal libraries or binaries.
- Added support for libgamemode
- Set BUILD_PLATFORM to nix to make nix builds identifiable