### PR TITLE
Fix mangohud feature

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1601,7 +1601,7 @@ void Application::updateCapabilities()
         m_capabilities |= SupportsGameMode;
 
     {
-        void *dummy = dlopen("libMangoHud_dlsym.so", RTLD_LAZY);
+        void *dummy = dlopen("libMangoHud_shim.so", RTLD_LAZY);
         // try normal variant as well
         if (dummy == NULL)
             dummy = dlopen("libMangoHud.so", RTLD_LAZY);

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1601,14 +1601,28 @@ void Application::updateCapabilities()
         m_capabilities |= SupportsGameMode;
 
     {
-        void *dummy = dlopen("libMangoHud_shim.so", RTLD_LAZY);
-        // try normal variant as well
-        if (dummy == NULL)
-            dummy = dlopen("libMangoHud.so", RTLD_LAZY);
+        /*
+         * Yes, we have other DLLS such as `libMangoHud_opengl.so` and `libMangoHud.so`.
+         * However, you're supposed to use the shim.
+         *
+         * As a fallback, we'll also look for `libMangoHud_dlsym.so`.
+         */
+        static std::vector<QString> MangoHudDLLs = {
+            "libMangoHud_shim.so",
+            "libMangoHud_dlsym.so"
+        };
 
-        if (dummy != NULL) {
-            dlclose(dummy);
-            m_capabilities |= SupportsMangoHud;
+        for (auto DLL: MangoHudDLLs)
+        {
+            void *dummy = dlopen(DLL.toStdString().c_str(), RTLD_LAZY);
+            
+            if (dummy != NULL) 
+            {
+                dlclose(dummy);
+                m_capabilities |= SupportsMangoHud;
+                m_chosenmango = DLL;
+                break;
+            }
         }
     }
 #endif

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -186,6 +186,10 @@ public:
         return m_capabilities;
     }
 
+    const QString &chosenmango() {
+        return m_chosenmango;
+    }
+
     /*!
      * Opens a json file using either a system default editor, or, if not empty, the editor
      * specified in the settings
@@ -264,6 +268,7 @@ private:
     QMap<QString, std::shared_ptr<BaseProfilerFactory>> m_profilers;
 
     QString m_rootPath;
+    QString m_chosenmango;
     Status m_status = Application::StartingUp;
     Capabilities m_capabilities;
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -481,7 +481,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
 #ifdef Q_OS_LINUX
     if (settings()->get("EnableMangoHud").toBool() && APPLICATION->capabilities() & Application::SupportsMangoHud)
     {
-        auto preload = env.value("LD_PRELOAD", "") + ":libMangoHud_shim.so:libMangoHud.so";
+        auto preload = env.value("LD_PRELOAD", "") + ":" + APPLICATION->chosenmango();
 
         env.insert("LD_PRELOAD", preload);
         env.insert("MANGOHUD", "1");

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -481,7 +481,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
 #ifdef Q_OS_LINUX
     if (settings()->get("EnableMangoHud").toBool() && APPLICATION->capabilities() & Application::SupportsMangoHud)
     {
-        auto preload = env.value("LD_PRELOAD", "") + ":libMangoHud_dlsym.so:libMangoHud.so";
+        auto preload = env.value("LD_PRELOAD", "") + ":libMangoHud_shim.so:libMangoHud.so";
 
         env.insert("LD_PRELOAD", preload);
         env.insert("MANGOHUD", "1");

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,6 +9,7 @@
 , jdk21
 , xorg
 , gamemode
+, mangohud
 , mesa-demos
 , libpulseaudio
 , qtbase
@@ -78,7 +79,7 @@ symlinkJoin {
     in
     [
       "--prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
-      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}:${mangohud}/lib/mangohud"
       "--prefix PATH : ${lib.makeBinPath runtimeBins}"
     ];
 


### PR DESCRIPTION
This PR updates what .so files PolyMC should be looking for when detecting and loading mangohud.

Getting the objects to be included in RPATH, RUNPATH or LD_LIBRARY_PATH is trivial to do on Nix (see https://github.com/NixOS/nixpkgs/pull/461881 or the `patchelf` tool), but not outside of it.

I am not sure how you're supposed to have it be found by dlopen(), especially considering that nowadays mangohud vomits the libraries under a subfolder under lib (for example on Ubuntu the objects are stored on `/usr/lib/x86_64-linux-gnu/mangohud/libMangoHud.so` `/usr/lib/x86_64-linux-gnu/mangohud/libMangoHud_dlsym.so`). Does flatpak, .deb, etc handle this automagically?

