### PR TITLE
nix: Disable Qt5 and switch to kdePackages due to deprecation in nixos 26.05

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,9 @@
 
       packagesFn = pkgs: rec {
         polymc-unwrapped = pkgs.qt6Packages.callPackage ./nix/unwrapped.nix { inherit version self libnbtplusplus tomlplusplus; };
-        polymc-qt5-unwrapped = pkgs.libsForQt5.callPackage ./nix/unwrapped.nix { inherit version self libnbtplusplus tomlplusplus; };
+        #polymc-qt5-unwrapped = pkgs.libsForQt5.callPackage ./nix/unwrapped.nix { inherit version self libnbtplusplus tomlplusplus; };
         polymc = pkgs.qt6Packages.callPackage ./nix { inherit version self polymc-unwrapped; };
-        polymc-qt5 = pkgs.libsForQt5.callPackage ./nix { inherit version self; polymc-unwrapped = polymc-qt5-unwrapped; };
+        #polymc-qt5 = pkgs.libsForQt5.callPackage ./nix { inherit version self; polymc-unwrapped = polymc-qt5-unwrapped; };
         default = polymc;
       };
     in

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -9,7 +9,7 @@
 , file
 , qtbase
 , quazip
-, extra-cmake-modules
+, kdePackages
 , qtcharts
 , qtwayland
   # flake

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
 
   src = lib.cleanSource self;
 
-  nativeBuildInputs = [ cmake extra-cmake-modules ninja jdk8 ghc_filesystem file ];
+  nativeBuildInputs = [ cmake kdePackages.extra-cmake-modules ninja jdk8 ghc_filesystem file ];
   buildInputs = [ qtbase quazip zlib qtcharts ]
     ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
     ++ lib.optional gamemodeSupport gamemode;


### PR DESCRIPTION
fixes #1764