### PR TITLE
CI: Enable NSIS on Windows on ARM

### DIFF
--- a/.ci/windows/package.sh
+++ b/.ci/windows/package.sh
@@ -42,9 +42,6 @@ cmake --install "$BUILD" --prefix "$INSTALL_PORTABLE" --component portable
 PORTABLE=1 mkzip "$INSTALL_PORTABLE"
 
 # setup package
-# disable on arm for now
-[ "$ARCH" = amd64 ] || exit 0
-
 cd "$INSTALL"
 makensis -NOCD "$BUILD/program_info/win_install.nsi"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,8 +56,14 @@ jobs:
             qt${{ matrix.qt_ver }}-imageformats:p qt${{ matrix.qt_ver }}-charts:p
             ccache:p
             ${{ matrix.qt_ver == 6 && 'quazip-qt6:p' || '' }}
-            ${{ matrix.msystem != 'clangarm64' && 'nsis:m' || '' }}
             ${{ matrix.qt_ver == 6 && 'qt6-5compat:p' || '' }}
+
+      # Yes, this is x86 on ARM
+      # The translation layer handles it fine
+      - name: Install NSIS
+        uses: repolevedavaj/install-nsis@v1
+        with:
+          nsis-version: '3.12'
 
       - name: Build
         uses: ./.github/workflows/build


### PR DESCRIPTION
The installer is technically x86, but even the ancient translation layer
on Windows 10 ARM can handle that.

Signed-off-by: crueter <crueter@eden-emu.dev>
