### PR TITLE
nix: Replace glxinfo with mesa-demos after package rename

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,7 +9,7 @@
 , jdk21
 , xorg
 , gamemode
-, glxinfo
+, mesa-demos
 , libpulseaudio
 , qtbase
 , libGL
@@ -73,7 +73,7 @@ symlinkJoin {
       runtimeBins = [
         # Required by old LWJGL versions
         xorg.xrandr
-        glxinfo
+        mesa-demos
       ] ++ additionalBins;
     in
     [


### PR DESCRIPTION
Replaced glxinfo dependency with mesa-demos after package rename