### PR TITLE
Support local http metadata mirrors + 

### DIFF
--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -42,11 +42,14 @@
 #include <QJsonObject>
 #include <QVariant>
 #include <QDebug>
+#include <QHostAddress>
+#include <QUrl>
 
 #include "AssetsUtils.h"
 #include "FileSystem.h"
 #include "net/Download.h"
 #include "net/ChecksumValidator.h"
+#include "settings/SettingsObject.h"
 #include "BuildConfig.h"
 
 #include "Application.h"
@@ -76,11 +79,71 @@ QSet<QString> collectPathsFromDir(QString dirPath)
     }
     return out;
 }
+
+QUrl assetResourceBaseUrl()
+{
+    QUrl baseUrl(BuildConfig.RESOURCE_BASE);
+    const QUrl metaOverride(APPLICATION->settings()->get("MetaURLOverride").toString());
+    if (!metaOverride.isEmpty() && AssetsUtils::isLocalMetadataHost(metaOverride.host()))
+    {
+        baseUrl = metaOverride;
+        baseUrl.setPath("/resources/");
+        baseUrl.setQuery(QString());
+        baseUrl.setFragment(QString());
+    }
+    return baseUrl;
+}
 }
 
 
 namespace AssetsUtils
 {
+
+bool isLocalMetadataHost(const QString &host)
+{
+    auto normalizedHost = host.trimmed().toLower();
+    if (normalizedHost.endsWith('.'))
+    {
+        normalizedHost.chop(1);
+    }
+
+    if (normalizedHost == "localhost"
+        || normalizedHost.endsWith(".localhost")
+        || normalizedHost == "localhost.localdomain")
+    {
+        return true;
+    }
+
+    QHostAddress address;
+    if (!address.setAddress(normalizedHost))
+    {
+        return false;
+    }
+
+    if (address.isLoopback() || address == QHostAddress::AnyIPv4 || address == QHostAddress::AnyIPv6)
+    {
+        return true;
+    }
+
+    const QPair<QHostAddress, int> localSubnets[] = {
+        { QHostAddress("10.0.0.0"), 8 },
+        { QHostAddress("169.254.0.0"), 16 },
+        { QHostAddress("172.16.0.0"), 12 },
+        { QHostAddress("192.168.0.0"), 16 },
+        { QHostAddress("fc00::"), 7 },
+        { QHostAddress("fe80::"), 10 },
+    };
+
+    for (const auto &subnet : localSubnets)
+    {
+        if (address.isInSubnet(subnet.first, subnet.second))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
 
 /*
  * Returns true on success, with index populated
@@ -330,7 +393,7 @@ QString AssetObject::getLocalPath()
 
 QUrl AssetObject::getUrl()
 {
-    return BuildConfig.RESOURCE_BASE + getRelPath();
+    return assetResourceBaseUrl().resolved(QUrl(getRelPath()));
 }
 
 QString AssetObject::getRelPath()

--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -109,7 +109,8 @@ bool isLocalMetadataHost(const QString &host)
 
     if (normalizedHost == "localhost"
         || normalizedHost.endsWith(".localhost")
-        || normalizedHost == "localhost.localdomain")
+        || normalizedHost == "localhost.localdomain"
+        || normalizedHost.endsWith(".local"))
     {
         return true;
     }

--- a/launcher/minecraft/AssetsUtils.h
+++ b/launcher/minecraft/AssetsUtils.h
@@ -44,6 +44,9 @@ struct AssetsIndex
 /// FIXME: this is absolutely horrendous. REDO!!!!
 namespace AssetsUtils
 {
+/// Returns whether a host name or address belongs to the local machine or a local network.
+bool isLocalMetadataHost(const QString &host);
+
 bool loadAssetsIndexJson(const QString &id, const QString &file, AssetsIndex& index);
 
 QDir getAssetsDir(const QString &assetsId, const QString &resourcesFolder);

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -47,6 +47,7 @@
 #include "settings/SettingsObject.h"
 #include "tools/BaseProfiler.h"
 #include "Application.h"
+#include "minecraft/AssetsUtils.h"
 #include "net/PasteUpload.h"
 #include "BuildConfig.h"
 
@@ -173,8 +174,11 @@ void APIPage::applySettings()
         path.append('/');
         metaURL.setPath(path);
     }
-    // Don't allow HTTP, since meta is basically RCE with all the jar files.
-    if(!metaURL.isEmpty() && metaURL.scheme() == "http")
+    // Don't allow HTTP for remote metadata, since meta is basically RCE with all the jar files.
+    // Local HTTP is useful for development and offline metadata mirrors.
+    if(!metaURL.isEmpty()
+        && metaURL.scheme() == "http"
+        && !AssetsUtils::isLocalMetadataHost(metaURL.host()))
     {
         metaURL.setScheme("https");
     }


### PR DESCRIPTION
* Allows to use loopback/local metadata urls, like this:
<img width="628" height="187" alt="image" src="https://github.com/user-attachments/assets/e40318e2-3c61-43eb-9270-783ccb999135" />

* Uses the custom url for resource downloads as well (instead of the hardcoded `BuildConfig.RESOURCE_BASE`).