### PR TITLE
Java: Warn with <1024 MiB max alloc, and allow 8 MiB maximum

### DIFF
--- a/launcher/ui/pages/global/JavaPage.cpp
+++ b/launcher/ui/pages/global/JavaPage.cpp
@@ -46,9 +46,7 @@
 #include "ui/dialogs/VersionSelectDialog.h"
 
 #include "java/JavaUtils.h"
-#include "java/JavaInstallList.h"
 
-#include "settings/SettingsObject.h"
 #include <FileSystem.h>
 #include "Application.h"
 #include <sys.h>
@@ -60,6 +58,19 @@ JavaPage::JavaPage(QWidget *parent) : QWidget(parent), ui(new Ui::JavaPage)
 
     auto sysMiB = Sys::getSystemRam() / Sys::mebibyte;
     ui->maxMemSpinBox->setMaximum(sysMiB);
+    ui->lowMemWarnWidget->hide();
+
+    // TODO(crueter): add warning theme icons.
+    ui->lowMemWarnIcon->setPixmap(QMessageBox::standardIcon(QMessageBox::Warning).scaled(24, 24));
+
+    connect(ui->minMemSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &JavaPage::updateMemoryWarning);
+
+    connect(ui->maxMemSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &JavaPage::updateMemoryWarning);
+
+    updateMemoryWarning();
+
     loadSettings();
 }
 
@@ -123,6 +134,24 @@ void JavaPage::loadSettings()
     ui->jvmArgsTextBox->setPlainText(s->get("JvmArgs").toString());
     ui->skipCompatibilityCheckbox->setChecked(s->get("IgnoreJavaCompatibility").toBool());
     ui->skipJavaWizardCheckbox->setChecked(s->get("IgnoreJavaWizard").toBool());
+}
+
+void JavaPage::updateMemoryWarning() {
+    int minMem = ui->minMemSpinBox->value();
+    int maxMem = ui->maxMemSpinBox->value();
+
+    if (minMem > maxMem) {
+        ui->maxMemSpinBox->setValue(minMem);
+        maxMem = minMem;
+    }
+
+    if (maxMem < 1024) {
+        ui->lowMemWarnLabel->setText(
+            tr("Allocating less than 1024 MiB may cause performance issues on newer versions! Use with caution."));
+        ui->lowMemWarnWidget->show();
+    } else {
+        ui->lowMemWarnWidget->hide();
+    }
 }
 
 void JavaPage::on_javaDetectBtn_clicked()

--- a/launcher/ui/pages/global/JavaPage.h
+++ b/launcher/ui/pages/global/JavaPage.h
@@ -86,6 +86,7 @@ slots:
     void on_javaTestBtn_clicked();
     void on_javaBrowseBtn_clicked();
     void checkerFinished();
+    void updateMemoryWarning();
 
 private:
     Ui::JavaPage *ui;

--- a/launcher/ui/pages/global/JavaPage.ui
+++ b/launcher/ui/pages/global/JavaPage.ui
@@ -16,6 +16,12 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="leftMargin">
     <number>0</number>
@@ -54,7 +60,7 @@
              <string notr="true"> MiB</string>
             </property>
             <property name="minimum">
-             <number>128</number>
+             <number>8</number>
             </property>
             <property name="maximum">
              <number>65536</number>
@@ -64,6 +70,38 @@
             </property>
             <property name="value">
              <number>1024</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelMaxMem">
+            <property name="text">
+             <string>Ma&amp;ximum memory allocation:</string>
+            </property>
+            <property name="buddy">
+             <cstring>maxMemSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="permGenSpinBox">
+            <property name="toolTip">
+             <string>The amount of memory available to store loaded Java classes.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> MiB</string>
+            </property>
+            <property name="minimum">
+             <number>64</number>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="singleStep">
+             <number>8</number>
+            </property>
+            <property name="value">
+             <number>64</number>
             </property>
            </widget>
           </item>
@@ -77,13 +115,13 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelMaxMem">
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelPermGen">
             <property name="text">
-             <string>Ma&amp;ximum memory allocation:</string>
+             <string notr="true">&amp;PermGen:</string>
             </property>
             <property name="buddy">
-             <cstring>maxMemSpinBox</cstring>
+             <cstring>permGenSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -109,36 +147,45 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelPermGen">
-            <property name="text">
-             <string notr="true">&amp;PermGen:</string>
+          <item row="2" column="0" colspan="2">
+           <widget class="QWidget" name="lowMemWarnWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
-            <property name="buddy">
-             <cstring>permGenSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QSpinBox" name="permGenSpinBox">
-            <property name="toolTip">
-             <string>The amount of memory available to store loaded Java classes.</string>
-            </property>
-            <property name="suffix">
-             <string notr="true"> MiB</string>
-            </property>
-            <property name="minimum">
-             <number>64</number>
-            </property>
-            <property name="maximum">
-             <number>999999999</number>
-            </property>
-            <property name="singleStep">
-             <number>8</number>
-            </property>
-            <property name="value">
-             <number>64</number>
-            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="lowMemWarnIcon">
+               <property name="minimumSize">
+                <size>
+                 <width>24</width>
+                 <height>24</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lowMemWarnLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Allocating less than 1024 MiB may cause performance issues on newer versions! Use with caution.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>
@@ -175,7 +222,7 @@
              <string>JVM arguments:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
             </property>
            </widget>
           </item>
