### PR TITLE
Skip empty Java paths in POLYMC_JAVA_PATHS

### DIFF
--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -41,6 +41,7 @@
 #include "java/JavaInstallList.h"
 #include "java/JavaCheckerJob.h"
 #include "java/JavaUtils.h"
+#include "FileSystem.h"
 #include "MMCStrings.h"
 #include "minecraft/VersionFilterData.h"
 
@@ -176,6 +177,8 @@ void JavaListLoadTask::executeTask()
     int id = 0;
     for(QString candidate : candidate_paths)
     {
+        if (FS::ResolveExecutable(candidate).isEmpty())
+            continue;
         qDebug() << " " << candidate;
 
         auto candidate_checker = new JavaChecker();

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -188,7 +188,8 @@ QStringList addJavasFromEnv(QList<QString> javas)
 #endif
     for(QString i : javaPaths)
     {
-        javas.append(i);
+        if (i != "")
+            javas.append(i);
     };
     return javas;
 }


### PR DESCRIPTION
If `POLYMC_JAVA_PATHS` is empty or unset, the Java checker tries to check an empty path for a valid Java binary. This has the undesirable effect of potentially attempting to kill a process with PID -1, or every process for which the launcher has permission to send signals.