### PR TITLE
fix nix build on unstable-small

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , symlinkJoin
-, addOpenGLRunpath
+, addDriverRunpath
 , polymc-unwrapped
 , wrapQtAppsHook
 , jdk8
@@ -78,7 +78,7 @@ symlinkJoin {
     in
     [
       "--prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
-      "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
       "--prefix PATH : ${lib.makeBinPath runtimeBins}"
     ];
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/141803

The usage of addOpenGLRunpath has been deprecated in favor of addDriverRunpath.

This changes nothing for the unstable nixpkgs branch but fixes builds on unstable-small.