@@ -285,7 +332,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -49,7 +49,6 @@
 #include "JavaCommon.h"
 #include "Application.h"
 
-#include "java/JavaInstallList.h"
 #include "java/JavaUtils.h"
 #include "FileSystem.h"
 
@@ -72,6 +71,18 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
     connect(ui->openGlobalJavaSettingsButton, &QCommandLinkButton::clicked, this, &InstanceSettingsPage::globalSettingsButtonClicked);
     connect(APPLICATION, &Application::globalSettingsAboutToOpen, this, &InstanceSettingsPage::applySettings);
     connect(APPLICATION, &Application::globalSettingsClosed, this, &InstanceSettingsPage::loadSettings);
+
+    // TODO(crueter): add warning theme icons.
+    ui->lowMemWarnIcon->setPixmap(QMessageBox::standardIcon(QMessageBox::Warning).scaled(24, 24));
+
+    connect(ui->minMemSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &InstanceSettingsPage::updateMemoryWarning);
+
+    connect(ui->maxMemSpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &InstanceSettingsPage::updateMemoryWarning);
+
+    updateMemoryWarning();
+
     loadSettings();
 }
 
@@ -97,6 +108,24 @@ void InstanceSettingsPage::globalSettingsButtonClicked(bool)
         case 2:
             APPLICATION->ShowGlobalSettings(this, "custom-commands");
             return;
+    }
+}
+
+void InstanceSettingsPage::updateMemoryWarning() {
+    int minMem = ui->minMemSpinBox->value();
+    int maxMem = ui->maxMemSpinBox->value();
+
+    if (minMem > maxMem) {
+        ui->maxMemSpinBox->setValue(minMem);
+        maxMem = minMem;
+    }
+
+    if (maxMem < 1024) {
+        ui->lowMemWarnLabel->setText(tr("Allocating less than 1024 MiB may cause performance "
+                                        "issues on newer versions! Use with caution."));
+        ui->lowMemWarnWidget->show();
+    } else {
+        ui->lowMemWarnWidget->hide();
     }
 }
 

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -89,6 +89,9 @@ private slots:
 
     void globalSettingsButtonClicked(bool checked);
 
+    void updateMemoryWarning();
+
+
 private:
     Ui::InstanceSettingsPage *ui;
     BaseInstance *m_instance;

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -129,7 +129,7 @@
              <string notr="true"> MiB</string>
             </property>
             <property name="minimum">
-             <number>128</number>
+             <number>8</number>
             </property>
             <property name="maximum">
              <number>65536</number>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="QTabWidget" name="settingsTabs">
      <property name="tabShape">
-      <enum>QTabWidget::Rounded</enum>
+      <enum>QTabWidget::TabShape::Rounded</enum>
      </property>
      <property name="currentIndex">
       <number>0</number>
@@ -164,7 +164,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="4" column="1">
            <widget class="QSpinBox" name="permGenSpinBox">
             <property name="toolTip">
              <string>The amount of memory available to store loaded Java classes.</string>
@@ -186,7 +186,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="labelPermGen">
             <property name="text">
              <string notr="true">PermGen:</string>
@@ -198,6 +198,47 @@
             <property name="text">
              <string>Maximum memory allocation:</string>
             </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QWidget" name="lowMemWarnWidget" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QLabel" name="lowMemWarnIcon">
+               <property name="minimumSize">
+                <size>
+                 <width>24</width>
+                 <height>24</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="lowMemWarnLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Allocating less than 1024 MiB may cause performance issues on newer versions! Use with caution.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
@@ -381,7 +422,7 @@
        <item>
         <spacer name="verticalSpacerMinecraft_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -443,7 +484,7 @@
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -511,7 +552,7 @@
        <item>
         <spacer name="verticalSpacer_2">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -640,7 +681,7 @@
        <item>
         <spacer name="verticalSpacerMiscellaneous">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -79,7 +79,7 @@ void JavaSettingsWidget::setupUi()
     m_minMemSpinBox = new QSpinBox(m_memoryGroupBox);
     m_minMemSpinBox->setObjectName(QStringLiteral("minMemSpinBox"));
     m_minMemSpinBox->setSuffix(QStringLiteral(" MiB"));
-    m_minMemSpinBox->setMinimum(128);
+    m_minMemSpinBox->setMinimum(1);
     m_minMemSpinBox->setMaximum(m_availableMemory);
     m_minMemSpinBox->setSingleStep(128);
     m_labelMinMem->setBuddy(m_minMemSpinBox);
@@ -92,16 +92,28 @@ void JavaSettingsWidget::setupUi()
     m_maxMemSpinBox = new QSpinBox(m_memoryGroupBox);
     m_maxMemSpinBox->setObjectName(QStringLiteral("maxMemSpinBox"));
     m_maxMemSpinBox->setSuffix(QStringLiteral(" MiB"));
