### PR TITLE
nix: rename glxinfo -> mesa-demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ result/
 # Flatpak
 .flatpak-builder
 flatbuild
+
+# Nix output
+result*

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733064805,
-        "narHash": "sha256-7NbtSLfZO0q7MXPl5hzA0sbVJt6pWxxtGWbaVUDDmjs=",
+        "lastModified": 1761880412,
+        "narHash": "sha256-QoJjGd4NstnyOG4mm4KXF+weBzA2AH/7gn1Pmpfcb0A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "31d66ae40417bb13765b0ad75dd200400e98de84",
+        "rev": "a7fc11be66bdfb5cdde611ee5ce381c183da8386",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     "tomlplusplus": {
       "flake": false,
       "locked": {
-        "lastModified": 1731586115,
-        "narHash": "sha256-FLZvfbMN3PwmBOqvMUxQe96/Yukk0OAFPeDzHcBYZhk=",
+        "lastModified": 1756542235,
+        "narHash": "sha256-qcc8yXND9htFqjQADU60+xoJZ0acoQwcs7tIK1LgAOg=",
         "owner": "marzer",
         "repo": "tomlplusplus",
-        "rev": "c4369ae1d8955cae20c4ab40b9813ef4b60e48be",
+        "rev": "e7aaccca3fa3dbde9818ab8313250f3da4976e37",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@
 , jdk21
 , xorg
 , gamemode
-, glxinfo
+, mesa-demos
 , libpulseaudio
 , qtbase
 , libGL
@@ -73,7 +73,7 @@ symlinkJoin {
       runtimeBins = [
         # Required by old LWJGL versions
         xorg.xrandr
-        glxinfo
+        mesa-demos # For glxinfo
       ] ++ additionalBins;
     in
     [


### PR DESCRIPTION
This updates nixpkgs and changes `glxinfo` to `mesa-demos` in accordance to an upstream rename. Furthermore, `result*` (nix output) has been added to .gitignore.