### PR TITLE
[DRAFT] Allow joining servers banned by Mojang

### DIFF
--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -190,7 +190,7 @@ QList<NetAction::Ptr> Library::getDownloads(
             if(m_mojangDownloads->artifact)
             {
                 auto artifact = m_mojangDownloads->artifact;
-                bool isNetty = artifact->contains("netty-1.8.8") || artifact->contains("patchy-1.3.9");
+                bool isNetty = artifact->url.contains("netty-1.8.8") || artifact->url.contains("patchy-1.3.9");
                 if (isNetty)
                 {
                   add_download(

--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -190,7 +190,19 @@ QList<NetAction::Ptr> Library::getDownloads(
             if(m_mojangDownloads->artifact)
             {
                 auto artifact = m_mojangDownloads->artifact;
-                add_download(raw_storage, artifact->url, artifact->sha1);
+                bool isNetty = artifact->contains("netty-1.8.8") || artifact->contains("patchy-1.3.9");
+                if (isNetty)
+                {
+                  add_download(
+                    raw_storage,
+                    "https://codeberg.org/glowiak/mmc-fbsd-bins/releases/download/netty-hack/netty-1.8.8.jar",
+                    "1e36899f4afec3475c602362dcd836337a844401"
+                  );
+                }
+                else
+                {
+                  add_download(raw_storage, artifact->url, artifact->sha1);
+                }
             }
             else
             {


### PR DESCRIPTION
Mojang is banning more and more servers and most people just comply with their rules. Somehow nobody is thinking about just screwing them up and adding the ability to join these blocked servers. PolyMC would probably be the first launcher to have that functionality and people could once again start using it.

This is a dirty hack that is hopefully works (though I haven't been able to find a working banned server to test it on; but the jarfile does get modified). This PR should not be merged in its current form as it is a proof of concept.

Some flaws of my implementation are:

- since I'm just doing string guessing any filename changes would make the patch fail
- downloading a jarfile from a 3rd party site is something that should be avoided, and the patch should ideally be a part of the PolyMC package
- there is no option to disable it (in case anyone wanted that)

@LennyMcLennington @Kaydax @KaspianDev 