-    m_maxMemSpinBox->setMinimum(128);
+    m_maxMemSpinBox->setMinimum(8);
     m_maxMemSpinBox->setMaximum(m_availableMemory);
     m_maxMemSpinBox->setSingleStep(128);
     m_labelMaxMem->setBuddy(m_maxMemSpinBox);
     m_gridLayout_2->addWidget(m_maxMemSpinBox, 1, 1, 1, 1);
 
+    m_lowMemWarnWidget = new QWidget(m_memoryGroupBox);
+    m_lowMemWarnWidget->setVisible(false);
+    m_lowMemWarnLayout = new QHBoxLayout(m_lowMemWarnWidget);
+    m_lowMemWarnIcon = new QLabel(m_lowMemWarnWidget);
+    // TODO(crueter): add warning theme icons.
+    m_lowMemWarnIcon->setPixmap(QMessageBox::standardIcon(QMessageBox::Warning).scaled(24, 24));
+    m_lowMemWarnLabel = new QLabel(m_lowMemWarnWidget);
+    m_lowMemWarnLabel->setWordWrap(true);
+    m_lowMemWarnLayout->addWidget(m_lowMemWarnIcon);
+    m_lowMemWarnLayout->addWidget(m_lowMemWarnLabel, 1);
+    m_gridLayout_2->addWidget(m_lowMemWarnWidget, 2, 0, 1, 2);
+
     m_labelPermGen = new QLabel(m_memoryGroupBox);
     m_labelPermGen->setObjectName(QStringLiteral("labelPermGen"));
     m_labelPermGen->setText(QStringLiteral("PermGen:"));
-    m_gridLayout_2->addWidget(m_labelPermGen, 2, 0, 1, 1);
+    m_gridLayout_2->addWidget(m_labelPermGen, 3, 0, 1, 1);
     m_labelPermGen->setVisible(false);
 
     m_permGenSpinBox = new QSpinBox(m_memoryGroupBox);
@@ -110,7 +122,7 @@ void JavaSettingsWidget::setupUi()
     m_permGenSpinBox->setMinimum(64);
     m_permGenSpinBox->setMaximum(m_availableMemory);
     m_permGenSpinBox->setSingleStep(8);
-    m_gridLayout_2->addWidget(m_permGenSpinBox, 2, 1, 1, 1);
+    m_gridLayout_2->addWidget(m_permGenSpinBox, 3, 1, 1, 1);
     m_permGenSpinBox->setVisible(false);
 
     m_verticalLayout->addWidget(m_memoryGroupBox);
@@ -130,6 +142,8 @@ void JavaSettingsWidget::initialize()
     m_minMemSpinBox->setValue(observedMinMemory);
     m_maxMemSpinBox->setValue(observedMaxMemory);
     m_permGenSpinBox->setValue(observedPermGenMemory);
+
+    m_lowMemWarnWidget->setVisible(m_maxMemSpinBox->value() < 256);
 }
 
 void JavaSettingsWidget::refresh()
@@ -242,6 +256,14 @@ void JavaSettingsWidget::memoryValueChanged(int)
     if(actuallyChanged)
     {
         checkJavaPathOnEdit(m_javaPathTextBox->text());
+    }
+
+    if (max < 1024) {
+        m_lowMemWarnLabel->setText(
+            tr("Allocating less than 1024 MiB may cause performance issues on newer versions! Use with caution."));
+        m_lowMemWarnWidget->show();
+    } else {
+        m_lowMemWarnWidget->hide();
     }
 }
 
@@ -431,6 +453,7 @@ void JavaSettingsWidget::retranslate()
     m_maxMemSpinBox->setToolTip(tr("The maximum amount of memory Minecraft is allowed to use."));
     m_labelMinMem->setText(tr("Minimum memory allocation:"));
     m_labelMaxMem->setText(tr("Maximum memory allocation:"));
+    m_lowMemWarnLabel->setText(tr("Values below 256 MiB may cause instability on newer versions! Use with caution."));
     m_minMemSpinBox->setToolTip(tr("The amount of memory Minecraft is started with."));
     m_permGenSpinBox->setToolTip(tr("The amount of memory available to store loaded Java classes."));
     m_javaBrowseBtn->setText(tr("Browse"));

--- a/launcher/ui/widgets/JavaSettingsWidget.h
+++ b/launcher/ui/widgets/JavaSettingsWidget.h
@@ -92,6 +92,11 @@ private: /* data */
     QIcon yellowIcon;
     QIcon badIcon;
 
+    QWidget *m_lowMemWarnWidget = nullptr;
+    QHBoxLayout *m_lowMemWarnLayout = nullptr;
+    QLabel *m_lowMemWarnIcon = nullptr;
+    QLabel *m_lowMemWarnLabel = nullptr;
+
     int observedMinMemory = 0;
     int observedMaxMemory = 0;
     int observedPermGenMemory = 0;


### PR DESCRIPTION
Any value under 1024 MiB is usually going to cause issues, users should
be careful at these low values.

Also reduced the minimum max alloc to 8 MiB.

Closes https://github.com/PolyMC/PolyMC/issues/1786

Signed-off-by: crueter <crueter@eden-emu.dev>