### PR TITLE
Added allowances for duplicating account names on different services/hosts

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -128,23 +128,40 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
     connect(account.get(), &MinecraftAccount::changed, this, &AccountList::accountChanged);
     connect(account.get(), &MinecraftAccount::activityChanged, this, &AccountList::accountActivityChanged);
 
-    // override/replace existing account with the same profileId
+    // override/replace existing account with the same profileId AND account type
     auto profileId = account->profileId();
     if(profileId.size()) {
         auto existingAccount = findAccountByProfileId(profileId);
         if(existingAccount != -1) {
-            qDebug() << "Replacing old account with a new one with the same profile ID!";
-
             MinecraftAccountPtr existingAccountPtr = m_accounts[existingAccount];
-            m_accounts[existingAccount] = account;
-            if(m_defaultAccount == existingAccountPtr) {
-                m_defaultAccount = account;
+            bool shouldReplace = false;
+            
+            // Check if account types match
+            if(existingAccountPtr->accountData()->type == account->accountData()->type) {
+                // For authlib injector accounts, also check the server URL
+                if(account->accountData()->type == AccountType::AuthlibInjector) {
+                    if(existingAccountPtr->accountData()->authlibInjectorBaseUrl == account->accountData()->authlibInjectorBaseUrl) {
+                        shouldReplace = true;
+                    }
+                } else {
+                    // For other account types, matching type is enough
+                    shouldReplace = true;
+                }
             }
-            // disconnect notifications for changes in the account being replaced
-            existingAccountPtr->disconnect(this);
-            emit dataChanged(index(existingAccount), index(existingAccount, columnCount(QModelIndex()) - 1));
-            onListChanged();
-            return;
+            
+            if(shouldReplace) {
+                qDebug() << "Replacing old account with a new one with the same profile ID, account type, and server!";
+
+                m_accounts[existingAccount] = account;
+                if(m_defaultAccount == existingAccountPtr) {
+                    m_defaultAccount = account;
+                }
+                // disconnect notifications for changes in the account being replaced
+                existingAccountPtr->disconnect(this);
+                emit dataChanged(index(existingAccount), index(existingAccount, columnCount(QModelIndex()) - 1));
+                onListChanged();
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
Found a bug where adding accounts would silently overwrite each other if they had the same username, even when they were completely different account types or from different servers.

Example scenarios that would cause overwrites:

Add a Microsoft account "steve" → works fine
Add an authlib injector account "steve" → MS account is gone

Also:
"steve" from authlib-server1.com and
"steve" from authlib-server2.com would overwrite each other

In AccountList::addAccount()  it only checked if the profileId matched and ignored the account type and server URL.

**The Fix**
Modified the account replacement logic to be smarter about what actually constitutes a "duplicate" account:

Profile ID must match (same as before)
Account type must match (new check)
For authlib injector accounts: The server URL must also match (new check)

Now accounts only replace each other if they're truly the same account being re-added, not just because they happen to share a username.

**Known Limitation:** Command-line --profile flag

The command-line --profile <username> flag still has ambiguity issues - it uses getAccountByProfileName() which just grabs the first account with a matching username.

If you have multiple accounts with the same username:

Using the UI to select accounts works with identifier, but Using --profile myusername Gets whichever account it finds first

I will update this PR with whatever feedback you offer to fix the ambiguity issue of the --profile