### PR TITLE
Nix: Add jdk25 and migrate from deprecated xorg namespace

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,33 +1,45 @@
-{ stdenv
-, lib
-, symlinkJoin
-, addDriverRunpath
-, polymc-unwrapped
-, wrapQtAppsHook
-, jdk8
-, jdk17
-, jdk21
-, xorg
-, gamemode
-, mangohud
-, mesa-demos
-, libpulseaudio
-, qtbase
-, libGL
-, vulkan-loader
-, glfw
-, openal
-, udev
-, wayland
-, qtwayland
-, msaClientID ? ""
-, jdks ? [ jdk21 jdk17 jdk8 ]
-, enableLTO ? false
-, gamemodeSupport ? stdenv.isLinux
-, additionalLibs ? [ ]
-, additionalBins ? [ ]
-, self
-, version
+{
+  stdenv,
+  lib,
+  symlinkJoin,
+  addDriverRunpath,
+  polymc-unwrapped,
+  wrapQtAppsHook,
+  jdk8,
+  jdk17,
+  jdk21,
+  jdk25,
+  libX11,
+  libXext,
+  libXcursor,
+  libXrandr,
+  libXxf86vm,
+  xrandr,
+  gamemode,
+  mangohud,
+  mesa-demos,
+  libpulseaudio,
+  qtbase,
+  libGL,
+  vulkan-loader,
+  glfw,
+  openal,
+  udev,
+  wayland,
+  qtwayland,
+  msaClientID ? "",
+  jdks ? [
+    jdk25
+    jdk21
+    jdk17
+    jdk8
+  ],
+  enableLTO ? false,
+  gamemodeSupport ? stdenv.isLinux,
+  additionalLibs ? [ ],
+  additionalBins ? [ ],
+  self,
+  version,
   # flake
 }:
 
@@ -42,7 +54,10 @@ symlinkJoin {
   paths = [ polymcInner ];
 
   nativeBuildInputs = [ wrapQtAppsHook ];
-  buildInputs = [ qtbase qtwayland ];
+  buildInputs = [
+    qtbase
+    qtwayland
+  ];
 
   postBuild = ''
     wrapQtAppsHook
@@ -50,32 +65,34 @@ symlinkJoin {
 
   qtWrapperArgs =
     let
-      runtimeLibs = (with xorg; [
+      runtimeLibs = [
         libX11
         libXext
         libXcursor
         libXrandr
         libXxf86vm
-      ]) ++
-      # lwjgl
-      [
-        libpulseaudio
-        libGL
-        glfw
-        openal
-        stdenv.cc.cc.lib
-        udev # OSHI
-        wayland
-        vulkan-loader # VulkanMod's lwjgl
       ]
+      ++
+        # lwjgl
+        [
+          libpulseaudio
+          libGL
+          glfw
+          openal
+          stdenv.cc.cc.lib
+          udev # OSHI
+          wayland
+          vulkan-loader # VulkanMod's lwjgl
+        ]
       ++ lib.optional gamemodeSupport gamemode.lib
       ++ additionalLibs;
 
       runtimeBins = [
         # Required by old LWJGL versions
-        xorg.xrandr
+        xrandr
         mesa-demos # For glxinfo
-      ] ++ additionalBins;
+      ]
+      ++ additionalBins;
     in
     [
       "--prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"


### PR DESCRIPTION
As mentioned in https://github.com/PolyMC/PolyMC/issues/1754 : 
- Added JDK25 as Minecraft 26.1.2 requires it.
- Changed package names from `xorg.*` as they are deprecated. 