### PR TITLE
Fix profile in use

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -90,6 +90,14 @@ MinecraftAccountPtr AccountList::getAccountByProfileName(const QString& profileN
     return nullptr;
 }
 
+MinecraftAccountPtr AccountList::getAccountByProfileId(const QString& profileId) const {
+    int idx = findAccountByProfileId(profileId);
+    if(idx == -1) {
+        return nullptr;
+    }
+    return at(idx);
+}
+
 const MinecraftAccountPtr AccountList::at(int i) const
 {
     return MinecraftAccountPtr(m_accounts.at(i));

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -85,6 +85,7 @@ public:
     void removeAccount(QModelIndex index);
     int findAccountByProfileId(const QString &profileId) const;
     MinecraftAccountPtr getAccountByProfileName(const QString &profileName) const;
+    MinecraftAccountPtr getAccountByProfileId(const QString &profileId) const;
     QStringList profileNames() const;
 
     // requesting a refresh pushes it to the front of the queue

--- a/launcher/minecraft/launch/ClaimAccount.cpp
+++ b/launcher/minecraft/launch/ClaimAccount.cpp
@@ -9,7 +9,7 @@ ClaimAccount::ClaimAccount(LaunchTask* parent, AuthSessionPtr session): LaunchSt
     if(session->status == AuthSession::Status::PlayableOnline && !session->demo)
     {
         auto accounts = APPLICATION->accounts();
-        m_account = accounts->getAccountByProfileName(session->player_name);
+        m_account = accounts->getAccountByProfileId(session->uuid);
     }
 }
 


### PR DESCRIPTION
There is a visual only bug in PolyMC which when there are multiple accounts with the same name and one is marked as in use, the UI will claim the first account it finds with the same profile name as in use, no matter if its the correct account or not. This is unaffected by account type and is only based off account name. The bug is purely visual