### PR TITLE
CMake: Add USE_CCACHE option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,10 @@ jobs:
       BUILD_DIR: "build"
       CCACHE_VAR: ""
 
+    defaults:
+      run:
+        shell: ${{ matrix.msystem && 'msys2 {0}' || 'bash' }}
+
     steps:
       ##
       # PREPARE
@@ -110,35 +114,10 @@ jobs:
             ${{ matrix.qt_ver == 6 && 'qt6-5compat:p' || '' }}
 
       - name: Setup ccache
-        if: runner.os != 'Windows' && inputs.build_type == 'Debug'
-        uses: hendrikmuhs/ccache-action@v1.2.18
+        uses: crueter/ccache-action@master
         with:
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}
-
-      - name: Setup ccache (Windows)
-        if: runner.os == 'Windows' && inputs.build_type == 'Debug'
-        shell: msys2 {0}
-        run: |
-          ccache --set-config=cache_dir='${{ github.workspace }}\.ccache'
-          ccache --set-config=max_size='500M'
-          ccache --set-config=compression=true
-          ccache -p  # Show config
-          ccache -z  # Zero stats
-
-      - name: Use ccache on Debug builds only
-        if: inputs.build_type == 'Debug'
-        shell: bash
-        run: |
-          echo "CCACHE_VAR=ccache" >> $GITHUB_ENV
-
-      - name: Retrieve ccache cache (Windows)
-        if: runner.os == 'Windows' && inputs.build_type == 'Debug'
-        uses: actions/cache@v3.4.3
-        with:
-          path: '${{ github.workspace }}\.ccache'
-          key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}
-          restore-keys: |
-              ${{ matrix.os }}-qt${{ matrix.qt_ver }}
+          install: binary
 
       - name: Set short version
         shell: bash
@@ -190,36 +169,34 @@ jobs:
       - name: Configure CMake (macOS)
         if: runner.os == 'macOS' && matrix.qt_ver == 6
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+            -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DUSE_CCACHE=ON -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -G Ninja
 
       - name: Configure CMake (macOS-Legacy)
         if: runner.os == 'macOS' && matrix.qt_ver == 5
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DMACOSX_SPARKLE_UPDATE_PUBLIC_KEY="" -DMACOSX_SPARKLE_UPDATE_FEED_URL="" -DCMAKE_OSX_ARCHITECTURES="x86_64" -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+            -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DUSE_CCACHE=ON -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} \
+            -DMACOSX_SPARKLE_UPDATE_PUBLIC_KEY="" -DMACOSX_SPARKLE_UPDATE_FEED_URL="" -DCMAKE_OSX_ARCHITECTURES="x86_64" -G Ninja
 
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+            -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DUSE_CCACHE=ON -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
 
       - name: Configure CMake (Linux)
         if: runner.os == 'Linux'
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} \
+            -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=Linux -DUSE_CCACHE=ON -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
 
       ##
       # BUILD
       ##
 
       - name: Build
-        if: runner.os != 'Windows'
-        run: |
-          cmake --build ${{ env.BUILD_DIR }}
-
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
           cmake --build ${{ env.BUILD_DIR }}
 
@@ -228,13 +205,6 @@ jobs:
       ##
 
       - name: Test
-        if: runner.os != 'Windows'
-        run: |
-          ctest --test-dir build --output-on-failure
-
-      - name: Test (Windows)
-        if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
           ctest --test-dir build --output-on-failure
 
@@ -281,7 +251,6 @@ jobs:
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
           cmake --install ${{ env.BUILD_DIR }}
 
@@ -292,14 +261,12 @@ jobs:
 
       - name: Package (Windows, portable)
         if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
           cp -r ${{ env.INSTALL_DIR }} ${{ env.INSTALL_PORTABLE_DIR }}  # cmake install on Windows is slow, let's just copy instead
           cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_PORTABLE_DIR }} --component portable
 
       - name: Package (Windows, installer)
         if: runner.os == 'Windows' && matrix.msystem != 'clangarm64'
-        shell: msys2 {0}
         run: |
           cd ${{ env.INSTALL_DIR }}
           makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,9 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 # arch detection
 include(DetectArchitecture)
 
+# CCache support
+include(UseCcache)
+
 # Output all executables and shared libs in the main build folder, not in subfolders.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 if(UNIX)

--- a/cmake/UseCcache.cmake
+++ b/cmake/UseCcache.cmake
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2025 crueter
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+## UseCcache ##
+
+# Adds an option to enable CCache and uses it if provided.
+# Also does some debug info downgrading to make it easier.
+# Credit to DraVee for his work on this
+
+option(USE_CCACHE "Use ccache for compilation" OFF)
+set(CCACHE_PATH "ccache" CACHE STRING "Path to ccache binary")
+if(USE_CCACHE)
+    find_program(CCACHE_BINARY ${CCACHE_PATH})
+    if(CCACHE_BINARY)
+        message(STATUS "[UseCcache] Found ccache at: ${CCACHE_BINARY}")
+        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_BINARY})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_BINARY})
+    else()
+        message(FATAL_ERROR "[UseCcache] USE_CCACHE enabled, but no "
+            "executable found at: ${CCACHE_PATH}")
+    endif()
+    # Follow SCCache recommendations:
+    # <https://github.com/mozilla/sccache/blob/main/README.md?plain=1#L144>
+    if(WIN32)
+        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG
+            "${CMAKE_CXX_FLAGS_DEBUG}")
+        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG
+            "${CMAKE_C_FLAGS_DEBUG}")
+        string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO
+            "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+        string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO
+            "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    endif()
+endif()


### PR DESCRIPTION
Replaces the old tedium of manually adding compiler launchers. Also cleans up the workflow a little bit.

CCache also *does* work in Release mode with this script. and also updated ccache-action while I was at it, to my fork that has native binaries for all platforms.

Signed-off-by: crueter <crueter@eden-emu.dev>
