### PR TITLE
Improve offline account checks

### DIFF
--- a/launcher/ui/dialogs/OfflineLoginDialog.cpp
+++ b/launcher/ui/dialogs/OfflineLoginDialog.cpp
@@ -4,6 +4,11 @@
 #include "minecraft/auth/AccountTask.h"
 
 #include <QtWidgets/QPushButton>
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
+#include <QString>
+
+bool regexDisabled;
 
 OfflineLoginDialog::OfflineLoginDialog(QWidget *parent) : QDialog(parent), ui(new Ui::OfflineLoginDialog)
 {
@@ -13,6 +18,8 @@ OfflineLoginDialog::OfflineLoginDialog(QWidget *parent) : QDialog(parent), ui(ne
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    regex = QRegularExpression("^[a-zA-Z0-9_]{2,16}$");
 }
 
 OfflineLoginDialog::~OfflineLoginDialog()
@@ -42,20 +49,25 @@ void OfflineLoginDialog::setUserInputsEnabled(bool enable)
     ui->buttonBox->setEnabled(enable);
 }
 
-void OfflineLoginDialog::on_allowLongUsernames_stateChanged(int value)
+void OfflineLoginDialog::on_ignoreUsernameGuidelines_stateChanged(int value)
 {
+    regexDisabled = (bool) value;
+
     if (value == Qt::Checked) {
         ui->userTextBox->setMaxLength(INT_MAX);
     } else {
         ui->userTextBox->setMaxLength(16);
     }
+
+    OfflineLoginDialog::on_userTextBox_textEdited(ui->userTextBox->text());
 }
 
 // Enable the OK button only when the textbox contains something.
 void OfflineLoginDialog::on_userTextBox_textEdited(const QString &newText)
 {
-    ui->buttonBox->button(QDialogButtonBox::Ok)
-        ->setEnabled(!newText.isEmpty());
+    bool expr = !regexDisabled ? regex.match(newText).hasMatch(): true;
+
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!newText.isEmpty() && expr);
 }
 
 void OfflineLoginDialog::onTaskFailed(const QString &reason)

--- a/launcher/ui/dialogs/OfflineLoginDialog.h
+++ b/launcher/ui/dialogs/OfflineLoginDialog.h
@@ -2,6 +2,7 @@
 
 #include <QtWidgets/QDialog>
 #include <QtCore/QEventLoop>
+#include <QRegularExpression>
 
 #include "minecraft/auth/MinecraftAccount.h"
 #include "tasks/Task.h"
@@ -35,10 +36,11 @@ slots:
     void onTaskProgress(qint64 current, qint64 total);
 
     void on_userTextBox_textEdited(const QString &newText);
-    void on_allowLongUsernames_stateChanged(int value);
+    void on_ignoreUsernameGuidelines_stateChanged(int value);
 
 private:
     Ui::OfflineLoginDialog *ui;
     MinecraftAccountPtr m_account;
     Task::Ptr m_loginTask;
+    QRegularExpression regex;
 };

--- a/launcher/ui/dialogs/OfflineLoginDialog.ui
+++ b/launcher/ui/dialogs/OfflineLoginDialog.ui
@@ -44,12 +44,13 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="allowLongUsernames">
+    <widget class="QCheckBox" name="ignoreUsernameGuidelines">
      <property name="toolTip">
-      <string>Usernames longer than 16 characters cannot be used for LAN games or offline-mode servers.</string>
+      <string>Normally, Minecraft only allows usernames with alphanumeric characters.
+Username length has to be 2 to 16 characters long. Underscores are allowed.</string>
      </property>
      <property name="text">
-      <string>Allow long usernames</string>
+      <string>Ignore username rules</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This improves the current username checks. Now checks for full validity of username, not just length.

You can still choose to ignore such safeguards with the checkbox, however.

Here's some screenshots to demonstrate the changes:
<img width="500" height="210" alt="image" src="https://github.com/user-attachments/assets/5813f3b3-afef-4ad7-ba15-4c68fc4dd658" />
<img width="500" height="210" alt="image" src="https://github.com/user-attachments/assets/ae82343b-1583-40bd-99b3-87fce7ee48cf" />
<img width="555" height="44" alt="image" src="https://github.com/user-attachments/assets/77eb0299-57b8-4d7d-8a20-e313b3026bf3" />

I'm not sure if QT6 provides features to make this more interactive, though.

