### PR TITLE
Fix CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Setup ccache
         if: runner.os != 'Windows' && inputs.build_type == 'Debug'
-        uses: hendrikmuhs/ccache-action@v1.2.1
+        uses: hendrikmuhs/ccache-action@v1.2.18
         with:
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}
 
@@ -128,7 +128,7 @@ jobs:
 
       - name: Retrieve ccache cache (Windows)
         if: runner.os == 'Windows' && inputs.build_type == 'Debug'
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v3.4.3
         with:
           path: '${{ github.workspace }}\.ccache'
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         include:
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             qt_ver: 5
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             qt_ver: 6
             qt_host: linux
             qt_version: '6.2.4'
@@ -57,6 +57,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macosx_deployment_target }}
       INSTALL_DIR: "install"
       INSTALL_PORTABLE_DIR: "install-portable"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Retrieve ccache cache (Windows)
         if: runner.os == 'Windows' && inputs.build_type == 'Debug'
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v4.2.3
         with:
           path: '${{ github.workspace }}\.ccache'
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.15)  # minimum version required by QuaZip
 
-if(WIN32)
-    # In Qt 5.1+ we have our own main() function, don't autolink to qtmain on Windows
-    cmake_policy(SET CMP0020 OLD)
-endif()
+# if(WIN32)
+#     # In Qt 5.1+ we have our own main() function, don't autolink to qtmain on Windows
+#     cmake_policy(SET CMP0020 OLD)
+# endif()
 
 project(Launcher)
 


### PR DESCRIPTION
Everything tested, should work fine now.

Changes:
- Update Ubuntu from 20.04 to 22.04 due to deprecation
- Update actions/cache to v3.4.3 and hendrikmuhs/ccache-action to v1.2.18
- Remove `cmake_policy(SET CMP0020 OLD)` from the main CMakeList as its deprecated and no longer needed for QT 5