### PR TITLE
Disable __GL_THREADED_OPTIMIZATIONS on discrete graphics

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -495,6 +495,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
         env.insert("__NV_PRIME_RENDER_OFFLOAD", "1");
         env.insert("__VK_LAYER_NV_optimus", "NVIDIA_only");
         env.insert("__GLX_VENDOR_LIBRARY_NAME", "nvidia");
+        env.insert("__GL_THREADED_OPTIMIZATIONS", "0");
     }
 #endif
 


### PR DESCRIPTION
Fixes minecraft freezes/crashes when full-screening/exiting the game. 

The problem exists for like a year on all my devices and it also was reported on nvidia/reddit forums by users. On old versions, like 1.8.9 this happens every minecraft launch. On new versions I don't see the problem, but here might be some related artefacts (black line in bottom on random minecraft launch). 

The solution was found by a user on nvidia forum, but it seems, like no fix was applied: https://forums.developer.nvidia.com/t/opengl-crash-when-entering-fullscreen-on-rtx-3060-mobile-with-nvidia-dkms-555-58-02-minecraft/299192/26 

This PR implements a workaround in PolyMC useDiscreteGpu option.